### PR TITLE
WA: Disable cumsum in HPU _prepare_prompt

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -402,15 +402,6 @@ class HabanaModelRunner:
                                     dtype=torch.int32,
                                     device=self.device)
 
-        torch.cumsum(query_lens_tensor,
-                     dim=0,
-                     dtype=subquery_start_loc.dtype,
-                     out=subquery_start_loc[1:])
-
-        torch.cumsum(seq_lens_tensor,
-                     dim=0,
-                     dtype=seq_start_loc.dtype,
-                     out=seq_start_loc[1:])
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=True,
             seq_lens=seq_lens,


### PR DESCRIPTION
This patch removes usage of torch.cumsum for subquery_start_loc and seq_start_loc. These tensors are needed for prefill chunking, which we don't support now (so this change doesn't break anything functionally), and we've identified some sporadic crashes while computing torch.cumsum here.  