### PR TITLE
Eliminate graph break in torch.compile mode

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -230,8 +230,9 @@ def hpu_backend_string():
 
 @lru_cache(maxsize=None)
 def _is_habana_frameworks_installed() -> bool:
-    from importlib import util
-    return util.find_spec('habana_frameworks') is not None
+    if hasattr(torch, "hpu"):
+        return torch.hpu.is_available()
+    return False
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
This change eliminates the graph break due to **is_hpu** function (vllm/utils.py) with torch.compile mode.