### PR TITLE
Enable PA_SPLIT_VALUE by default

### DIFF
--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple
 
 import vllm.hpu.utils as hpu_utils
 
-PA_SPLIT_VALUE = (os.environ.get('PA_SPLIT_VALUE', '0') == '1')
+PA_SPLIT_VALUE = (os.environ.get('PA_SPLIT_VALUE', '1') == '1')
 
 
 def silu_and_mul(output, input):


### PR DESCRIPTION
This PR enables PA_SPLIT_VALUE optimization by default. It theoretically might introduce numerical errors due to lower precision datatypes being used for accumulation, but more extensive testing determined its impact on accuracy to be negligible. It can still be disabled with PA_SPLIT_VALUE=0 if any accuracy/precision errors are encountered.