### PR TITLE
Support larger block sizes

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -145,7 +145,7 @@ class EngineArgs:
         parser.add_argument('--block-size',
                             type=int,
                             default=EngineArgs.block_size,
-                            choices=[8, 16, 32],
+                            choices=[8, 16, 32, 48, 64, 96, 128, 192, 256],
                             help='token block size')
         # TODO(woosuk): Support fine-grained seeds (e.g., seed per request).
         parser.add_argument('--seed',


### PR DESCRIPTION
This minor change enables usage of larger block sizes on HPU. Other than argument parser's constraints, there's nothing preventing us from doing so, and we've identified a significant performance boost on block sizes higher than 32.