### PR TITLE
Setting enough cache_size_limit for torch.compile warmup

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1477,7 +1477,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             torch._dynamo.config.accumulated_cache_size_limit = max(
                 cache_size_limit * 8,
                 torch._dynamo.config.accumulated_cache_size_limit)
-        
+
         start_mem = HabanaMemoryProfiler.current_device_memory_usage()
         start_time = time.perf_counter()
 

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -597,7 +597,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 if self._is_valid_bucket(bucket)
             ]
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
-            cache_size_limit = len(self.prompt_buckets)+len(self.decode_buckets)
+            cache_size_limit = len(self.prompt_buckets) + len(self.decode_buckets)
             torch._dynamo.config.cache_size_limit = cache_size_limit
             torch._dynamo.config.accumulated_cache_size_limit = cache_size_limit*8
 

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -596,6 +596,11 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 bucket for bucket in self.decode_buckets
                 if self._is_valid_bucket(bucket)
             ]
+        if not htorch.utils.internal.is_lazy() and not enforce_eager:
+            cache_size_limit = len(self.prompt_buckets)+len(self.decode_buckets)
+            torch._dynamo.config.cache_size_limit = cache_size_limit
+            torch._dynamo.config.accumulated_cache_size_limit = cache_size_limit*8
+            
         msg = (f"Generated {len(self.decode_buckets)} decode buckets: "
                f"{list(sorted(self.decode_buckets))}")
         logger.info(msg)

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -599,7 +599,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
             cache_size_limit = len(self.prompt_buckets) + len(self.decode_buckets)
             torch._dynamo.config.cache_size_limit = cache_size_limit
-            torch._dynamo.config.accumulated_cache_size_limit = cache_size_limit*8
+            torch._dynamo.config.accumulated_cache_size_limit = cache_size_limit * 8
 
         msg = (f"Generated {len(self.decode_buckets)} decode buckets: "
                f"{list(sorted(self.decode_buckets))}")

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1469,8 +1469,10 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
             cache_size_limit = len(self.prompt_buckets) + len(self.decode_buckets)
-            torch._dynamo.config.cache_size_limit = cache_size_limit
-            torch._dynamo.config.accumulated_cache_size_limit = cache_size_limit * 8
+            torch._dynamo.config.cache_size_limit = max(cache_size_limit, 
+                                                        torch._dynamo.config.cache_size_limit)
+            torch._dynamo.config.accumulated_cache_size_limit = max(cache_size_limit * 8, 
+                                                                    torch._dynamo.config.accumulated_cache_size_limit)
         
         start_mem = HabanaMemoryProfiler.current_device_memory_usage()
         start_time = time.perf_counter()

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1469,7 +1469,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
             cache_size_limit = len(self.prompt_buckets) + len(
-                self.decode_buckets)
+                self.decode_buckets) + 1
             torch._dynamo.config.cache_size_limit = max(
                 cache_size_limit, torch._dynamo.config.cache_size_limit)
             # Multiply by 8 to follow the original default ratio between

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1468,13 +1468,15 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                     list(sorted(self.decode_buckets)))
 
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
-            cache_size_limit = len(self.prompt_buckets) + len(self.decode_buckets)
-            torch._dynamo.config.cache_size_limit = max(cache_size_limit, 
-                                                        torch._dynamo.config.cache_size_limit)
+            cache_size_limit = len(self.prompt_buckets) + len(
+                self.decode_buckets)
+            torch._dynamo.config.cache_size_limit = max(
+                cache_size_limit, torch._dynamo.config.cache_size_limit)
             # Multiply by 8 to follow the original default ratio between
             # the cache_size_limit and accumulated_cache_size_limit
-            torch._dynamo.config.accumulated_cache_size_limit = max(cache_size_limit * 8, 
-                                                                    torch._dynamo.config.accumulated_cache_size_limit)
+            torch._dynamo.config.accumulated_cache_size_limit = max(
+                cache_size_limit * 8,
+                torch._dynamo.config.accumulated_cache_size_limit)
         
         start_mem = HabanaMemoryProfiler.current_device_memory_usage()
         start_time = time.perf_counter()

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1471,6 +1471,8 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             cache_size_limit = len(self.prompt_buckets) + len(self.decode_buckets)
             torch._dynamo.config.cache_size_limit = max(cache_size_limit, 
                                                         torch._dynamo.config.cache_size_limit)
+            # Multiply by 8 to follow the original default ratio between
+            # the cache_size_limit and accumulated_cache_size_limit
             torch._dynamo.config.accumulated_cache_size_limit = max(cache_size_limit * 8, 
                                                                     torch._dynamo.config.accumulated_cache_size_limit)
         

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -596,11 +596,11 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 bucket for bucket in self.decode_buckets
                 if self._is_valid_bucket(bucket)
             ]
-        if not htorch.utils.internal.is_lazy() and not enforce_eager:
+        if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
             cache_size_limit = len(self.prompt_buckets)+len(self.decode_buckets)
             torch._dynamo.config.cache_size_limit = cache_size_limit
             torch._dynamo.config.accumulated_cache_size_limit = cache_size_limit*8
-            
+
         msg = (f"Generated {len(self.decode_buckets)} decode buckets: "
                f"{list(sorted(self.decode_buckets))}")
         logger.info(msg)


### PR DESCRIPTION
Fix the issue that warmup sometimes doesn't work because the default cache_size_limit is only 8 .



