### PR TITLE
Cherry pick of delayed sampling

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -796,7 +796,8 @@ class SchedulerConfig:
                  delay_factor: float = 0.0,
                  enable_chunked_prefill: bool = False,
                  embedding_mode: Optional[bool] = False,
-                 preemption_mode: Optional[str] = None) -> None:
+                 preemption_mode: Optional[str] = None,
+                 enable_delayed_sampling: bool = False) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
         else:
@@ -825,6 +826,7 @@ class SchedulerConfig:
         self.chunked_prefill_enabled = enable_chunked_prefill
         self.embedding_mode = embedding_mode
         self.preemption_mode = preemption_mode
+        self.enable_delayed_sampling = enable_delayed_sampling
         self._verify_args()
 
     def _verify_args(self) -> None:
@@ -849,6 +851,17 @@ class SchedulerConfig:
                 "num_lookahead_slots "
                 f"({self.num_lookahead_slots}) must be greater than or "
                 "equal to 0.")
+
+        if self.enable_delayed_sampling and self.num_lookahead_slots != 1:
+            raise ValueError(
+                "num_lookahead_slots "
+                f"({self.num_lookahead_slots}) must be 1 for delayed sampling."
+            )
+
+        if self.enable_delayed_sampling and not self.use_v2_block_manager:
+            raise ValueError("use_v2_block_manager "
+                             f"({self.use_v2_block_manager}) must be True "
+                             "for delayed sampling.")
 
 
 class DeviceConfig:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -103,6 +103,7 @@ class EngineArgs:
 
     scheduler_delay_factor: float = 0.0
     enable_chunked_prefill: Optional[bool] = None
+    enable_delayed_sampling: bool = False
 
     guided_decoding_backend: str = 'outlines'
     # Speculative decoding configuration.
@@ -527,6 +528,13 @@ class EngineArgs:
             const="True",
             help='If set, the prefill requests can be chunked based on the '
             'max_num_batched_tokens.')
+        parser.add_argument(
+            '--enable-delayed-sampling',
+            action='store_true',
+            help='If set, the sampling will be delayed by 1 step. First '
+            'model request execution (prefill) will return an invalid token '
+            'id that will be discarded. Actual sampling of valid token ids '
+            'starts from second model execution.')
 
         parser.add_argument(
             '--speculative-model',
@@ -824,6 +832,7 @@ class EngineArgs:
             enable_chunked_prefill=self.enable_chunked_prefill,
             embedding_mode=model_config.embedding_mode,
             preemption_mode=self.preemption_mode,
+            enable_delayed_sampling=self.enable_delayed_sampling,
         )
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,

--- a/vllm/engine/output_processor/interfaces.py
+++ b/vllm/engine/output_processor/interfaces.py
@@ -37,7 +37,9 @@ class SequenceGroupOutputProcessor(ABC):
         This returns a single-step output processor if num_lookahead_slots is
         zero, else returns a multi-step output processor.
         """
-        if scheduler_config.num_lookahead_slots == 0:
+        if (scheduler_config.num_lookahead_slots == 0
+                or (scheduler_config.num_lookahead_slots == 1
+                    and scheduler_config.enable_delayed_sampling)):
             # Importing here to avoid cycle.
             from vllm.engine.output_processor.single_step import (
                 SingleStepOutputProcessor)

--- a/vllm/engine/output_processor/multi_step.py
+++ b/vllm/engine/output_processor/multi_step.py
@@ -85,10 +85,9 @@ class MultiStepOutputProcessor(SequenceGroupOutputProcessor):
         valid_samples = [
             sample for sample in samples if sample.output_token != -1
         ]
-        assert valid_samples
-
-        self._process_seq_outputs(seq, valid_samples,
-                                  sequence_group.sampling_params)
+        if valid_samples:
+            self._process_seq_outputs(seq, valid_samples,
+                                      sequence_group.sampling_params)
 
     def _process_seq_outputs(self, seq: Sequence,
                              valid_samples: List[SequenceOutput],

--- a/vllm/engine/output_processor/single_step.py
+++ b/vllm/engine/output_processor/single_step.py
@@ -122,9 +122,12 @@ class SingleStepOutputProcessor(SequenceGroupOutputProcessor):
             # We reuse the parent sequence here to reduce redundant memory
             # copies, especially when using non-beam search sampling methods.
             last_child_sample = child_samples[-1]
-            parent.append_token_id(last_child_sample.output_token,
-                                   last_child_sample.logprobs)
-            child_seqs.append((parent, parent))
+            # -1 means the output token is not valid (eg. first token if
+            # delayed sampling is enabled).
+            if last_child_sample.output_token != -1:
+                parent.append_token_id(last_child_sample.output_token,
+                                       last_child_sample.logprobs)
+                child_seqs.append((parent, parent))
 
         for seq, _ in child_seqs:
             if seq_group.sampling_params.detokenize and self.detokenizer:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -129,6 +129,8 @@ class SequenceData:
         # The number of tokens that are computed (that run against the model).
         self._num_computed_tokens = 0
         self._stage: SequenceStage = SequenceStage.PREFILL
+        self.prev_logits = None
+        self.prev_logits_idx = None
 
         self._update_cached_all_tokens()
 
@@ -163,10 +165,10 @@ class SequenceData:
     def output_token_ids_array(self) -> array:
         return self._output_token_ids
 
-    def append_token_id(self, token_id: int, logprob: float) -> None:
+    def append_token_id(self, token_id: int, logprob: Optional[float]) -> None:
         self._output_token_ids.append(token_id)
         self._cached_all_token_ids.append(token_id)
-        self.cumulative_logprob += logprob
+        self.cumulative_logprob += logprob if logprob is not None else 0.0
 
     def get_len(self) -> int:
         return len(self._output_token_ids) + len(self._prompt_token_ids)
@@ -198,8 +200,6 @@ class SequenceData:
     def update_num_computed_tokens(self, num_new_computed_tokens: int):
         """Update number of tokens computed so far."""
         self._num_computed_tokens += num_new_computed_tokens
-        assert self._num_computed_tokens <= self.get_len(), (
-            self._num_computed_tokens, self.get_len())
         # If all tokens are computed, it means it is in decoding phase.
         if self.get_num_uncomputed_tokens() == 0:
             self._stage = SequenceStage.DECODE
@@ -336,9 +336,10 @@ class Sequence:
         token_id: int,
         logprobs: Dict[int, Logprob],
     ) -> None:
-        assert token_id in logprobs
         self.output_logprobs.append(logprobs)
-        self.data.append_token_id(token_id, logprobs[token_id].logprob)
+        self.data.append_token_id(
+            token_id,
+            logprobs[token_id].logprob if token_id in logprobs else None)
 
     def get_len(self) -> int:
         return self.data.get_len()

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -407,6 +407,7 @@ class ModelInputForHPU(ModelRunnerInputBase):
     virtual_engine: int = 0
     lora_mask: Optional[torch.Tensor] = None
     lora_logits_mask: Optional[torch.Tensor] = None
+    seq_group_metadata_list: Optional[List[SequenceGroupMetadata]] = None
 
     def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
         tensor_dict = {
@@ -617,6 +618,12 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 htcore.mark_step()
             torch.hpu.synchronize()
 
+            if self.scheduler_config.enable_delayed_sampling:
+                self.model.sampler.include_gpu_probs_tensor = True
+                self.model.sampler.sample_token_positions_only = True
+
+            # FIXME: Running with disable_tensor_cache=True causes
+            # RuntimeErrors. This needs to be debugged
             with HabanaMemoryProfiler() as m_wrap:
                 self.model = _maybe_wrap_in_hpu_graph(
                     self.model,
@@ -951,7 +958,9 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 generation_token = seq_data.get_last_token_id()
                 input_tokens.append([generation_token])
 
-                seq_len = seq_data.get_len()
+                seq_len = ((seq_data.get_num_computed_tokens() +
+                            1) if self.scheduler_config.enable_delayed_sampling
+                           else seq_data.get_len())
                 position = seq_len - 1
                 input_positions.append([position])
 
@@ -1188,7 +1197,8 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             "num_prefills": num_prefills,
             "batch_type": batch_type,
             "seq_lens": seq_lens,
-            "query_lens": query_lens
+            "query_lens": query_lens,
+            "seq_group_metadata_list": seq_group_metadata_list,
         }
         if prefill_attn_metadata is not None:
             metadata_dict.update(prefill_attn_metadata.asdict_zerocopy())
@@ -1199,19 +1209,21 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         attn_metadata = prefill_attn_metadata if \
             prefill_attn_metadata is not None else decode_attn_metadata
 
-        return self._model_input_cls(input_tokens=input_tokens,
-                                     seq_lens=seq_lens,
-                                     query_lens=query_lens,
-                                     input_positions=input_positions,
-                                     attn_metadata=attn_metadata,
-                                     lora_requests=lora_requests,
-                                     lora_mapping=lora_mapping,
-                                     multi_modal_kwargs=multi_modal_input,
-                                     real_batch_size=real_batch_size,
-                                     batch_size_padded=batch_size_padded,
-                                     lora_mask=lora_mask,
-                                     lora_logits_mask=lora_logits_mask), \
-                                        sampling_metadata
+        return self._model_input_cls(
+            input_tokens=input_tokens,
+            seq_lens=seq_lens,
+            query_lens=query_lens,
+            input_positions=input_positions,
+            attn_metadata=attn_metadata,
+            lora_requests=lora_requests,
+            lora_mapping=lora_mapping,
+            multi_modal_kwargs=multi_modal_input,
+            real_batch_size=real_batch_size,
+            batch_size_padded=batch_size_padded,
+            lora_mask=lora_mask,
+            lora_logits_mask=lora_logits_mask,
+            seq_group_metadata_list=seq_group_metadata_list), \
+            sampling_metadata
 
     def _seq_len(self, attn_metadata):
         if attn_metadata.num_prefills != 0:
@@ -1842,6 +1854,55 @@ class HabanaModelRunner(
             execute_model_kwargs.update({"bypass_hpu_graphs": not use_graphs})
 
         htorch.core.mark_step()
+
+        # Sample the next token based on previous logits if any.
+        if self.scheduler_config.enable_delayed_sampling and not is_prompt:
+            logits_ids_list = []
+            logits_tensor = None
+            logits_tensor_list = []
+            if model_input.seq_group_metadata_list is not None:
+                for seq_group_metadata in model_input.seq_group_metadata_list:
+                    assert len(seq_group_metadata.seq_data) == 1
+                    for seq_data in seq_group_metadata.seq_data.values():
+                        if seq_data.prev_logits is not None:
+                            if logits_tensor is None:
+                                logits_tensor = seq_data.prev_logits
+                            if seq_data.prev_logits is logits_tensor:
+                                # accumulate row ids from the same tensor
+                                logits_ids_list.append(
+                                    seq_data.prev_logits_idx)
+                            else:
+                                # new logits tensor,
+                                # gather all previously collected rows
+                                logits_tensor_list.append(
+                                    logits_tensor[torch.tensor(
+                                        logits_ids_list,
+                                        device=seq_data.prev_logits.device)])
+                                logits_ids_list = [seq_data.prev_logits_idx]
+                                logits_tensor = seq_data.prev_logits
+                        else:
+                            # warmup only, TODO add a check
+                            logits_tensor_list.append(
+                                torch.zeros([1, 32000],
+                                            dtype=torch.float,
+                                            device="hpu"))
+            if logits_tensor is not None:
+                logits_tensor_list.append(logits_tensor[torch.tensor(
+                    logits_ids_list, device=seq_data.prev_logits.device)])
+
+            prev_logits = torch.cat(logits_tensor_list, dim=0)
+
+            with self.profiler.record_event(
+                    'internal', f'sample_{"prompt" if is_prompt else "decode"}'
+                    '_bs{batch_size}_seq{seq_len}'):
+                output = self.model.sample(
+                    logits=prev_logits,
+                    sampling_metadata=sampling_metadata,
+                )
+
+            execute_model_kwargs["input_ids"] = output.sampled_token_ids
+            htorch.core.mark_step()
+
         if self.is_driver_worker:
             model_event_name = ("model_"
                                 f"{'prompt' if is_prompt else 'decode'}_"
@@ -1870,6 +1931,45 @@ class HabanaModelRunner(
                 lora_logits_mask.index_select(
                     0, sampling_metadata.selected_token_indices))
 
+        if self.scheduler_config.enable_delayed_sampling:
+            if not is_prompt:
+                htorch.core.mark_step()
+                # Only after dispatching next model.forward() read and update
+                # the previous token ids to return
+                sampled_token_ids = output.sampled_token_ids.tolist()
+                for seq_group_output in output.outputs[:real_batch_size]:
+                    for sample in seq_group_output.samples:
+                        sample.output_token = sampled_token_ids[
+                            sample.output_token][0]
+                output = output
+            else:
+                # For prompts compose empty output
+                from vllm.sequence import (CompletionSequenceGroupOutput,
+                                           Logprob, SamplerOutput,
+                                           SequenceOutput)
+                sampler_output = []
+                for seq_group in sampling_metadata.seq_groups:
+                    seq_ids = seq_group.seq_ids
+                    next_token_id, parent_id = -1, 0
+                    seq_outputs = []
+                    seq_outputs.append(
+                        SequenceOutput(seq_ids[parent_id], next_token_id,
+                                       {-1: Logprob(0.0)}))
+                    sampler_output.append(
+                        CompletionSequenceGroupOutput(seq_outputs, None))
+
+                sampled_token_probs, logprobs_tensor, sampled_token_ids = (
+                    None, None, None)
+                output = SamplerOutput(
+                    outputs=sampler_output,
+                    sampled_token_probs=sampled_token_probs,
+                    sampled_token_ids=sampled_token_ids,
+                    logprobs=logprobs_tensor,
+                )
+
+            output.outputs = output.outputs[:real_batch_size]
+            htorch.core.mark_step()
+
         # Compute the logits.
         with self.profiler.record_event(
                 'internal', ('compute_logits_'
@@ -1879,22 +1979,33 @@ class HabanaModelRunner(
             sampling_metadata.selected_token_indices = None
             logits = self.model.compute_logits(hidden_states,
                                                sampling_metadata)
+
+        if (self.scheduler_config.enable_delayed_sampling
+                and model_input.seq_group_metadata_list is not None):
+            for idx, seq_group_metadata in enumerate(
+                    model_input.seq_group_metadata_list):
+                assert len(seq_group_metadata.seq_data) == 1
+                for seq_data in seq_group_metadata.seq_data.values():
+                    seq_data.prev_logits = logits
+                    seq_data.prev_logits_idx = idx
+
         htorch.core.mark_step()
         # Only perform sampling in the driver worker.
         if not self.is_driver_worker:
             return []
 
         # Sample the next token.
-        with self.profiler.record_event(
-                'internal', ('sample_'
-                             f'{"prompt" if is_prompt else "decode"}_'
-                             f'bs{batch_size}_'
-                             f'seq{seq_len}')):
-            output = self.model.sample(
-                logits=logits,
-                sampling_metadata=sampling_metadata,
-            )
-        output.outputs = output.outputs[:real_batch_size]
+        if not self.scheduler_config.enable_delayed_sampling:
+            with self.profiler.record_event(
+                    'internal', ('sample_'
+                                 f'{"prompt" if is_prompt else "decode"}_'
+                                 f'bs{batch_size}_'
+                                 f'seq{seq_len}')):
+                output = self.model.sample(
+                    logits=logits,
+                    sampling_metadata=sampling_metadata,
+                )
+            output.outputs = output.outputs[:real_batch_size]
         htorch.core.mark_step()
 
         if self.is_driver_worker and self.profiler.enabled:


### PR DESCRIPTION
Cherry pick of delayed sampling from habana_next. To use it, pass additional flags to vllm server:
--num-lookahead-slots 1 --use-v2-block-manager --enable-delayed-sampling

Tested on 1 Gaudi2 card on llama2 7b on a 4k offline accuracy test. Accuracy is good (>100%), observed perf improvement is ~38%.