### PR TITLE
Use Ray 2.9.3 for HPU

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -1,6 +1,6 @@
 ninja  # For faster builds.
 psutil
-ray >= 2.5.1
+ray == 2.9.3
 pandas  # Required for Ray data.
 pyarrow  # Required for Ray data.
 sentencepiece  # Required for LLaMA tokenizer.


### PR DESCRIPTION
This is a workaround for error occuring with current vLLM revision and latest ray:
> ImportError: cannot import name 'DEFAULT_NCCL_SOCKET_IFNAME' from 'ray.train.constants'

This fix is expected to be irrelevant once we rebase our codebase.