### PR TITLE
Mask based BGMV implementation for LoRA Embedding 

### DIFF
--- a/tests/lora/test_multilora_hpu.py
+++ b/tests/lora/test_multilora_hpu.py
@@ -96,7 +96,7 @@ def _test_llama_multilora(sql_lora_files, tp_size):
                              enable_lora=True,
                              max_loras=2,
                              max_lora_rank=8,
-                             max_num_seqs=16,
+                             max_num_seqs=256,
                              dtype='float32',
                              tensor_parallel_size=tp_size)
     engine = LLMEngine.from_engine_args(engine_args)

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -24,7 +24,7 @@ from vllm.lora.lora import LoRALayerWeights, PackedLoRALayerWeights
 from vllm.lora.utils import (from_layer, from_layer_logits_processor,
                              parse_fine_tuned_lora_name, replace_submodule)
 from vllm.model_executor.models.interfaces import SupportsLoRA
-from vllm.utils import get_device, is_hpu, is_pin_memory_available
+from vllm.utils import get_device, is_pin_memory_available
 
 logger = init_logger(__name__)
 
@@ -465,25 +465,11 @@ class LoRAModelManager(AdapterModelManager):
 
     @property
     def capacity(self) -> int:
-        if is_hpu():
-            # HPU handles no LoRA requests using zero valued A and B tensors.
-            # These zero valued tensors are appended at the end of A and B,
-            # making total number of loras to be lora_config.max_cpu_loras + 1.
-            # This demands the total number of max_cpu_loras to be
-            # lora_config.max_cpu_loras + 1
-            return self.lora_config.max_cpu_loras + 1
-        else:
-            return self.lora_config.max_cpu_loras
+        return self.lora_config.max_cpu_loras
 
     @property
     def lora_slots(self) -> int:
-        if is_hpu():
-            # HPU handles no LoRA requests using zero valued A and B tensors.
-            # These zero valued tensors are appended at the end of A and B,
-            # making total number of loras to be lora_config.max_cpu_loras + 1.
-            return self.lora_config.max_loras + 1
-        else:
-            return self.lora_config.max_loras
+        return self.lora_config.max_loras
 
     @property
     def adapter_slots(self) -> int:

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -752,11 +752,11 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if self.lora_config:
             lora_mask = torch.zeros(len(seq_group_metadata_list) *
                                     max_prompt_len,
-                                    (self.lora_config.max_loras + 1) *
+                                    (self.lora_config.max_loras) *
                                     self.lora_config.max_lora_rank,
                                     dtype=self.lora_config.lora_dtype)
             lora_logits_mask = torch.zeros(len(seq_group_metadata_list),
-                                           (self.lora_config.max_loras + 1) *
+                                           (self.lora_config.max_loras) *
                                            self.lora_config.max_lora_rank,
                                            dtype=self.lora_config.lora_dtype)
 
@@ -880,7 +880,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         if self.lora_config:
             lora_mask = torch.zeros(len(seq_group_metadata_list),
-                                    (self.lora_config.max_loras + 1) *
+                                    (self.lora_config.max_loras) *
                                     self.lora_config.max_lora_rank,
                                     dtype=self.lora_config.lora_dtype)
             ones = torch.ones(1,

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -750,11 +750,10 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         lora_logits_mask: torch.Tensor = None
         counter = 0
         if self.lora_config:
-            lora_mask = torch.zeros(len(seq_group_metadata_list) *
-                                    max_prompt_len,
-                                    (self.lora_config.max_loras) *
-                                    self.lora_config.max_lora_rank,
-                                    dtype=self.lora_config.lora_dtype)
+            lora_mask = torch.zeros(
+                len(seq_group_metadata_list) * max_prompt_len,
+                (self.lora_config.max_loras) * self.lora_config.max_lora_rank,
+                dtype=self.lora_config.lora_dtype)
             lora_logits_mask = torch.zeros(len(seq_group_metadata_list),
                                            (self.lora_config.max_loras) *
                                            self.lora_config.max_lora_rank,


### PR DESCRIPTION
This PR contains mask based BGMV implementation for LoRA embedding instead of index-select of LoRA-B weights.

Also removes special handling in no LoRA case.