### PR TITLE
Graphs v2

### DIFF
--- a/vllm/attention/backends/habana_attn.py
+++ b/vllm/attention/backends/habana_attn.py
@@ -217,7 +217,7 @@ class HabanaAttentionImpl(AttentionImpl):
                                      .masked_fill_(mask, -math.inf))
                         if self.sliding_window is not None:
                             raise NotImplementedError("Sliding window is not supported on HPU")
-                        prefill_meta.attn_bias = attn_bias
+                        #prefill_meta.attn_bias = attn_bias
                     else:
                         prefill_meta.attn_bias = _make_alibi_bias(
                             self.alibi_slopes, self.num_kv_heads, batch_size,

--- a/vllm/attention/backends/habana_attn.py
+++ b/vllm/attention/backends/habana_attn.py
@@ -84,9 +84,6 @@ class HabanaAttentionMetadata(AttentionMetadataPerStage, HabanaPagedAttentionMet
 
     # Maximum query length in the batch.
     max_query_len: Optional[int]
-    # FIXME: It is for flash attn.
-    # Maximum sequence length in the batch.
-    max_seq_len: Optional[int]
     # (batch_size + 1,). The cumulative subquery lengths of the sequences in
     # the batch, used to index into subquery. E.g., if the subquery length
     # is [4, 6], it is [0, 4, 10].
@@ -201,27 +198,7 @@ class HabanaAttentionImpl(AttentionImpl):
             # Prompt run.
             if kv_cache is None or prefill_meta.block_tables.numel() == 0:
                 # TODO: move this outside of model
-                if prefill_meta.attn_bias is None:
-                    if self.alibi_slopes is None:
-                        lens = torch.tensor(attn_metadata.prefill_metadata.seq_lens, device=query.device, dtype=torch.int32)
-                        len_mask = (torch.arange(0, seq_len, device=query.device, dtype=torch.int32)
-                                    .view(1, seq_len)
-                                    .ge(lens.unsqueeze(-1))
-                                    .view(batch_size, 1, 1, seq_len))
-                        causal_mask = torch.triu(
-                            torch.ones((batch_size, 1, seq_len, seq_len), device=query.device, dtype=torch.bool),
-                            diagonal=1
-                        )
-                        mask = causal_mask.logical_or(len_mask)
-                        attn_bias = (torch.zeros_like(mask, dtype=query.dtype)
-                                     .masked_fill_(mask, -math.inf))
-                        if self.sliding_window is not None:
-                            raise NotImplementedError("Sliding window is not supported on HPU")
-                        #prefill_meta.attn_bias = attn_bias
-                    else:
-                        prefill_meta.attn_bias = _make_alibi_bias(
-                            self.alibi_slopes, self.num_kv_heads, batch_size,
-                            seq_len, query.dtype)
+                assert prefill_meta.attn_bias is not None, 'attn_bias must be set before calling model.forward!'
                 query_shape = (batch_size, seq_len, self.num_heads, self.head_size)
                 kv_shape = (batch_size, seq_len_kv, self.num_kv_heads, self.head_size)
                 out = xops.prompt_attention(
@@ -256,7 +233,6 @@ class HabanaAttentionImpl(AttentionImpl):
                 value_cache,
                 decode_meta.block_tables,
                 decode_meta.seq_lens_tensor,
-                decode_meta.max_seq_len,
                 attn_metadata.kv_cache_dtype,
                 self.num_kv_heads,
                 self.scale,

--- a/vllm/attention/ops/habana_paged_attn.py
+++ b/vllm/attention/ops/habana_paged_attn.py
@@ -19,8 +19,6 @@ class HabanaPagedAttentionMetadata:
     # (batch_size,). The length of sequences (entire tokens seen so far) per
     # sequence.
     seq_lens_tensor: Optional[torch.Tensor]
-    # Maximum sequence length in the batch.
-    max_seq_len: Optional[int]
     # (batch_size, max_blocks_per_seq).
     # Block addresses per sequence. (Seq id -> list of physical block)
     # E.g., [0, 1, 2] means tokens are stored in 0th, 1st, and 2nd blocks
@@ -82,7 +80,6 @@ class HabanaPagedAttention:
         value_cache: torch.Tensor,
         block_tables: torch.Tensor,
         seq_lens: torch.Tensor,
-        max_seq_len: int,
         kv_cache_dtype: str,
         num_kv_heads: int,
         scale: float,
@@ -99,7 +96,6 @@ class HabanaPagedAttention:
             block_tables,
             seq_lens,
             block_size,
-            max_seq_len,
             alibi_slopes,
             kv_cache_dtype,
         )

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -36,7 +36,7 @@ def fetch_from_cache(cache, blocks):
 
 
 @hpu_utils.with_mark_steps
-def paged_attention_v1(query, key_cache, value_cache, head_mapping, scale, block_tables, context_lens, block_size, max_context_len, alibi_slopes, kv_cache_dtype=None)  -> None:
+def paged_attention_v1(query, key_cache, value_cache, head_mapping, scale, block_tables, context_lens, block_size, alibi_slopes, kv_cache_dtype=None) -> None:
     seq_len = block_tables.size(1)
     batch_size, query_heads, _ = query.shape
     _, kv_heads, _, _ = key_cache.shape

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -85,8 +85,11 @@ def _prune_hidden_states(
     hidden_states: torch.Tensor,
     sampling_metadata: SamplingMetadata,
 ) -> torch.Tensor:
-    return hidden_states.index_select(0,
-                                      sampling_metadata.selected_token_indices)
+    if sampling_metadata.selected_token_indices is not None:
+        return hidden_states.index_select(0,
+                                          sampling_metadata.selected_token_indices)
+    else:
+        return hidden_states
 
 
 def _apply_logits_processors(

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -512,16 +512,17 @@ class HabanaMemoryProfiler:
         return total_hpu_memory
 
     def __enter__(self):
+        # Force garbage collection
+        gc.collect()
         self.initial_memory = HabanaMemoryProfiler.current_memory_usage()
         # This allows us to call methods of the context manager if needed
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.final_memory = HabanaMemoryProfiler.current_memory_usage()
-        self.consumed_memory = self.final_memory - self.initial_memory
-
         # Force garbage collection
         gc.collect()
+        self.final_memory = HabanaMemoryProfiler.current_memory_usage()
+        self.consumed_memory = self.final_memory - self.initial_memory
 
 
 # Adapted from https://stackoverflow.com/a/49361727

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -942,11 +942,11 @@ class HabanaModelRunner:
         self.warmup_scenario(self.max_num_seqs, seq_len, True, kv_caches)
 
     def warmup_scenario(self, batch_size, seq_len, is_prompt, kv_caches) -> None:
-        use_graphs = self.use_graphs(batch_size, seq_len, is_prompt)
-        scenario_name = f"warmup_{'prompt' if is_prompt else 'decode'}_bs{batch_size}_seq{seq_len}_graphs{use_graphs}"
+        use_graphs = self._use_graphs(batch_size, seq_len, is_prompt)
+        scenario_name = f"warmup_{'prompt' if is_prompt else 'decode'}_bs{batch_size}_seq{seq_len}_graphs{'T' if use_graphs else 'F'}"
+        self.profiler.start('internal', scenario_name)
         times = 3 if use_graphs else 1
         seqs = [self.create_dummy_seq_group_metadata(i, seq_len, is_prompt) for i in range(batch_size)]
-        self.profiler.start('internal', scenario_name)
         torch.hpu.synchronize()
         for _ in range(times):
             self.execute_model(seqs, kv_caches)

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -981,14 +981,14 @@ class HabanaModelRunner:
         self.warmup_all_buckets(self.decode_buckets, False, kv_caches)
 
         if not self.enforce_eager:
-            mem_margin = 1.0 - float(os.environ.get('VLLM_GRAPH_MEM_MARGIN', '0.05'))
+            mem_margin = 1.0 - float(os.environ.get('VLLM_GRAPH_MEM_MARGIN', '0.02'))
             free_mem = mem_margin * HabanaMemoryProfiler.current_free_memory()
             free_mem = align_workers(free_mem, torch.distributed.ReduceOp.MIN)
             prompt_graph_mem_ratio = float(os.environ.get('VLLM_GRAPH_PROMPT_RATIO', '0.5'))
             prompt_available_memory = prompt_graph_mem_ratio * free_mem
             decode_available_memory = free_mem - prompt_available_memory
             prompt_strategy = 'min_tokens'
-            decode_strategy = os.environ.get('VLLM_GRAPH_DECODE_STRATEGY', 'min_tokens')
+            decode_strategy = os.environ.get('VLLM_GRAPH_DECODE_STRATEGY', 'max_bs')
             self.warmup_graphs(prompt_strategy, self.prompt_buckets, True, kv_caches, prompt_available_memory)
             self.warmup_graphs(decode_strategy, self.decode_buckets, False, kv_caches, decode_available_memory)
 

--- a/vllm/worker/habana_worker.py
+++ b/vllm/worker/habana_worker.py
@@ -129,8 +129,8 @@ class HabanaWorker(WorkerBase):
         free_hpu_memory = torch.hpu.mem_get_info()[0]
 
         cache_block_size = self.get_cache_block_size_bytes()
-        graph_headroom = float(os.environ.get('VLLM_GRAPH_HEADROOM', '0.2')) if not self.model_config.enforce_eager else 0.0
-        num_hpu_blocks = int(free_hpu_memory * self.cache_config.gpu_memory_utilization // cache_block_size)
+        graph_headroom = 1 - (float(os.environ.get('VLLM_GRAPH_RESERVED_MEM', '0.2')) if not self.model_config.enforce_eager else 0)
+        num_hpu_blocks = int(free_hpu_memory * graph_headroom * self.cache_config.gpu_memory_utilization // cache_block_size)
         num_cpu_blocks = int(self.cache_config.swap_space_bytes //
                              cache_block_size)
         num_hpu_blocks = max(num_hpu_blocks, 0)

--- a/vllm/worker/habana_worker.py
+++ b/vllm/worker/habana_worker.py
@@ -90,7 +90,6 @@ class HabanaWorker(WorkerBase):
         if self.device_config.device.type == "hpu":
             self.device = torch.device("hpu")
             torch.hpu.set_device(self.device)
-            self.init_hpu_memory = torch.hpu.mem_get_info()[0]
         else:
             raise RuntimeError(
                 f"Not support device type: {self.device_config.device}")
@@ -123,22 +122,12 @@ class HabanaWorker(WorkerBase):
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         self.model_runner.profile_run()
-
-        # Calculate the number of blocks that can be allocated with the
-        # profiled peak memory.
         torch.hpu.synchronize()
-        free_hpu_memory, total_hpu_memory = torch.hpu.mem_get_info()
-        # NOTE(woosuk): Here we assume that the other processes using the same
-        # HPU did not change their memory usage during the profiling.
-        peak_memory = self.init_hpu_memory - free_hpu_memory
-        assert peak_memory > 0, (
-            "Error in memory profiling. This happens when the HPU memory was "
-            "not properly cleaned up before initializing the vLLM instance.")
+        free_hpu_memory = torch.hpu.mem_get_info()[0]
 
         cache_block_size = self.get_cache_block_size_bytes()
-        num_hpu_blocks = int(
-            (total_hpu_memory * self.cache_config.gpu_memory_utilization -
-             peak_memory) // cache_block_size)
+        graph_headroom = 0.1
+        num_hpu_blocks = int(free_hpu_memory * (1.0 - graph_headroom) * self.cache_config.gpu_memory_utilization // cache_block_size)
         num_cpu_blocks = int(self.cache_config.swap_space_bytes //
                              cache_block_size)
         num_hpu_blocks = max(num_hpu_blocks, 0)
@@ -298,7 +287,8 @@ def init_worker_distributed_environment(
     assert dummy_tensor_hpu.item() == parallel_config.world_size
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size)
-    
+
+
 def raise_if_cache_size_invalid(num_gpu_blocks, block_size,
                                 max_model_len) -> None:
     if num_gpu_blocks <= 0:

--- a/vllm/worker/habana_worker.py
+++ b/vllm/worker/habana_worker.py
@@ -129,7 +129,7 @@ class HabanaWorker(WorkerBase):
         free_hpu_memory = torch.hpu.mem_get_info()[0]
 
         cache_block_size = self.get_cache_block_size_bytes()
-        graph_headroom = 1 - (float(os.environ.get('VLLM_GRAPH_RESERVED_MEM', '0.2')) if not self.model_config.enforce_eager else 0)
+        graph_headroom = 1 - (float(os.environ.get('VLLM_GRAPH_RESERVED_MEM', '0.3')) if not self.model_config.enforce_eager else 0)
         num_hpu_blocks = int(free_hpu_memory * graph_headroom * self.cache_config.gpu_memory_utilization // cache_block_size)
         num_cpu_blocks = int(self.cache_config.swap_space_bytes //
                              cache_block_size)

--- a/vllm/worker/habana_worker.py
+++ b/vllm/worker/habana_worker.py
@@ -129,7 +129,7 @@ class HabanaWorker(WorkerBase):
         free_hpu_memory = torch.hpu.mem_get_info()[0]
 
         cache_block_size = self.get_cache_block_size_bytes()
-        graph_headroom = 1 - (float(os.environ.get('VLLM_GRAPH_RESERVED_MEM', '0.3')) if not self.model_config.enforce_eager else 0)
+        graph_headroom = 1 - (float(os.environ.get('VLLM_GRAPH_RESERVED_MEM', '0.4')) if not self.model_config.enforce_eager else 0)
         num_hpu_blocks = int(free_hpu_memory * graph_headroom * self.cache_config.gpu_memory_utilization // cache_block_size)
         num_cpu_blocks = int(self.cache_config.swap_space_bytes //
                              cache_block_size)


### PR DESCRIPTION
Rework of HPU graphs. Now the flow looks like this:
* VLLM_GRAPH_RESERVED_MEM is used to determine how much free memory after loading weights should be used for HPU-graphs (by default 30%)
* we allocate blocks according to gpu-memory-utilization
* we warmup all shapes without HPU graphs
* we calculate remaining free memory and split it between prompt and decode graphs according to VLLM_GRAPH_PROMPT_RATIO (50%) and VLLM_GRAPH_MEM_MARGIN (5%)
* we capture prompt graphs in order defined by bs*seq_len stoping when according to heuristics we won't fit another graph
* as above but for decode graphs

Other important changes:
* selecting token ids has been moved inside HPU graphs to limit memory usage
* calculating attention_mask has been moved inside HPU graphs, but before model.forward to limit memory usage
* *AttentionMetadata objects are trimmed before going into HPU graphs for better control over parameters (and avoiding recompilations due to changing constants)