### PR TITLE
fix bug: device_str in initialize_ray_cluster requires uppercase string

### DIFF
--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -98,7 +98,7 @@ def initialize_ray_cluster(
     if is_tpu():
         device_str = "TPU"
     elif is_hpu():
-        device_str = hpu_device_string()
+        device_str = hpu_device_string().upper()
     # Create placement group for worker processes
     current_placement_group = ray.util.get_current_placement_group()
     if current_placement_group:

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -488,8 +488,6 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     Helper class for shared methods between GPU model runners.
     """
     _model_input_cls: Type[TModelInputForHPU]
-    dummy_prompt_list: List[SequenceGroupMetadata]
-    dummy_decode_list: List[SequenceGroupMetadata]
 
     def __init__(
         self,
@@ -1089,16 +1087,9 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         batch_size_padded = find_bucket(real_batch_size, bucket_cfg)
         batch_size_padding = batch_size_padded - real_batch_size
         seq_group_metadata_list = seq_group_metadata_list.copy()
-        
-        if is_prompt:
-            seq_group_metadata_list.extend(
-                self.dummy_prompt_list
-                for _ in range(batch_size_padding))
-        else:
-            seq_group_metadata_list.extend(
-                self.dummy_decode_list
-                for _ in range(batch_size_padding))
-
+        seq_group_metadata_list.extend(
+            self.create_dummy_seq_group_metadata(0, 0, is_prompt)
+            for _ in range(batch_size_padding))
 
         prefill_reqs = []
         decode_reqs = []
@@ -1301,9 +1292,6 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                           self.max_num_batched_tokens // max_batch_size)
 
         self.warmup_scenario(max_batch_size, max_seq_len, True, kv_caches)
-        self.dummy_prompt_list = self.create_dummy_seq_group_metadata(0, 0, 1)
-        self.dummy_decode_list = self.create_dummy_seq_group_metadata(0, 0, 0)
-
         return
 
     def warmup_scenario(self,


### PR DESCRIPTION
fix bug: device_str in initialize_ray_cluster requires uppercase string

w/o the bug fix, multi HPUs will encounter "ValueError: The number of required hpus exceeds the total number of available hpus in the placement group" error, as the device_str is not expected as uppercase, then available hpus always returns 0.