### PR TITLE
Fix blocks allocation range

### DIFF
--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -54,7 +54,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         """
         # For HPU block ids cannot be equal to 0
         start_id = 1 if is_hpu() else 0
-        block_ids = list(range(start_id, num_gpu_blocks + num_cpu_blocks))
+        block_ids = list(range(start_id, num_gpu_blocks + num_cpu_blocks + start_id))
         gpu_block_ids = block_ids[:num_gpu_blocks]
         cpu_block_ids = block_ids[num_gpu_blocks:]
 


### PR DESCRIPTION
Fixes AssertionError introduced by #160 

In `vllm/core/block/naive_block.py:42`:
```python
assert len(self._all_block_indices) == num_blocks
```
The original change reduced the number of blocks and caused the above condition to fail.