### PR TITLE
Revert "Ensure buckets do not exceed the batch token limit"

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -94,16 +94,10 @@ def warmup_range(config: Tuple[int, int, int]):
     return list(ramp_up_tw) + list(stable)
 
 
-def warmup_buckets(bs_bucket_config, seq_bucket_config,
-                   max_num_batched_tokens):
+def warmup_buckets(bs_bucket_config, seq_bucket_config):
     buckets = itertools.product(warmup_range(bs_bucket_config),
                                 warmup_range(seq_bucket_config))
-    # Remove buckets exceeding batch token budget
-    filtered_buckets = filter(
-        lambda bucket: bucket[0] * bucket[1] <= max_num_batched_tokens,
-        buckets)
-    return list(
-        sorted(filtered_buckets, key=lambda b: (b[0] * b[1], b[1], b[0])))
+    return list(sorted(buckets, key=lambda b: (b[0] * b[1], b[1], b[0])))
 
 
 def next_pow2(value: int):
@@ -532,8 +526,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                f"seq:{self.prompt_seq_bucket_cfg}")
         logger.info(msg)
         self.prompt_buckets = warmup_buckets(self.prompt_bs_bucket_cfg,
-                                             self.prompt_seq_bucket_cfg,
-                                             self.max_num_batched_tokens)
+                                             self.prompt_seq_bucket_cfg)
 
         if self.lora_config:
             self.prompt_buckets[:] = [
@@ -550,8 +543,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                f"seq:{self.decode_seq_bucket_cfg}")
         logger.info(msg)
         self.decode_buckets = warmup_buckets(self.decode_bs_bucket_cfg,
-                                             self.decode_seq_bucket_cfg,
-                                             self.max_num_batched_tokens)
+                                             self.decode_seq_bucket_cfg)
         if self.lora_config:
             self.decode_buckets[:] = [
                 bucket for bucket in self.decode_buckets


### PR DESCRIPTION
Reverts HabanaAI/vllm-fork#206

Motivation: Mixtral workloads started crashing due to this change. 

Logs:
```
INFO 08-27 18:14:26 selector.py:85] Using HabanaAttention backend.
INFO 08-27 18:14:26 habana_model_runner.py:533] Prompt bucket config (min, step, max_warmup) bs:[2, 2, 4], seq:[512, 512, 2048]
INFO 08-27 18:14:26 habana_model_runner.py:546] Generated 4 prompt buckets: [(2, 512), (2, 1024), (2, 1536), (4, 512)]
INFO 08-27 18:14:26 habana_model_runner.py:551] Decode bucket config (min, step, max_warmup) bs:[128, 128, 128], seq:[128, 128, 2048]
INFO 08-27 18:14:26 habana_model_runner.py:562] Generated 0 decode buckets: []
```
...
```
[rank0]:   File "(..)/vllm-fork/vllm/worker/habana_model_runner.py", line 1331, in warmup_model
[rank0]:     self.log_graph_warmup_summary(self.decode_buckets, False,
[rank0]:   File "(..)/vllm-fork/vllm/worker/habana_model_runner.py", line 1259, in log_graph_warmup_summary
[rank0]:     f'({100 * len(graphed) / num_candidates:.1f}%) '
[rank0]: ZeroDivisionError: division by zero
```

Please make this new feature more verbose and make sure that the user is not forced to set the "--max-num-batched-tokens". Until it's fixed, please consider reverting the problematic commit.