### PR TITLE
Fix guided sampling with outlines

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -18,7 +18,7 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.10.3
-outlines >= 0.0.43, < 0.1 # Requires torch >= 2.1.0
+outlines >= 0.0.46, < 0.1 # Requires torch >= 2.1.0
 typing_extensions
 filelock >= 3.10.4 # filelock starts to support `mode` argument from 3.10.4
 pyzmq

--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -68,7 +68,7 @@ class BaseLogitsProcessor:
 class RegexLogitsProcessor(BaseLogitsProcessor):
 
     @classmethod
-    @cache()
+    @lru_cache(maxsize=32)
     def _get_guide(cls, regex_string: str,
                    tokenizer: PreTrainedTokenizerBase) -> Guide:
         tokenizer = _adapt_tokenizer(tokenizer)
@@ -127,7 +127,7 @@ class JSONLogitsProcessor(RegexLogitsProcessor):
 class CFGLogitsProcessor(BaseLogitsProcessor):
 
     @classmethod
-    @cache()
+    @lru_cache(maxsize=32)
     def _get_guide(cls, cfg: str, tokenizer: PreTrainedTokenizerBase) -> Guide:
         tokenizer = _adapt_tokenizer(tokenizer)
         return CFGGuide(cfg, tokenizer)

--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -57,11 +57,9 @@ class BaseLogitsProcessor:
             raise TypeError(
                 f"Unsupported instruction type {type(instruction)}")
 
-        mask = torch.full((scores.shape[-1], ),
-                          -math.inf,
-                          device=scores.device)
+        mask = torch.ones((scores.shape[-1], ), device=scores.device, dtype=torch.bool)
         mask[allowed_tokens] = 0
-        scores.add_(mask)
+        scores.masked_fill_(mask, -math.inf)
         return scores
 
 

--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -27,6 +27,7 @@ from outlines.fsm.json_schema import build_regex_from_schema
 from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
 
+from vllm.hpu.utils import with_mark_steps
 
 class BaseLogitsProcessor:
 
@@ -34,6 +35,7 @@ class BaseLogitsProcessor:
         self._guide: Guide = guide
         self._fsm_state: DefaultDict[int, int] = defaultdict(int)
 
+    @with_mark_steps
     def __call__(self, input_ids: List[int],
                  scores: torch.Tensor) -> torch.Tensor:
         """Use the FSM to bias the logits before sampling the next token."""

--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -21,7 +21,6 @@ from functools import lru_cache
 from typing import Callable, DefaultDict, Dict, List, Union
 
 import torch
-from outlines.caching import cache
 from outlines.fsm.guide import CFGGuide, Generate, Guide, RegexGuide, Write
 from outlines.fsm.json_schema import build_regex_from_schema
 from pydantic import BaseModel
@@ -59,9 +58,11 @@ class BaseLogitsProcessor:
             raise TypeError(
                 f"Unsupported instruction type {type(instruction)}")
 
-        mask = torch.ones((scores.shape[-1], ), device=scores.device, dtype=torch.bool)
+        mask = torch.full((scores.shape[-1], ),
+                          -math.inf,
+                          device=scores.device)
         mask[allowed_tokens] = 0
-        scores.masked_fill_(mask, -math.inf)
+        scores = scores.add(mask)
         return scores
 
 


### PR DESCRIPTION
This is a rebase of PR #153 to habana_main due to the deprecation of habana_next.

Current habana_main includes guided decoding related code from vllm, and the feature is already there in the openAI api endpoint. However, guided decoding currently fails to run with following error:

```
...
 File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1535, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1585, in _call_impl
    result = forward_call(*args, **kwargs)
  File "/workspace/codes/vllm/model_executor/layers/sampler.py", line 138, in forward
    sample_results, maybe_sampled_tokens_tensor = _sample(
  File "/workspace/codes/vllm/model_executor/layers/sampler.py", line 711, in _sample
    return _sample_with_torch(
  File "/workspace/codes/vllm/model_executor/layers/sampler.py", line 592, in _sample_with_torch
    sample_results = _greedy_sample(seq_groups, greedy_samples)
  File "/workspace/codes/vllm/model_executor/layers/sampler.py", line 336, in _greedy_sample
    samples_lst = samples.tolist()
RuntimeError: synNodeCreateWithId failed for node: strided_insert with synStatus 1 [Invalid argument]. .
```

This PR suggests to use masked_fill rather than _add for the masking process of guided decode. With this PR, openai endpoint supports guided decoding. For example,

Input:

```
payload = {
        "model": "/models/Meta-Llama-3-8B-Instruct",
        "messages": [
            {"role": "user", "content": "reply negatively."}
        ],
        "best_of": best_of,
        "use_beam_search": use_beam_search,
        "temperature": 0.0,
        "top_p": 1.0,
        "guided_regex": "[Pp]ositive format |[Nn]egative format",
}
```

Output:

```
{'id': 'cmpl-f3e792eb0197492a8d7eec4bb9916936', 'object': 'chat.completion', 'created': 1722847036, 'model': '/models/Meta-Llama-3-8B-Instruct', 'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': 'Negative format'}, 'logprobs': None, 'finish_reason': 'stop', 'stop_reason': None}], 'usage': {'prompt_tokens': 14, 'total_tokens': 21, 'completion_tokens': 7}}
```
