### PR TITLE
Reduce `block_indices` and `block_offsets` computation to once per forward pass

### DIFF
--- a/vllm/attention/ops/habana_paged_attn.py
+++ b/vllm/attention/ops/habana_paged_attn.py
@@ -19,6 +19,8 @@ class HabanaPagedAttentionMetadata:
     block_list: Optional[torch.Tensor]
     block_mapping: Optional[torch.Tensor]
     block_usage: Optional[torch.Tensor]
+    block_indices: Optional[torch.Tensor]
+    block_offsets: Optional[torch.Tensor]
 
 
 class HabanaPagedAttention:

--- a/vllm/hpu/cache_ops.py
+++ b/vllm/hpu/cache_ops.py
@@ -10,24 +10,6 @@ import torch
 import habana_frameworks.torch as htorch
 
 
-def reshape_and_cache(key, value, key_cache, value_cache, slot_mapping, dtype, is_prompt=False):
-    block_size = key_cache.size(1)
-    slot_mapping = slot_mapping.flatten()
-    indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
-    offsets = torch.fmod(slot_mapping, block_size)
-    key_cache.index_put_((indices, offsets), key)
-    value_cache.index_put_((indices, offsets), value)
-
-
-def prepare_to_cache(cache, slot_mapping):
-    block_size = cache.size(1)
-    slot_mapping = slot_mapping.flatten()
-    indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
-    offsets = torch.fmod(slot_mapping, block_size)
-
-    return indices, offsets
-
-
 def insert_or_update_cache(input, cache, block_indices, block_offsets):
     cache.index_put_((block_indices, block_offsets), input)
 


### PR DESCRIPTION
Currently, `block_indices` and `block_offsets` are computed for each LLM layer, this is not necessary as they don't change during forward pass.