### PR TITLE
Make weights_load_device not change EngineArgs.create_load_config()

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -751,7 +751,8 @@ class LoadConfig:
         ignore_patterns: The list of patterns to ignore when loading the model.
             Default to "original/**/*" to avoid repeated loading of llama's 
             checkpoints.
-        device: Device on which weights are loaded.
+        device: Device to which model weights will be loaded, default to
+            device_config.device
     """
 
     load_format: Union[str, LoadFormat, "BaseModelLoader"] = LoadFormat.AUTO

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -844,11 +844,13 @@ class EngineArgs:
             mm_processor_kwargs=self.mm_processor_kwargs,
         )
 
-    def create_load_config(self) -> LoadConfig:
+    def create_load_config(self, load_device=None) -> LoadConfig:
+        if load_device is None:
+            load_device = DeviceConfig(device=self.device).device
         return LoadConfig(
             load_format=self.load_format,
             download_dir=self.download_dir,
-            device=self.load_device,
+            device=load_device,
             model_loader_extra_config=self.model_loader_extra_config,
             ignore_patterns=self.ignore_patterns,
         )
@@ -1032,9 +1034,9 @@ class EngineArgs:
             self.model_loader_extra_config[
                 "qlora_adapter_name_or_path"] = self.qlora_adapter_name_or_path
 
-        self.load_device = device_config.device if self.weights_load_device is \
+        load_device = device_config.device if self.weights_load_device is \
             None else self.weights_load_device
-        load_config = self.create_load_config()
+        load_config = self.create_load_config(load_device)
 
         prompt_adapter_config = PromptAdapterConfig(
             max_prompt_adapters=self.max_prompt_adapters,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -268,8 +268,9 @@ class EngineArgs:
         parser.add_argument("--weights-load-device",
                             type=str,
                             default=EngineArgs.weights_load_device,
-                            choices=["cuda", "neuron", "hpu", "cpu"],
-                            help='Device on which weights are loaded.')
+                            choices=DEVICE_OPTIONS,
+                            help=('Device to which model weights '
+                                  'will be loaded.'))
         parser.add_argument(
             '--config-format',
             default=EngineArgs.config_format,
@@ -843,11 +844,11 @@ class EngineArgs:
             mm_processor_kwargs=self.mm_processor_kwargs,
         )
 
-    def create_load_config(self, load_device) -> LoadConfig:
+    def create_load_config(self) -> LoadConfig:
         return LoadConfig(
             load_format=self.load_format,
             download_dir=self.download_dir,
-            device=load_device,
+            device=self.load_device,
             model_loader_extra_config=self.model_loader_extra_config,
             ignore_patterns=self.ignore_patterns,
         )
@@ -1031,9 +1032,9 @@ class EngineArgs:
             self.model_loader_extra_config[
                 "qlora_adapter_name_or_path"] = self.qlora_adapter_name_or_path
 
-        load_device = device_config.device if self.weights_load_device is \
+        self.load_device = device_config.device if self.weights_load_device is \
             None else self.weights_load_device
-        load_config = self.create_load_config(load_device)
+        load_config = self.create_load_config()
 
         prompt_adapter_config = PromptAdapterConfig(
             max_prompt_adapters=self.max_prompt_adapters,

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -363,7 +363,7 @@ class DefaultModelLoader(BaseModelLoader):
                 model = _initialize_model(model_config, self.load_config,
                                           lora_config, cache_config,
                                           scheduler_config)
-            logger.info("Loading weights on %s ...", self.load_config.device)
+            logger.info("Loading weights on %s...", self.load_config.device)
             model.load_weights(
                 self._get_weights_iterator(model_config.model,
                                            model_config.revision,


### PR DESCRIPTION
Some backends rely on calling  EngineArgs.create_load_config() directly, for which we've altered the API. We don't need to alter it to enable weight load device functionality. This PR fixes it.