### PR TITLE
Limit prefill batch size

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -629,7 +629,10 @@ class Scheduler:
         waiting_queue = deque([s for s in waiting_queue])
 
         leftover_waiting_sequences: Deque[SequenceGroup] = deque()
-        while self._passed_delay(time.time()) and waiting_queue:
+        i = 0
+        max_prefill_batch_size = int(os.getenv("VLLM_PROMPT_BS_BUCKET_MAX", budget.max_num_seqs))
+        while self._passed_delay(time.time()) and waiting_queue and i < max_prefill_batch_size:
+            i += 1
             seq_group = waiting_queue[0]
 
             waiting_seqs = seq_group.get_seqs(status=SequenceStatus.WAITING)

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -122,12 +122,14 @@ def setup_profiler():
     return method(schedule)
 
 
-# Read bucketing configuration from env variables
-# phase is either 'prompt' or 'decode'
-# dim is either 'bs' or 'block'
-# param is either 'min', 'step' or 'max'
-# example env variable: VLLM_DECODE_BS_BUCKET_STEP=128
 def read_bucket_settings(phase: str, dim: str, **defaults: Dict):
+    """Read bucketing configuration from env variables.
+
+    phase is either 'prompt' or 'decode'
+    dim is either 'bs' or 'block'
+    param is either 'min', 'step' or 'max'
+    example env variable: VLLM_DECODE_BS_BUCKET_STEP=128
+    """
     params = ['min', 'step', 'max']
     env_vars = [f'VLLM_{phase}_{dim}_BUCKET_{p}'.upper() for p in params]
     defaults = [defaults[p] for p in params]
@@ -138,7 +140,19 @@ def read_bucket_settings(phase: str, dim: str, **defaults: Dict):
 
 
 def warmup_range(config: Tuple[int, int, int]):
+    """Generate a warmup range.
+
+    Start from bmin and multiply by 2 until you reach bstep.
+    Then, increase the values in the range by the value of bstep until you reach bmax.
+
+    Example:
+    bmin = 2, bstep = 32, bmax = 64
+    => ramp_up = (2, 4, 8, 16)
+    => stable = (32, 64)
+    => return ramp_up + stable => (2, 4, 8, 16, 32, 64)
+    """
     bmin, bstep, bmax = config
+    assert bmin <= bmax, "Min. batch size cannot be greater than max. batch size. If you want to skip warmup, set VLLM_SKIP_WARMUP=true"
     base = itertools.repeat(2)
     ramp_up = itertools.accumulate(base, func=operator.mul, initial=bmin)
     ramp_up = itertools.takewhile(lambda x: x < bstep and x <= bmax, ramp_up)


### PR DESCRIPTION
Limit prefill batch size so that we avoid recompilations. This can be controlled with an env var VLLM_PROMPT_BS_BUCKET_MAX