### PR TITLE
Improved Paged Attention

### DIFF
--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -37,6 +37,7 @@ def paged_attention_v1(query_in, key_cache_in, value_cache_in, head_mapping, sca
         raise NotImplementedError
     if attn_masks is not None:
         raise NotImplementedError
+    htorch.core.mark_step()
     batch_size, num_head, head_dim = query_in.shape
     query_in = query_in.view(batch_size * num_head, 1, head_dim)
     key = fetch_from_cache(key_cache_in, block_tables)
@@ -51,6 +52,7 @@ def paged_attention_v1(query_in, key_cache_in, value_cache_in, head_mapping, sca
     attn_weights = torch.softmax(attn_weights, dim=-1)
     attn_weights = torch.bmm(attn_weights, value.transpose(1, 2))
     attn_weights = attn_weights.view(batch_size, num_head, head_dim)
+    htorch.core.mark_step()
     return attn_weights
 
 

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -12,86 +12,50 @@ import habana_frameworks.torch as htorch
 from typing import List, Optional, Tuple
 
 def silu_and_mul(output, input):
-    htorch.core.mark_step()
     d = input.shape[-1] // 2
     silu = torch.nn.SiLU().to(input.device)
     x, y = torch.split(input, d, dim=-1)
     output.copy_(silu(x) * y)
-    htorch.core.mark_step()
+
 
 def gelu_new(output, input):
     raise NotImplementedError
 
+
 def gelu_fast(output, input):
     raise NotImplementedError
 
+
+def fetch_from_cache(cache, blocks, batch_size):
+    return (cache
+            .index_select(0, blocks.flatten())
+            .unflatten(0, (batch_size, -1))
+            .permute(0, 2, 3, 1, 4)
+            .flatten(3, 4)
+            .flatten(0, 1))
+
+
 def paged_attention_v1(query_in, key_cache_in, value_cache_in, head_mapping, scale, block_tables, context_lens, block_size, max_context_len, alibi_slopes, attn_masks=None)  -> None:
-    query = query_in.bfloat16()
-    key_cache = key_cache_in.bfloat16()
-    value_cache = value_cache_in.bfloat16()
-    num_kv_heads = value_cache[0].shape[0]
-    head_size = value_cache[0].shape[1]
-    block_size = value_cache[0].shape[2]
-    num_seqs = query.shape[0]
-    num_query_heads = query.shape[1]
-    max_num_blocks_per_seq = block_tables.shape[1]
-
-    if alibi_slopes or num_query_heads != num_kv_heads: #or attn_masks is None:
+    if alibi_slopes is not None:
         raise NotImplementedError
+    if attn_masks is not None:
+        raise NotImplementedError
+    batch_size, num_head, head_dim = query_in.shape
+    query_in = query_in.view(batch_size * num_head, 1, head_dim)
+    key = fetch_from_cache(key_cache_in, block_tables, batch_size)
+    value = fetch_from_cache(value_cache_in, block_tables, batch_size)
+    seq_len = key.size(-1)
+    attn_weights = torch.bmm(query_in, key).mul_(scale)
+    min_inf = torch.finfo(query_in.dtype).min
+    mask = torch.arange(0, seq_len, dtype=torch.int32, device=key.device).view(1, 1, -1).expand(batch_size, 1, seq_len)
+    mask = mask.ge(context_lens.view(-1, 1, 1))
+    mask = mask.repeat_interleave(num_head, dim=0)
+    attn_weights.masked_fill_(mask, min_inf)
+    attn_weights = torch.softmax(attn_weights, dim=-1)
+    attn_weights = torch.bmm(attn_weights, value.transpose(1, 2))
+    attn_weights = attn_weights.view(batch_size, num_head, head_dim)
+    return attn_weights
 
-    attn_weights_blocks = []
-    value_blocks = []
-    seq_index = torch.tensor([0], dtype=torch.int64, device="hpu")
-
-    for i in range(0, max_num_blocks_per_seq):
-        # FIXME: dynamic hard override for filler. These blocks would contribute nothing to the output due to zero attention_probs and
-        #  will clog up compute resources. The override itself makes the code unsuitable for graph precompilation
-        if (i - 2) * block_size > torch.max(context_lens):
-            break
-        attn_weights = torch.full((num_seqs, num_query_heads, 1, block_size), torch.finfo(query.dtype).min, dtype=query.dtype, device="hpu")
-        values = torch.zeros((num_seqs, num_query_heads, head_size, block_size), dtype=query.dtype, device="hpu")
-        for seq_id in range(num_seqs):
-            seq_index.fill_(seq_id)
-            if i * block_size < context_lens[seq_id]:
-
-                q =  torch.index_select(query, 0, seq_index).transpose(0, 1)
-                key = torch.index_select(key_cache, 0, block_tables[seq_id][i]).squeeze(0)
-                attn_weight = scale * torch.matmul(q, key)
-
-                if attn_masks is not None:
-                    attn_mask = torch.index_select(attn_masks[i], 0, seq_index)
-                    attn_weight = torch.masked_fill(attn_weight, ~(attn_mask.unsqueeze(0).to(torch.bool)), torch.finfo(attn_weight.dtype).min)
-
-                # FIXME: these dynamic checks serve to ensure the -inf default value is not overwritten with fillers that would cause errors
-                #  in logsoftmax computation. A change to custom block multiplication code is required to avoid incurring extra costs here
-                if context_lens[seq_id] < (i + 1) * block_size:
-                    if context_lens[seq_id] - i*block_size < 0:
-                        attn_weight = torch.finfo(query.dtype).min
-                    else:
-                        attn_weight[:, :, context_lens[seq_id] - i*block_size:] = torch.finfo(query.dtype).min
-                attn_weights.index_copy_(0, seq_index, attn_weight.unsqueeze(0))
-            value = torch.index_select(value_cache, 0, block_tables[seq_id][i])
-            # FIXME: these checks concern filler values in the V cache and should be removed once the underlying issue is addressed
-            value = torch.nan_to_num(value)
-            value[value < -1.0e+30] = 0.0
-            values.index_copy_(0, seq_index, value)
-            torch.hpu.synchronize()
-
-        attn_weights_blocks.append(attn_weights.reshape(num_seqs * num_query_heads, 1, block_size))
-        value_blocks.append(values.reshape(num_seqs * num_query_heads, head_size, block_size).transpose(1, 2))
-
-    exp_sum = torch.zeros((*attn_weights_blocks[0].shape[:2], 1), dtype=attn_weights_blocks[0].dtype, device="hpu")
-    for x in attn_weights_blocks:
-        exp_sum.add_(torch.exp(x).sum(dim=-1, keepdim=True))
-
-    output = torch.zeros_like(query)
-    for i in range(len(attn_weights_blocks)):
-        attention_probs = torch.exp(attn_weights_blocks[i]) / exp_sum
-        value = value_blocks[i]
-        out = torch.matmul(attention_probs.to(value.dtype), value).reshape(num_seqs, num_query_heads, head_size)
-        output.add_(out)
-    htorch.core.mark_step()
-    return output.to(dtype=query_in.dtype)
 
 def rms_norm(out, hidden_states, weight, eps):
     htorch.core.mark_step()
@@ -101,6 +65,7 @@ def rms_norm(out, hidden_states, weight, eps):
     hidden_states = hidden_states * torch.rsqrt(variance + eps)
     out.copy_(weight * hidden_states.to(input_dtype))
     htorch.core.mark_step()
+
 
 def rotate_neox(x: torch.Tensor) -> torch.Tensor:
     x1 = x[..., :x.shape[-1] // 2]

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -11,6 +11,9 @@ import torch.nn.functional as F
 import habana_frameworks.torch as htorch
 from typing import List, Optional, Tuple
 
+import vllm.hpu.utils as hpu_utils
+
+
 def silu_and_mul(output, input):
     d = input.shape[-1] // 2
     silu = torch.nn.SiLU().to(input.device)
@@ -28,31 +31,50 @@ def gelu_fast(output, input):
 
 def fetch_from_cache(cache, blocks):
     _, seq_len = blocks.shape
-    return torch.cat([cache.index_select(0, blocks[:, i]) for i in range(seq_len)], dim=-1).flatten(0, 1)
+    return torch.cat([cache.index_select(0, blocks[:, i]) for i in range(seq_len)], dim=-1)
 
 
+def scaled_dot_product_attention(query, key, value, scale, mask):
+    bs = query.size(0)
+    min_inf = torch.finfo(query.dtype).min
+    return (torch.matmul(query, key)
+            .mul_(scale)
+            .masked_fill_(mask, min_inf)
+            .softmax(dim=-1)
+            .matmul(value.transpose(-1, -2)))
 
+
+@hpu_utils.with_mark_steps
 def paged_attention_v1(query, key_cache, value_cache, head_mapping, scale, block_tables, context_lens, block_size, max_context_len, alibi_slopes, attn_masks=None)  -> None:
     if alibi_slopes is not None:
         raise NotImplementedError
     if attn_masks is not None:
         raise NotImplementedError
-    htorch.core.mark_step()
-    batch_size, num_head, head_dim = query.shape
-    query = query.view(batch_size * num_head, 1, head_dim)
+
     key = fetch_from_cache(key_cache, block_tables)
     value = fetch_from_cache(value_cache, block_tables)
-    seq_len = key.size(-1)
-    attn_weights = torch.bmm(query, key).mul_(scale)
-    min_inf = torch.finfo(query.dtype).min
-    mask = torch.arange(0, seq_len, dtype=torch.int32, device=key.device).view(1, 1, -1).expand(batch_size, 1, seq_len)
-    mask = mask.ge(context_lens.view(-1, 1, 1))
-    mask = mask.repeat_interleave(num_head, dim=0)
-    attn_weights.masked_fill_(mask, min_inf)
-    attn_weights = torch.softmax(attn_weights, dim=-1)
-    attn_weights = torch.bmm(attn_weights, value.transpose(1, 2))
-    attn_weights = attn_weights.view(batch_size, num_head, head_dim)
-    htorch.core.mark_step()
+    query = query.unsqueeze(-2)
+    batch_size, query_heads, head_dim, _ = query.shape
+    _, kv_heads, _, seq_len = key.shape
+
+    mask = (torch.arange(0, seq_len, dtype=torch.int32, device=key.device)
+            .view(1, -1)
+            .expand(batch_size, seq_len)
+            .ge(context_lens.view(-1, 1))
+            .view(batch_size, 1, 1, -1))
+
+    if query_heads != kv_heads:
+        attn_weights = scaled_dot_product_attention(
+            query.unflatten(1, (kv_heads, -1)),
+            key.unsqueeze(2),
+            value.unsqueeze(2),
+            scale,
+            mask.unsqueeze(2))
+        attn_weights = attn_weights.flatten(1, 2)
+    else:
+        attn_weights = scaled_dot_product_attention(query, key, value, scale, mask)
+    attn_weights = attn_weights.squeeze(-2)
+
     return attn_weights
 
 

--- a/vllm/hpu/utils.py
+++ b/vllm/hpu/utils.py
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+import habana_frameworks.torch as htorch
+
+def with_mark_steps(fn):
+    def wrapped(*args, **kwargs):
+        htorch.core.mark_step()
+        result = fn(*args, **kwargs)
+        del args
+        del kwargs
+        htorch.core.mark_step()
+        return result
+    return wrapped
+
+


### PR DESCRIPTION
Rewrite of paged_attention_v1 implementation on gaudi. Blocks are gathered by columns to form a single tensor with whole context, out-of-bounds indices are masked and then regular dot-product attention is calculated.
TODO: add support for alibi and attention_masks