### PR TITLE
SiLU memory leak in fwd

### DIFF
--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -37,15 +37,6 @@ class SiluAndMul(CustomOp):
         ops.silu_and_mul(out, x)
         return out
 
-    def forward_hpu(self, x: torch.Tensor) -> torch.Tensor:
-        import vllm.hpu.ops as ops
-
-        d = x.shape[-1] // 2
-        output_shape = (x.shape[:-1] + (d, ))
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        ops.silu_and_mul(out, x)
-        return out
-
     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
         from vllm._ipex_ops import ipex_ops as ops
 


### PR DESCRIPTION
Implementation using custom op for SiLU makes memory increased while generating HPU graphs for Prompt.
This removes custom implementation.