### PR TITLE
Allocate blocks from id=1 for HPU

### DIFF
--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -4,7 +4,7 @@ from vllm.core.block.interfaces import (Block, BlockAllocator, BlockId,
                                         DeviceAwareBlockAllocator)
 from vllm.core.block.naive_block import NaiveBlock, NaiveBlockAllocator
 from vllm.core.block.prefix_caching_block import PrefixCachingBlockAllocator
-from vllm.utils import Device
+from vllm.utils import Device, is_hpu
 
 
 class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
@@ -52,7 +52,9 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             - The block IDs are assigned contiguously, with GPU block IDs coming
                 before CPU block IDs.
         """
-        block_ids = list(range(num_gpu_blocks + num_cpu_blocks))
+        # For HPU block ids cannot be equal to 0
+        start_id = 1 if is_hpu() else 0
+        block_ids = list(range(start_id, num_gpu_blocks + num_cpu_blocks))
         gpu_block_ids = block_ids[:num_gpu_blocks]
         cpu_block_ids = block_ids[num_gpu_blocks:]
 


### PR DESCRIPTION
This PR is related to the change from habana_next: #155 

When using BlockManagerV2, blocks are allocated from id=0, which can cause undefined behavior in reuse_and_cache function. This issue is better visible with --tensor-parallel-size > 1.
This change moves the first block id from 0 to 1 for HPU device.