### PR TITLE
Allocate blocks from id=1

### DIFF
--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -53,7 +53,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
                 before CPU block IDs.
         """
         # Block ids cannot be equal to 0
-        block_ids = list(range(1, num_gpu_blocks + num_cpu_blocks + 1))
+        block_ids = list(range(1, num_gpu_blocks + num_cpu_blocks))
         gpu_block_ids = block_ids[:num_gpu_blocks]
         cpu_block_ids = block_ids[num_gpu_blocks:]
 

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -52,7 +52,8 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             - The block IDs are assigned contiguously, with GPU block IDs coming
                 before CPU block IDs.
         """
-        block_ids = list(range(num_gpu_blocks + num_cpu_blocks))
+        # Block ids cannot be equal to 0
+        block_ids = list(range(1, num_gpu_blocks + num_cpu_blocks + 1))
         gpu_block_ids = block_ids[:num_gpu_blocks]
         cpu_block_ids = block_ids[num_gpu_blocks:]
 


### PR DESCRIPTION
When using BlockManagerV2, blocks are allocated from id=0, which can cause undefined behavior in reuse_and_cache function. This issue is better visible with --tensor-parallel-size > 1.
This change moves the first block id from 0 to 1.