### PR TITLE
Fix minor logging issue in habana_model_runner.py

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -92,7 +92,7 @@ def read_bucket_settings(phase: str, dim: str, **defaults):
     values = [
         int(os.environ.get(e, d)) for e, d in zip(env_vars, default_values)
     ]
-    for e, v, d in zip(env_vars, values, defaults):
+    for e, v, d in zip(env_vars, values, default_values):
         logger.info('%s=%s (default:%s)', e, v, d)
     return values
 


### PR DESCRIPTION
The original code doesn't print the default value correctly

INFO 09-17 00:06:07 habana_model_runner.py:95] VLLM_PROMPT_BS_BUCKET_MIN=1 (default:_**min**_)
INFO 09-17 00:06:07 habana_model_runner.py:95] VLLM_PROMPT_BS_BUCKET_STEP=1 (default:_**step**_)
INFO 09-17 00:06:07 habana_model_runner.py:95] VLLM_PROMPT_BS_BUCKET_MAX=1 (default:_**max**_)

This change make it print the correct default value
INFO 09-17 21:30:51 habana_model_runner.py:95] VLLM_PROMPT_BS_BUCKET_MIN=1 (default:_**1**_)
INFO 09-17 21:30:51 habana_model_runner.py:95] VLLM_PROMPT_BS_BUCKET_STEP=4 (default:_**32**_)
INFO 09-17 21:30:51 habana_model_runner.py:95] VLLM_PROMPT_BS_BUCKET_MAX=4 (default:_**64**_)
