### PR TITLE
Remove logger from layernorm

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -4,10 +4,7 @@ from typing import Optional, Tuple, Union
 import torch
 import torch.nn as nn
 
-from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
-
-logger = init_logger(__name__)
 
 
 class RMSNorm(CustomOp):


### PR DESCRIPTION
Upstream does not use logger in layernorm. Neither do we. No idea why it's there.