### PR TITLE
Bump ray version to 2.23.0

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -2,7 +2,7 @@
 -r requirements-common.txt
 
 # Dependencies for HPU code
-ray == 2.9.3
+ray == 2.23.0
 triton
 pandas
 tabulate


### PR DESCRIPTION
This fixes setuptools/packaging issue on multi-card inference. 