### PR TITLE
Cherry pick of delayed sampling

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -796,7 +796,8 @@ class SchedulerConfig:
                  delay_factor: float = 0.0,
                  enable_chunked_prefill: bool = False,
                  embedding_mode: Optional[bool] = False,
-                 preemption_mode: Optional[str] = None) -> None:
+                 preemption_mode: Optional[str] = None,
+                 enable_delayed_sampling: bool = False) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
         else:
@@ -825,6 +826,7 @@ class SchedulerConfig:
         self.chunked_prefill_enabled = enable_chunked_prefill
         self.embedding_mode = embedding_mode
         self.preemption_mode = preemption_mode
+        self.enable_delayed_sampling = enable_delayed_sampling
         self._verify_args()
 
     def _verify_args(self) -> None:
@@ -850,6 +852,15 @@ class SchedulerConfig:
                 f"({self.num_lookahead_slots}) must be greater than or "
                 "equal to 0.")
 
+        if self.enable_delayed_sampling and self.num_lookahead_slots != 1:
+            raise ValueError(
+                "num_lookahead_slots "
+                f"({self.num_lookahead_slots}) must be 1 for delayed sampling.")
+
+        if self.enable_delayed_sampling and not self.use_v2_block_manager:
+            raise ValueError(
+                "use_v2_block_manager "
+                f"({self.use_v2_block_manager}) must be True for delayed sampling.")
 
 class DeviceConfig:
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -855,12 +855,14 @@ class SchedulerConfig:
         if self.enable_delayed_sampling and self.num_lookahead_slots != 1:
             raise ValueError(
                 "num_lookahead_slots "
-                f"({self.num_lookahead_slots}) must be 1 for delayed sampling.")
+                f"({self.num_lookahead_slots}) must be 1 for delayed sampling."
+            )
 
         if self.enable_delayed_sampling and not self.use_v2_block_manager:
-            raise ValueError(
-                "use_v2_block_manager "
-                f"({self.use_v2_block_manager}) must be True for delayed sampling.")
+            raise ValueError("use_v2_block_manager "
+                             f"({self.use_v2_block_manager}) must be True "
+                             "for delayed sampling.")
+
 
 class DeviceConfig:
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -103,6 +103,7 @@ class EngineArgs:
 
     scheduler_delay_factor: float = 0.0
     enable_chunked_prefill: Optional[bool] = None
+    enable_delayed_sampling: bool = False
 
     guided_decoding_backend: str = 'outlines'
     # Speculative decoding configuration.
@@ -527,6 +528,13 @@ class EngineArgs:
             const="True",
             help='If set, the prefill requests can be chunked based on the '
             'max_num_batched_tokens.')
+        parser.add_argument(
+            '--enable-delayed-sampling',
+            action='store_true',
+            help='If set, the sampling will be delayed by 1 step. First '
+            'model request execution (prefill) will return an invalid token '
+            'id that will be discarded. Actual sampling of valid token ids '
+            'starts from second model execution.')
 
         parser.add_argument(
             '--speculative-model',
@@ -824,6 +832,7 @@ class EngineArgs:
             enable_chunked_prefill=self.enable_chunked_prefill,
             embedding_mode=model_config.embedding_mode,
             preemption_mode=self.preemption_mode,
+            enable_delayed_sampling=self.enable_delayed_sampling,
         )
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,

--- a/vllm/engine/output_processor/interfaces.py
+++ b/vllm/engine/output_processor/interfaces.py
@@ -37,7 +37,8 @@ class SequenceGroupOutputProcessor(ABC):
         This returns a single-step output processor if num_lookahead_slots is
         zero, else returns a multi-step output processor.
         """
-        if scheduler_config.num_lookahead_slots == 0:
+        if (scheduler_config.num_lookahead_slots == 0 or (scheduler_config.num_lookahead_slots == 1
+            and scheduler_config.enable_delayed_sampling)):
             # Importing here to avoid cycle.
             from vllm.engine.output_processor.single_step import (
                 SingleStepOutputProcessor)

--- a/vllm/engine/output_processor/interfaces.py
+++ b/vllm/engine/output_processor/interfaces.py
@@ -37,8 +37,9 @@ class SequenceGroupOutputProcessor(ABC):
         This returns a single-step output processor if num_lookahead_slots is
         zero, else returns a multi-step output processor.
         """
-        if (scheduler_config.num_lookahead_slots == 0 or (scheduler_config.num_lookahead_slots == 1
-            and scheduler_config.enable_delayed_sampling)):
+        if (scheduler_config.num_lookahead_slots == 0
+                or (scheduler_config.num_lookahead_slots == 1
+                    and scheduler_config.enable_delayed_sampling)):
             # Importing here to avoid cycle.
             from vllm.engine.output_processor.single_step import (
                 SingleStepOutputProcessor)

--- a/vllm/engine/output_processor/multi_step.py
+++ b/vllm/engine/output_processor/multi_step.py
@@ -85,10 +85,9 @@ class MultiStepOutputProcessor(SequenceGroupOutputProcessor):
         valid_samples = [
             sample for sample in samples if sample.output_token != -1
         ]
-        assert valid_samples
-
-        self._process_seq_outputs(seq, valid_samples,
-                                  sequence_group.sampling_params)
+        if valid_samples:
+            self._process_seq_outputs(seq, valid_samples,
+                                      sequence_group.sampling_params)
 
     def _process_seq_outputs(self, seq: Sequence,
                              valid_samples: List[SequenceOutput],

--- a/vllm/engine/output_processor/single_step.py
+++ b/vllm/engine/output_processor/single_step.py
@@ -122,9 +122,12 @@ class SingleStepOutputProcessor(SequenceGroupOutputProcessor):
             # We reuse the parent sequence here to reduce redundant memory
             # copies, especially when using non-beam search sampling methods.
             last_child_sample = child_samples[-1]
-            parent.append_token_id(last_child_sample.output_token,
-                                   last_child_sample.logprobs)
-            child_seqs.append((parent, parent))
+            # -1 means the output token is not valid (eg. first token if
+            # delayed sampling is enabled).
+            if last_child_sample.output_token != -1:
+                parent.append_token_id(last_child_sample.output_token,
+                                    last_child_sample.logprobs)
+                child_seqs.append((parent, parent))
 
         for seq, _ in child_seqs:
             if seq_group.sampling_params.detokenize and self.detokenizer:

--- a/vllm/engine/output_processor/single_step.py
+++ b/vllm/engine/output_processor/single_step.py
@@ -126,7 +126,7 @@ class SingleStepOutputProcessor(SequenceGroupOutputProcessor):
             # delayed sampling is enabled).
             if last_child_sample.output_token != -1:
                 parent.append_token_id(last_child_sample.output_token,
-                                    last_child_sample.logprobs)
+                                       last_child_sample.logprobs)
                 child_seqs.append((parent, parent))
 
         for seq, _ in child_seqs:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -51,6 +51,7 @@ class Sampler(nn.Module):
         # containing the sampled token ids and probabilities. This is used by
         # speculative decoding.
         self.include_gpu_probs_tensor = False
+        self.sample_token_positions_only = False
 
     def _init_sampling_tensors(
         self,
@@ -142,6 +143,7 @@ class Sampler(nn.Module):
             sampling_tensors,
             include_gpu_probs_tensor=self.include_gpu_probs_tensor,
             modify_greedy_probs=self._should_modify_greedy_probs_inplace,
+            token_positions_only=self.sample_token_positions_only,
         )
 
         if self.include_gpu_probs_tensor:
@@ -320,6 +322,7 @@ def _apply_min_p(
 def _greedy_sample(
     selected_seq_groups: List[SequenceGroupToSample],
     samples: torch.Tensor,
+    token_positions_only: bool = False,
 ) -> SampleResultType:
     """Run greedy sampling on a given samples.
 
@@ -333,7 +336,8 @@ def _greedy_sample(
         same as the length of selected_seq_groups. If the corresponding
         seq_group has do_sample=False, tuple contains ([], [])
     """
-    samples_lst = samples.tolist()
+    if not token_positions_only:
+        samples_lst = samples.tolist()
     sample_idx = 0
     results: SampleResultType = []
     for seq_group in selected_seq_groups:
@@ -346,7 +350,7 @@ def _greedy_sample(
         assert num_parent_seqs == 1, (
             "Greedy sampling should have only one seq.")
         parent_ids = list(range(num_parent_seqs))
-        next_token_ids = [samples_lst[sample_idx]]
+        next_token_ids = [sample_idx if token_positions_only else samples_lst[sample_idx]]
         results.append((next_token_ids, parent_ids))
         sample_idx += num_parent_seqs
     return results
@@ -503,6 +507,7 @@ def _sample_with_torch(
     sampling_metadata: SamplingMetadata,
     include_gpu_probs_tensor: bool,
     modify_greedy_probs: bool,
+    token_positions_only: bool = False,
 ) -> Tuple[SampleResultType, Optional[torch.Tensor]]:
     categorized_seq_group_ids: Dict[SamplingType,
                                     List[int]] = {t: []
@@ -581,7 +586,7 @@ def _sample_with_torch(
         else:
             raise ValueError(f"Unsupported sampling type: {sampling_type}")
 
-    # GPU<->CPU sync happens in the loop below.
+    # GPU<->CPU sync happens in the loop below, unless we're storing only token positions (token_positions_only=True)
     # This also converts the sample output to Python objects.
     if not sampling_metadata.skip_sampler_cpu_output:
         for sampling_type in SamplingType:
@@ -589,7 +594,7 @@ def _sample_with_torch(
                 continue
             (seq_group_id, seq_groups) = sample_metadata[sampling_type]
             if sampling_type == SamplingType.GREEDY:
-                sample_results = _greedy_sample(seq_groups, greedy_samples)
+                sample_results = _greedy_sample(seq_groups, greedy_samples, token_positions_only)
             elif sampling_type in (SamplingType.RANDOM,
                                    SamplingType.RANDOM_SEED):
                 sample_results = _random_sample(
@@ -694,7 +699,7 @@ def _sample_with_triton_kernel(
 def _sample(
     probs: torch.Tensor, logprobs: torch.Tensor,
     sampling_metadata: SamplingMetadata, sampling_tensors: SamplingTensors,
-    include_gpu_probs_tensor: bool, modify_greedy_probs: bool
+    include_gpu_probs_tensor: bool, modify_greedy_probs: bool, token_positions_only: bool
 ) -> Tuple[SampleResultType, Optional[torch.Tensor]]:
     """
     Args:
@@ -714,6 +719,7 @@ def _sample(
         sampling_metadata,
         include_gpu_probs_tensor=include_gpu_probs_tensor,
         modify_greedy_probs=modify_greedy_probs,
+        token_positions_only=token_positions_only,
     )
 
     # TODO: Enable once Triton kernel & associated code is faster.

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -350,7 +350,9 @@ def _greedy_sample(
         assert num_parent_seqs == 1, (
             "Greedy sampling should have only one seq.")
         parent_ids = list(range(num_parent_seqs))
-        next_token_ids = [sample_idx if token_positions_only else samples_lst[sample_idx]]
+        next_token_ids = [
+            sample_idx if token_positions_only else samples_lst[sample_idx]
+        ]
         results.append((next_token_ids, parent_ids))
         sample_idx += num_parent_seqs
     return results
@@ -586,7 +588,8 @@ def _sample_with_torch(
         else:
             raise ValueError(f"Unsupported sampling type: {sampling_type}")
 
-    # GPU<->CPU sync happens in the loop below, unless we're storing only token positions (token_positions_only=True)
+    # GPU<->CPU sync happens in the loop below,
+    # unless we're storing only token positions (token_positions_only=True)
     # This also converts the sample output to Python objects.
     if not sampling_metadata.skip_sampler_cpu_output:
         for sampling_type in SamplingType:
@@ -594,7 +597,8 @@ def _sample_with_torch(
                 continue
             (seq_group_id, seq_groups) = sample_metadata[sampling_type]
             if sampling_type == SamplingType.GREEDY:
-                sample_results = _greedy_sample(seq_groups, greedy_samples, token_positions_only)
+                sample_results = _greedy_sample(seq_groups, greedy_samples,
+                                                token_positions_only)
             elif sampling_type in (SamplingType.RANDOM,
                                    SamplingType.RANDOM_SEED):
                 sample_results = _random_sample(
@@ -699,7 +703,8 @@ def _sample_with_triton_kernel(
 def _sample(
     probs: torch.Tensor, logprobs: torch.Tensor,
     sampling_metadata: SamplingMetadata, sampling_tensors: SamplingTensors,
-    include_gpu_probs_tensor: bool, modify_greedy_probs: bool, token_positions_only: bool
+    include_gpu_probs_tensor: bool, modify_greedy_probs: bool,
+    token_positions_only: bool
 ) -> Tuple[SampleResultType, Optional[torch.Tensor]]:
     """
     Args:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -129,6 +129,8 @@ class SequenceData:
         # The number of tokens that are computed (that run against the model).
         self._num_computed_tokens = 0
         self._stage: SequenceStage = SequenceStage.PREFILL
+        self.prev_logits = None
+        self.prev_logits_idx = None
 
         self._update_cached_all_tokens()
 
@@ -166,7 +168,7 @@ class SequenceData:
     def append_token_id(self, token_id: int, logprob: float) -> None:
         self._output_token_ids.append(token_id)
         self._cached_all_token_ids.append(token_id)
-        self.cumulative_logprob += logprob
+        self.cumulative_logprob += logprob if logprob is not None else 0.0
 
     def get_len(self) -> int:
         return len(self._output_token_ids) + len(self._prompt_token_ids)
@@ -198,8 +200,6 @@ class SequenceData:
     def update_num_computed_tokens(self, num_new_computed_tokens: int):
         """Update number of tokens computed so far."""
         self._num_computed_tokens += num_new_computed_tokens
-        assert self._num_computed_tokens <= self.get_len(), (
-            self._num_computed_tokens, self.get_len())
         # If all tokens are computed, it means it is in decoding phase.
         if self.get_num_uncomputed_tokens() == 0:
             self._stage = SequenceStage.DECODE
@@ -336,9 +336,9 @@ class Sequence:
         token_id: int,
         logprobs: Dict[int, Logprob],
     ) -> None:
-        assert token_id in logprobs
+        # assert token_id in logprobs
         self.output_logprobs.append(logprobs)
-        self.data.append_token_id(token_id, logprobs[token_id].logprob)
+        self.data.append_token_id(token_id, logprobs[token_id].logprob if token_id in logprobs else None)
 
     def get_len(self) -> int:
         return self.data.get_len()

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -165,7 +165,7 @@ class SequenceData:
     def output_token_ids_array(self) -> array:
         return self._output_token_ids
 
-    def append_token_id(self, token_id: int, logprob: float) -> None:
+    def append_token_id(self, token_id: int, logprob: Optional[float]) -> None:
         self._output_token_ids.append(token_id)
         self._cached_all_token_ids.append(token_id)
         self.cumulative_logprob += logprob if logprob is not None else 0.0
@@ -336,9 +336,10 @@ class Sequence:
         token_id: int,
         logprobs: Dict[int, Logprob],
     ) -> None:
-        # assert token_id in logprobs
         self.output_logprobs.append(logprobs)
-        self.data.append_token_id(token_id, logprobs[token_id].logprob if token_id in logprobs else None)
+        self.data.append_token_id(
+            token_id,
+            logprobs[token_id].logprob if token_id in logprobs else None)
 
     def get_len(self) -> int:
         return self.data.get_len()

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -24,6 +24,7 @@ from vllm.attention import AttentionMetadata, get_attn_backend
 from vllm.config import (CacheConfig, DeviceConfig, LoadConfig, LoRAConfig,
                          ModelConfig, MultiModalConfig, ParallelConfig,
                          SchedulerConfig)
+from vllm.distributed import broadcast_tensor_dict
 from vllm.distributed.parallel_state import get_world_group
 from vllm.hpu.ops import LoraMask as LoraMask
 from vllm.logger import init_logger
@@ -1733,8 +1734,9 @@ class HabanaModelRunner(
 
         htorch.core.mark_step()
 
+        input_ids = None
         # Sample the next token based on previous logits if any.
-        if self.scheduler_config.enable_delayed_sampling and not is_prompt:
+        if self.scheduler_config.enable_delayed_sampling and self.is_driver_worker and not is_prompt:
             logits_ids_list = []
             logits_tensor = None
             logits_tensor_list = []
@@ -1778,7 +1780,17 @@ class HabanaModelRunner(
                     sampling_metadata=sampling_metadata,
                 )
 
-            execute_model_kwargs["input_ids"] = output.sampled_token_ids
+            #TODO: check why broadcast failed for float tensor use dict instead
+            model_kwargs = { }
+            model_kwargs["input_ids"] =  output.sampled_token_ids
+            broadcast_tensor_dict(model_kwargs, src=0)
+            input_ids = output.sampled_token_ids
+        elif self.scheduler_config.enable_delayed_sampling and not is_prompt:
+            model_kwargs = broadcast_tensor_dict(src=0)
+            input_ids = model_kwargs["input_ids"]
+
+        if input_ids is not None:
+            execute_model_kwargs["input_ids"] = input_ids
             htorch.core.mark_step()
 
         if self.is_driver_worker:
@@ -1809,7 +1821,7 @@ class HabanaModelRunner(
                 lora_logits_mask.index_select(
                     0, sampling_metadata.selected_token_indices))
 
-        if self.scheduler_config.enable_delayed_sampling:
+        if self.scheduler_config.enable_delayed_sampling and self.is_driver_worker:
             if not is_prompt:
                 htorch.core.mark_step()
                 # Only after dispatching next model.forward() read and update
@@ -1859,7 +1871,8 @@ class HabanaModelRunner(
                                                sampling_metadata)
 
         if (self.scheduler_config.enable_delayed_sampling
-                and model_input.seq_group_metadata_list is not None):
+                and model_input.seq_group_metadata_list is not None
+                and self.is_driver_worker):
             for idx, seq_group_metadata in enumerate(
                     model_input.seq_group_metadata_list):
                 assert len(seq_group_metadata.seq_data) == 1

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1736,7 +1736,8 @@ class HabanaModelRunner(
 
         input_ids = None
         # Sample the next token based on previous logits if any.
-        if self.scheduler_config.enable_delayed_sampling and self.is_driver_worker and not is_prompt:
+        if self.scheduler_config.enable_delayed_sampling \
+                and self.is_driver_worker and not is_prompt:
             logits_ids_list = []
             logits_tensor = None
             logits_tensor_list = []
@@ -1781,8 +1782,8 @@ class HabanaModelRunner(
                 )
 
             #TODO: check why broadcast failed for float tensor use dict instead
-            model_kwargs = { }
-            model_kwargs["input_ids"] =  output.sampled_token_ids
+            model_kwargs = {}
+            model_kwargs["input_ids"] = output.sampled_token_ids
             broadcast_tensor_dict(model_kwargs, src=0)
             input_ids = output.sampled_token_ids
         elif self.scheduler_config.enable_delayed_sampling and not is_prompt:
@@ -1821,16 +1822,17 @@ class HabanaModelRunner(
                 lora_logits_mask.index_select(
                     0, sampling_metadata.selected_token_indices))
 
-        if self.scheduler_config.enable_delayed_sampling and self.is_driver_worker:
+        if self.scheduler_config.enable_delayed_sampling \
+                and self.is_driver_worker:
             if not is_prompt:
                 htorch.core.mark_step()
                 # Only after dispatching next model.forward() read and update
                 # the previous token ids to return
                 sampled_token_ids = output.sampled_token_ids.tolist()
-                for seq_group_output in output.outputs[:real_batch_size]:
+                for i, seq_group_output in enumerate(
+                        output.outputs[:real_batch_size]):
                     for sample in seq_group_output.samples:
-                        sample.output_token = sampled_token_ids[
-                            sample.output_token][0]
+                        sample.output_token = sampled_token_ids[i][0]
                 output = output
             else:
                 # For prompts compose empty output

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1153,20 +1153,21 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         attn_metadata = prefill_attn_metadata if \
             prefill_attn_metadata is not None else decode_attn_metadata
 
-        return self._model_input_cls(input_tokens=input_tokens,
-                                     seq_lens=seq_lens,
-                                     query_lens=query_lens,
-                                     input_positions=input_positions,
-                                     attn_metadata=attn_metadata,
-                                     lora_requests=lora_requests,
-                                     lora_mapping=lora_mapping,
-                                     multi_modal_kwargs=multi_modal_input,
-                                     real_batch_size=real_batch_size,
-                                     batch_size_padded=batch_size_padded,
-                                     lora_mask=lora_mask,
-                                     lora_logits_mask=lora_logits_mask,
-                                     seq_group_metadata_list=seq_group_metadata_list), \
-                                        sampling_metadata
+        return self._model_input_cls(
+            input_tokens=input_tokens,
+            seq_lens=seq_lens,
+            query_lens=query_lens,
+            input_positions=input_positions,
+            attn_metadata=attn_metadata,
+            lora_requests=lora_requests,
+            lora_mapping=lora_mapping,
+            multi_modal_kwargs=multi_modal_input,
+            real_batch_size=real_batch_size,
+            batch_size_padded=batch_size_padded,
+            lora_mask=lora_mask,
+            lora_logits_mask=lora_logits_mask,
+            seq_group_metadata_list=seq_group_metadata_list), \
+            sampling_metadata
 
     def _seq_len(self, attn_metadata):
         if attn_metadata.num_prefills != 0:

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -359,6 +359,7 @@ class ModelInputForHPUWithSamplingMetadata(ModelInputForHPU):
     # Used for speculative decoding. We do not broadcast it because it is only
     # used by the driver worker.
     is_prompt: Optional[bool] = None
+    seq_group_metadata_list: Optional[List[SequenceGroupMetadata]] = None
 
     def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
         tensor_dict = {
@@ -508,6 +509,10 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 self.model = self.model.to("hpu")
                 htcore.mark_step()
             torch.hpu.synchronize()
+
+            if self.scheduler_config.enable_delayed_sampling:
+                self.model.sampler.include_gpu_probs_tensor = True
+                self.model.sampler.sample_token_positions_only = True
 
             # FIXME: Running with disable_tensor_cache=True causes
             # RuntimeErrors. This needs to be debugged
@@ -850,7 +855,8 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 generation_token = seq_data.get_last_token_id()
                 input_tokens.append([generation_token])
 
-                seq_len = seq_data.get_len()
+                seq_len = ((seq_data.get_num_computed_tokens() + 1)
+                           if self.scheduler_config.enable_delayed_sampling else seq_data.get_len())
                 position = seq_len - 1
                 input_positions.append([position])
 
@@ -1054,7 +1060,8 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             "num_prefills": num_prefills,
             "batch_type": batch_type,
             "seq_lens": seq_lens,
-            "query_lens": query_lens
+            "query_lens": query_lens,
+            "seq_group_metadata_list": seq_group_metadata_list,
         }
         if prefill_attn_metadata is not None:
             metadata_dict.update(prefill_attn_metadata.asdict_zerocopy())
@@ -1075,7 +1082,8 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             lora_mapping=lora_mapping,
             multi_modal_kwargs=multi_modal_input,
             real_batch_size=real_batch_size,
-            batch_size_padded=batch_size_padded), sampling_metadata
+            batch_size_padded=batch_size_padded,
+            seq_group_metadata_list=seq_group_metadata_list), sampling_metadata
 
     def _seq_len(self, attn_metadata):
         if attn_metadata.num_prefills != 0:
@@ -1621,6 +1629,43 @@ class HabanaModelRunner(
             })
 
         htorch.core.mark_step()
+
+        # Sample the next token based on previous logits if any.
+        if self.scheduler_config.enable_delayed_sampling and not is_prompt:
+            logits_ids_list = []
+            logits_tensor = None
+            logits_tensor_list = []
+            for seq_group_metadata in model_input.seq_group_metadata_list:
+                assert len(seq_group_metadata.seq_data) == 1
+                for seq_data in seq_group_metadata.seq_data.values():
+                    if seq_data.prev_logits is not None:
+                        if logits_tensor is None:
+                            logits_tensor = seq_data.prev_logits
+                        if seq_data.prev_logits is logits_tensor:
+                            # accumulate row ids from the same tensor
+                            logits_ids_list.append(seq_data.prev_logits_idx)
+                        else:
+                            # new logits tensor, gather all previously collected rows
+                            logits_tensor_list.append(logits_tensor[torch.tensor(logits_ids_list, device=seq_data.prev_logits.device)])
+                            logits_ids_list = [seq_data.prev_logits_idx]
+                            logits_tensor = seq_data.prev_logits
+                    else:
+                        # warmup only, TODO add a check
+                        logits_tensor_list.append(torch.zeros([1, 32000], dtype=torch.float, device="hpu"))
+            if logits_tensor is not None:
+                logits_tensor_list.append(logits_tensor[torch.tensor(logits_ids_list, device=seq_data.prev_logits.device)])
+
+            prev_logits = torch.cat(logits_tensor_list, dim=0)
+
+            with self.profiler.record_event('internal', f'sample_{"prompt" if is_prompt else "decode"}_bs{batch_size}_seq{seq_len}'):
+                output = self.model.sample(
+                    logits=prev_logits,
+                    sampling_metadata=sampling_metadata,
+                )
+
+            execute_model_kwargs["input_ids"] = output.sampled_token_ids
+            htorch.core.mark_step()
+
         if self.is_driver_worker:
             model_event_name = ("model_"
                                 f"{'prompt' if is_prompt else 'decode'}_"
@@ -1645,6 +1690,39 @@ class HabanaModelRunner(
                             i] = sampling_metadata.selected_token_indices.numel(
                             )
 
+        if self.scheduler_config.enable_delayed_sampling:
+            if not is_prompt:
+                htorch.core.mark_step()
+                # Only after dispatching next model.forward() read and update the previous token ids to return
+                sampled_token_ids = output.sampled_token_ids.tolist()
+                for seq_group_output in output.outputs[:real_batch_size]:
+                    for sample in seq_group_output.samples:
+                        sample.output_token = sampled_token_ids[sample.output_token][0]
+                output = output
+            else:
+                # For prompts compose empty output
+                from vllm.sequence import (Logprob, SamplerOutput, CompletionSequenceGroupOutput, SequenceOutput)
+                sampler_output = []
+                for seq_group in sampling_metadata.seq_groups:
+                    seq_ids = seq_group.seq_ids
+                    next_token_id, parent_id = -1, 0
+                    seq_outputs = []
+                    seq_outputs.append(
+                        SequenceOutput(seq_ids[parent_id], next_token_id, {-1: Logprob(0.0)}))
+                    sampler_output.append(
+                        CompletionSequenceGroupOutput(seq_outputs, None))
+
+                sampled_token_probs, logprobs_tensor, sampled_token_ids = (None, None, None)
+                output = SamplerOutput(
+                    outputs=sampler_output,
+                    sampled_token_probs=sampled_token_probs,
+                    sampled_token_ids=sampled_token_ids,
+                    logprobs=logprobs_tensor,
+                )
+
+            output.outputs = output.outputs[:real_batch_size]
+            htorch.core.mark_step()
+
         # Compute the logits.
         with self.profiler.record_event(
                 'internal', ('compute_logits_'
@@ -1654,22 +1732,31 @@ class HabanaModelRunner(
             sampling_metadata.selected_token_indices = None
             logits = self.model.compute_logits(hidden_states,
                                                sampling_metadata)
+
+        if self.scheduler_config.enable_delayed_sampling:
+            for idx, seq_group_metadata in enumerate(model_input.seq_group_metadata_list):
+                assert len(seq_group_metadata.seq_data) == 1
+                for seq_data in seq_group_metadata.seq_data.values():
+                    seq_data.prev_logits = logits
+                    seq_data.prev_logits_idx = idx
+
         htorch.core.mark_step()
         # Only perform sampling in the driver worker.
         if not self.is_driver_worker:
             return []
 
         # Sample the next token.
-        with self.profiler.record_event(
-                'internal', ('sample_'
-                             f'{"prompt" if is_prompt else "decode"}_'
-                             f'bs{batch_size}_'
-                             f'seq{seq_len}')):
-            output = self.model.sample(
-                logits=logits,
-                sampling_metadata=sampling_metadata,
-            )
-        output.outputs = output.outputs[:real_batch_size]
+        if not self.scheduler_config.enable_delayed_sampling:
+            with self.profiler.record_event(
+                    'internal', ('sample_'
+                                f'{"prompt" if is_prompt else "decode"}_'
+                                f'bs{batch_size}_'
+                                f'seq{seq_len}')):
+                output = self.model.sample(
+                    logits=logits,
+                    sampling_metadata=sampling_metadata,
+                )
+            output.outputs = output.outputs[:real_batch_size]
         htorch.core.mark_step()
 
         if self.is_driver_worker and self.profiler.enabled:


### PR DESCRIPTION
Cherry pick of delayed sampling from habana_next. To use it, pass additional flags to vllm server:
--num-lookahead-slots 1 --use-v2-block-manager --enable-delayed-sampling

Tested on 1 Gaudi2 card on llama2 7b on a 4k offline accuracy test. Accuracy is good (>100%), observed perf improvement is ~38%.