### PR TITLE
schedule prefills considering padded shape

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1034,7 +1034,7 @@ class HabanaModelRunner:
         num_layers = self.model_config.get_num_layers(self.parallel_config)
         kv_caches = [None] * num_layers
         max_batch_size = self.prompt_bs_bucket_cfg[-1]
-        max_seq_len = self.prompt_seq_bucket_cfg[-1]
+        max_seq_len = self.block_size
 
         self.warmup_scenario(max_batch_size, max_seq_len, True, kv_caches)
 


### PR DESCRIPTION
This PR revises prefill scheduling to consider padded shapes of prefills, which is the actual shapes of input tensors for the graphs.

- While trying to reduce VLLM_GRAPH_RESERVED_MEM as much as possible, we found out that the number of total tokens in a prefill batch can exceed max_num_batched_tokens.
- It is because the prompt batch is padded in habana_model_runner(#L648) - it pads all prompts to max(find_bucket(max(seq_lens), self.prompt_seq_bucket_cfg), self.block_size).
- Since the scheduler checks if the sum of actual prompt length exceeds max_num_batched_tokens or not, total number of tokens in a prefill batch after padding can significantly deviate from max_num_batched_tokens in certain cases.

Therefore, we propose to consider the shape of padded prompts during the scheduling process. With this scheduler, we can ensure that the shapes of all prompt batches reside in a pre-defined set of shapes.
I think the pros and cons of the change are as follows:

- Pros: We can optimize VLLM_GRAPH_RESERVED_MEM further as no additional prefill compilation will happen. This reduces compilation overhead too. Zero pads for prompts tend to decrease since the number of zero pads are now considered during the scheduling.
- Cons: Prefill batch size tends be limited and overall prefill throughput can be degraded. max_num_batched_tokens must be chosen carefully.

Initial benchmarks of ours are like this:

- On habana_main, prefill only latency: 73.23 seconds -> 27.92 seconds
- On habana_main, end-to-end latency: 890.68 seconds --> 739.16 seconds

```
prefill only: llama-3-8b, single gaudi-2, max-model-len 3072, **max-output-len 1**, max-seq-len 128, max_num_batched_tokens 3072, 1024 queries from OpenOrca, hpu_graph
end-to-end: llama-3-8b, single gaudi-2, max-model-len 3072, **max-output-len 1024**, max-seq-len 128, max_num_batched_tokens 3072, 1024 queries from OpenOrca, hpu_graph
```

- On habana_next, prefill only latency: 74.42 seconds -> 32.61 seconds
- On habana_next, end-to-end latency: 412.73 seconds -> 395.28 seconds

```
prefill only: llama-3-8b, single gaudi-2, max-model-len 3072, **max-output-len 1**, max-seq-len 128, **max_num_batched_tokens 6144**, 1024 queries from OpenOrca, hpu_graph
end-to-end: llama-3-8b, single gaudi-2, max-model-len 3072, **max-output-len 1024**, max-seq-len 128, **max_num_batched_tokens 6144**, 1024 queries from OpenOrca, hpu_graph
```

Note that actual throughput gain is limited in habana_next. We are still happy with that since we can be sure that additional prefill graph compilation won't happen.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


