### PR TITLE
Fix seq_len for padding sequences

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -1268,6 +1268,7 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                         lora_request=None):
         sampling_params = SamplingParams(temperature=0)
         num_blocks = math.ceil(seq_len / self.block_size)
+        seq_len = max(seq_len, 1)
         if is_prompt:
             input_len = seq_len
             output_len = 0


### PR DESCRIPTION
Before the fix we used seq_len=0 for padding samples. This was later translated to an empty attention_mask (since we don't have any tokens that we should include in calculations) and in turn caused NaNs in prompt attention (0 divided by 0). Those NaNs later got propagated to kv-cache causing issues in flat_pa.