### PR TITLE
enabling multi-node serving on Gaudi ray cluster

### DIFF
--- a/vllm/worker/habana_worker.py
+++ b/vllm/worker/habana_worker.py
@@ -90,6 +90,11 @@ class HabanaWorker(LocalOrDistributedWorkerBase):
         self.cache_engine: List[CacheEngine]
         # Initialize gpu_cache as embedding models don't initialize kv_caches
         self.hpu_cache: Optional[List[List[torch.tensor]]] = None
+        if self.parallel_config.world_size > 8:
+            from habana_frameworks.torch.distributed.hccl import initialize_distributed_hpu
+            if 'HABANA_VISIBLE_MODULES' in os.environ:
+                os.environ.pop('HABANA_VISIBLE_MODULES')
+            initialize_distributed_hpu(self.parallel_config.world_size, self.rank, self.local_rank)
 
     def _set_env_vars(self):
         local_rank = self.local_rank


### PR DESCRIPTION
PR enables multi-node serving on Ray cluster. Tested with meta-llama/Meta-Llama-3.1-405B-Instruct
Originally implemented in SW-195705

Steps to test:
1. Install vllm-fork on master and worker nodes
2. Launch Ray cluster.
3. Run benchmark as below (eg: for 2 nodes, 16 Gaudi cards)
```shell
export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
export PT_HPUGRAPH_DISABLE_TENSOR_CACHE=0
export GLOO_SOCKET_IFNAME=eth0

python benchmarks/benchmark_throughput.py --backend vllm --input-len 128 --output-len 128 \
--model  meta-llama/Meta-Llama-3.1-405B-Instruct  --device hpu \
--dtype bfloat16 --tensor-parallel-size 16 --num-prompts 10
``` 
4. Serve the model
```shell
vllm serve  meta-llama/Meta-Llama-3.1-405B-Instruct  --tensor-parallel-size 16  --pipeline-parallel-size 1
``` 

Contributors - @jiunnyeu-habana @kzawora-intel , Jiafan Wang , Kobayashi-san , Nishant Agrawal
