### PR TITLE
Fix block_table shape in of non-graph runs

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -239,9 +239,10 @@ class ModelRunner:
                     input_block_tables[i, :len(block_table)] = block_table
             block_tables = torch.tensor(input_block_tables, device=device)
         else:
+            block_table_len = (max_context_len + self.block_size - 1) // self.block_size
             block_tables = _make_tensor_with_pad(
                 block_tables,
-                max_len=max_context_len,
+                max_len=block_table_len,
                 pad=0,
                 dtype=torch.int,
             )


### PR DESCRIPTION
Block table was incorrectly padded to max_context_len instead of 'max number of blocks'. Changing this gives a big perf boost as we're fetching only relevant blocks.