### PR TITLE
Normalize router weights in MoE OP

### DIFF
--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -130,6 +130,7 @@ def static_fused_moe(hidden_states, w1, w2, score, topk):
     num_experts = w1.shape[0]
     routing_weights = F.softmax(score, dim=1, dtype=torch.float32)
     routing_weights, selected_experts = torch.topk(routing_weights, topk, dim=-1)
+    routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
     routing_weights = routing_weights.to(hidden_states.dtype)
     final_hidden_states = torch.zeros(
             (1, B, D), dtype=hidden_states.dtype, device=hidden_states.device


### PR DESCRIPTION
Adds router weights normalization to improve mixtral accuracy.