### PR TITLE
Use int32 seeds for random sampler on HPU

### DIFF
--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -8,7 +8,7 @@ from vllm.model_executor.layers.ops.sample import get_num_triton_sampler_splits
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.sequence import SequenceData, SequenceGroupMetadata
 from vllm.utils import (async_tensor_h2d, is_pin_memory_available,
-                        maybe_expand_dim)
+                        maybe_expand_dim, is_hpu)
 
 _SAMPLING_EPS = 1e-5
 _SEED_0_REPLACEMENT = 3403598558
@@ -498,22 +498,23 @@ class SamplingTensors:
             dtype=torch.int,
             pin_memory=pin_memory,
         )
+        idx_dtype = torch.long if not is_hpu() else torch.int # Gaudi doesn't have full native int64 support 
         sample_indices_t = torch.tensor(
             sample_indices,
             device="cpu",
-            dtype=torch.long,
+            dtype=idx_dtype,
             pin_memory=pin_memory,
         )
         prompt_tensor = torch.tensor(
             prompt_padded_tokens,
             device="cpu",
-            dtype=torch.long,
+            dtype=idx_dtype,
             pin_memory=pin_memory,
         )
         output_tensor = torch.tensor(
             output_padded_tokens,
             device="cpu",
-            dtype=torch.long,
+            dtype=idx_dtype,
             pin_memory=pin_memory,
         )
         # need to transpose and make contiguous to
@@ -522,7 +523,7 @@ class SamplingTensors:
         sampling_seeds_t = torch.tensor(
             sampling_seeds,
             device="cpu",
-            dtype=torch.long,
+            dtype=idx_dtype,
             pin_memory=pin_memory,
         ).T.contiguous()
 
@@ -571,7 +572,8 @@ class SamplingTensors:
             else:
                 generator = random.Random(str((seed, ) + extra_entropy))
                 randint_fn = generator.randint
-            lo, hi = torch.iinfo(torch.long).min, torch.iinfo(torch.long).max
+            idx_dtype = torch.long if not is_hpu() else torch.int # Gaudi doesn't have full native int64 support 
+            lo, hi = torch.iinfo(idx_dtype).min, torch.iinfo(idx_dtype).max
             # If the user/random sets seed = 0 but request should
             # have sampling, we need to change it to something
             # else. We use a constant in that case.


### PR DESCRIPTION
Turns out that Gaudi doesn't have full native int64 support and it's preferred to use int32 indices on HPU. Other accelerators are not affected by this patch.