### PR TITLE
fix runtime key cache raw_hash_map error

### DIFF
--- a/vllm/hpu/cache_ops.py
+++ b/vllm/hpu/cache_ops.py
@@ -18,6 +18,7 @@ def reshape_and_cache(key, value, key_cache, value_cache, slot_mapping, is_promp
     value_cache: [num_heads, head_size, block_size] * num_blocks
     slot_mapping: [num_tokens]
     """
+    htorch.hpu.synchronize()
     num_tokens = key.shape[0]
     block_size = key_cache.shape[-1]
     slot_mapping = slot_mapping.to(key.device)


### PR DESCRIPTION
Hi there, thanks for bringing this great vLLM feature on habana gaudi! I am trying to integrate with your code to [langchain](https://github.com/langchain-ai/langchain). Langchain itself uses a [synchronous](https://github.com/langchain-ai/langchain/blob/master/libs/community/langchain_community/llms/vllm.py#L81) vLLM engine in its LLM component as default. When I run a basic example as follows,

```
import habana_frameworks.torch.core as htcore
import habana_frameworks.torch.gpu_migration

from langchain_community.llms import VLLM
llm = VLLM(
    model="/data/models--meta-llama--Llama-2-7b-hf/snapshots/8cca527612d856d7d32bd94f8103728d614eb852/",
    dtype="bfloat16",
    vllm_kwargs={"swap_space": 16, "enforce_eager": True}
)

print(llm("What is the capital of France?", temperature=0, max_tokens=20))
print(llm("What is banana?", temperature=0, max_tokens=18))
print(llm("What is apple?", temperature=0, max_tokens=28))

```

I met an **error** called `RuntimeError: absl::container_internal::raw_hash_map<>::at`

The whole error log is
```
]Traceback (most recent call last):
  File "/vllm-fork/test.py", line 10, in <module>
    print(llm("What is the capital of France?", temperature=0, max_tokens=20))
  File "/usr/local/lib/python3.10/dist-packages/langchain_core/_api/deprecation.py", line 145, in warning_emitting_wrapper
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/langchain_core/language_models/llms.py", line 991, in __call__
    self.generate(
  File "/usr/local/lib/python3.10/dist-packages/langchain_core/language_models/llms.py", line 741, in generate
    output = self._generate_helper(
  File "/usr/local/lib/python3.10/dist-packages/langchain_core/language_models/llms.py", line 605, in _generate_helper
    raise e
  File "/usr/local/lib/python3.10/dist-packages/langchain_core/language_models/llms.py", line 592, in _generate_helper
    self._generate(
  File "/usr/local/lib/python3.10/dist-packages/langchain_community/llms/vllm.py", line 132, in _generate
    outputs = self.client.generate(prompts, sampling_params)
  File "/vllm-fork/vllm/entrypoints/llm.py", line 167, in generate
    return self._run_engine(use_tqdm)
  File "/vllm-fork/vllm/entrypoints/llm.py", line 199, in _run_engine
    step_outputs = self.llm_engine.step()
  File "/vllm-fork/vllm/engine/llm_engine.py", line 589, in step
    output = self._run_workers(
  File "/vllm-fork/vllm/engine/llm_engine.py", line 763, in _run_workers
    self._run_workers_in_batch(workers, method, *args, **kwargs))
  File "/vllm-fork/vllm/engine/llm_engine.py", line 737, in _run_workers_in_batch
    output = executor(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/vllm-fork/vllm/worker/worker.py", line 360, in execute_model
    output = self.model_runner.execute_model(seq_group_metadata_list,
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/vllm-fork/vllm/worker/model_runner.py", line 355, in execute_model
    hidden_states = model_executable(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1521, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1530, in _call_impl
    return forward_call(*args, **kwargs)
  File "/vllm-fork/vllm/model_executor/models/llama.py", line 286, in forward
    hidden_states = self.model(input_ids, positions, kv_caches,
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1521, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1571, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/vllm-fork/vllm/model_executor/models/llama.py", line 254, in forward
    hidden_states, residual = layer(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1521, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1571, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/vllm-fork/vllm/model_executor/models/llama.py", line 208, in forward
    hidden_states = self.self_attn(
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1521, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1571, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/vllm-fork/vllm/model_executor/models/llama.py", line 155, in forward
    attn_output = self.attn(q, k, v, k_cache, v_cache, input_metadata)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1521, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1571, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/vllm-fork/vllm/model_executor/layers/attention.py", line 101, in forward
    cache_ops.reshape_and_cache(
  File "/vllm-fork/vllm/hpu/cache_ops.py", line 38, in reshape_and_cache
    key_cache[slot_indices[i][0], slot_indices[i][1], :, :] = key[i]
RuntimeError: absl::container_internal::raw_hash_map<>::at
```

It seems that hpu tries to access specific item in the `key_cache` but t is the data was not there, and I debuged for a while and found that the data in the key_cache actually should exist. Therefore I infer that it may be caused by a synchronization issue that the data are not synchronized back the moment when hpu accessed the data.

Therefore, I tried to add one line `htorch.hpu.synchronize()` before every `reshape_and_cache`, that avoid that error.

I am still not sure whether the root cause was the synchronous vLLM Engine used by langchain or other factors. I also have tested the basic functions with the async vLLM engine simply by starting `vllm.entrypoints.openai.api_server` and it should meet the same error. Could you give me some hints about this issue? Thanks!