### PR TITLE
optimize qwen2 model on Gaudi

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -49,7 +49,7 @@ from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors, SamplerOutput
 
 from .interfaces import SupportsLoRA
-from vllm.utils import is_hip, is_hpu
+from vllm.utils import is_hpu
 
 
 class Qwen2MLP(nn.Module):

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -47,9 +47,9 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader, maybe_remap_kv_scale_name)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors, SamplerOutput
+from vllm.utils import is_hpu
 
 from .interfaces import SupportsLoRA
-from vllm.utils import is_hpu
 
 
 class Qwen2MLP(nn.Module):


### PR DESCRIPTION
Add extra mark_step() on each decode layer to optimize the performance on Gaudi.

When by default, the performance with below command:
`VLLM_SKIP_WARMUP=true python benchmark_throughput.py --model /local_dataset_2/pytorch/Qwen2-7B-Instruct/ --device hpu --seed 2024 --backend vllm --input-len 1000 --output-len 500 --num-prompts 200 --dtype bfloat16
`
is:
`Throughput: 1.34 requests/s, 2015.75 tokens/s
`

After applying this patch, the performance boosts to:
`Throughput: 2.67 requests/s, 4003.20 tokens/s
`