### PR TITLE
Add bucket calibration, allow reading/writing bucketing configs to file

### DIFF
--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -2091,6 +2091,6 @@ class HabanaModelRunner(
             self._is_inc_finalized = True
 
     def __del__(self):
-        if self.calibrate_buckets:
+        if getattr(self, 'calibrate_buckets', False):
             self.serialize_bucket_settings(self.bucket_cfg_file)
         self.shutdown_inc()

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -41,8 +41,8 @@ from vllm.multimodal import (MULTIMODAL_REGISTRY, BatchedTensorInputs,
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import (IntermediateTensors, SequenceData,
                            SequenceGroupMetadata)
-from vllm.utils import (is_fake_hpu, is_pin_memory_available,
-                        make_tensor_with_pad, get_vllm_instance_id)
+from vllm.utils import (get_vllm_instance_id, is_fake_hpu,
+                        is_pin_memory_available, make_tensor_with_pad)
 from vllm.worker.model_runner_base import (
     ModelRunnerBase, ModelRunnerInputBase,
     _add_attn_metadata_broadcastable_dict,

--- a/vllm/worker/habana_model_runner.py
+++ b/vllm/worker/habana_model_runner.py
@@ -42,7 +42,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.sequence import (IntermediateTensors, SequenceData,
                            SequenceGroupMetadata)
 from vllm.utils import (is_fake_hpu, is_pin_memory_available,
-                        make_tensor_with_pad)
+                        make_tensor_with_pad, get_vllm_instance_id)
 from vllm.worker.model_runner_base import (
     ModelRunnerBase, ModelRunnerInputBase,
     _add_attn_metadata_broadcastable_dict,
@@ -563,7 +563,15 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.lora_manager: LRUCacheWorkerLoRAManager = None
         self.model: torch.nn.Module = None
         self.inc_initialized_successfully = False
-        self.loaded_bucketing_config_from_file = False
+        self.calibrate_buckets = os.environ.get('VLLM_HPU_CALIBRATE_BUCKETS',
+                                                'false') in ['true', '1']
+        self.bucket_cfg_file = os.environ.get('VLLM_HPU_BUCKET_CFG', None)
+        # Set default filename only if bucket calibration is enabled
+        if self.calibrate_buckets and self.bucket_cfg_file is None:
+            vllm_instance_id = get_vllm_instance_id()
+            self.bucket_cfg_file = f'hpu-buckets-{vllm_instance_id}.yaml'
+            msg = f"Calibration results will be saved to {self.bucket_cfg_file}"
+            logger.info(msg)
 
         # Profiler stats
         self.profiler_counter_helper = HabanaProfilerCounterHelper()
@@ -595,8 +603,9 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.multi_modal_input_mapper = MULTIMODAL_REGISTRY \
             .create_input_mapper(self.model_config)
 
-        self.skip_warmup = os.environ.get('VLLM_SKIP_WARMUP',
-                                          'false').lower() == 'true'
+        self.skip_warmup = os.environ.get(
+            'VLLM_SKIP_WARMUP',
+            'false').lower() == 'true' or self.calibrate_buckets
 
     def load_model(self) -> None:
         import habana_frameworks.torch.core as htcore
@@ -685,47 +694,60 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         #FIXME: The default values should be max_model_len
         max_prompt_seq = 1024
         max_decode_seq = 2048
-        
-        DefaultBucketConfig = collections.namedtuple('DefaultBucketConfig', ['min','step','max','from_file'])
-        prompt_bs_bucket_cfg_defaults = DefaultBucketConfig(min=1,max=align_bs(32),step=align_bs(max_bucket_cfg), from_file=False)
-        prompt_seq_bucket_cfg_defaults = DefaultBucketConfig(min=self.block_size,max=self.block_size,step=max_prompt_seq, from_file=False)
-        decode_bs_bucket_cfg_defaults = DefaultBucketConfig(min=1,max=align_bs(32),step=align_bs(max_bucket_cfg), from_file=False)
-        decode_block_bucket_cfg_defaults = DefaultBucketConfig(min=self.block_size, step=self.block_size, max=max(self.block_size,self.max_num_seqs * max_decode_seq // self.block_size), from_file=False)
-        
-        bucket_cfg_file = os.environ.get('VLLM_HPU_BUCKET_CFG', None)
-        if bucket_cfg_file is not None:
-            import pandas as pd
-            import yaml
-            try:
-                with open(bucket_cfg_file, 'r') as f:
-                    data = yaml.safe_load(f)
-                prompt_bs_bucket_cfg_defaults = DefaultBucketConfig(*data['bucket_cfg']['prompt_bs_bucket_cfg'], from_file=True)
-                prompt_seq_bucket_cfg_defaults = DefaultBucketConfig(*data['bucket_cfg']['prompt_seq_bucket_cfg'], from_file=True)
-                decode_bs_bucket_cfg_defaults = DefaultBucketConfig(*data['bucket_cfg']['decode_bs_bucket_cfg'], from_file=True)
-                decode_block_bucket_cfg_defaults = DefaultBucketConfig(*data['bucket_cfg']['decode_block_bucket_cfg'], from_file=True)
-                df = pd.DataFrame.from_dict(data['records'])
-                self.prompt_buckets = df[df['is_prefill'] == True][['batch_size','seq_or_block']].values.tolist()
-                self.decode_buckets = df[df['is_prefill'] == False][['batch_size','seq_or_block']].values.tolist()
-                self.loaded_bucketing_config_from_file = True
-            except (FileNotFoundError, IOError, PermissionError):
-                msg = "Could not open file specified in VLLM_HPU_BUCKET_CFG: {bucket_cfg_file}. Falling back to default config."
-                logger.error(msg)
-                
+
+        DefaultBucketConfig = collections.namedtuple(
+            'DefaultBucketConfig', ['min', 'step', 'max', 'from_file'])
+        prompt_bs_bucket_cfg_defaults = DefaultBucketConfig(
+            min=1,
+            step=align_bs(32),
+            max=align_bs(max_bucket_cfg),
+            from_file=False)
+        prompt_seq_bucket_cfg_defaults = DefaultBucketConfig(
+            min=self.block_size,
+            step=self.block_size,
+            max=max_prompt_seq,
+            from_file=False)
+        decode_bs_bucket_cfg_defaults = DefaultBucketConfig(
+            min=1,
+            step=align_bs(32),
+            max=align_bs(max_bucket_cfg),
+            from_file=False)
+        decode_block_bucket_cfg_defaults = DefaultBucketConfig(
+            min=self.block_size,
+            step=self.block_size,
+            max=max(self.block_size,
+                    self.max_num_seqs * max_decode_seq // self.block_size),
+            from_file=False)
+
+        # Do not load bucket config from file during bucket calibration
+        if self.bucket_cfg_file is not None and not self.calibrate_buckets:
+            bucket_settings, (
+                prompt_buckets,
+                decode_buckets) = self.deserialize_bucket_settings(
+                    self.bucket_cfg_file)
+            if bucket_settings is not None:
+                prompt_bs_bucket_cfg_defaults = DefaultBucketConfig(
+                    **bucket_settings['prompt_bs_bucket_cfg'], from_file=True)
+                prompt_seq_bucket_cfg_defaults = DefaultBucketConfig(
+                    **bucket_settings['prompt_seq_bucket_cfg'], from_file=True)
+                decode_bs_bucket_cfg_defaults = DefaultBucketConfig(
+                    **bucket_settings['decode_bs_bucket_cfg'], from_file=True)
+                decode_block_bucket_cfg_defaults = DefaultBucketConfig(
+                    **bucket_settings['decode_block_bucket_cfg'],
+                    from_file=True)
+            if prompt_buckets is not None:
+                self.prompt_buckets = prompt_buckets
+            if decode_buckets is not None:
+                self.decode_buckets = decode_buckets
+
         self.prompt_bs_bucket_cfg = read_bucket_settings(
-            'prompt',
-            'bs',
-            **prompt_bs_bucket_cfg_defaults._asdict())
-        self.decode_bs_bucket_cfg = read_bucket_settings('decode',
-                                                         'bs',
-                                                         **decode_bs_bucket_cfg_defaults._asdict())
-        self.prompt_seq_bucket_cfg = read_bucket_settings('prompt',
-                                                          'seq',
-                                                          **prompt_seq_bucket_cfg_defaults._asdict())
+            'prompt', 'bs', **prompt_bs_bucket_cfg_defaults._asdict())
+        self.decode_bs_bucket_cfg = read_bucket_settings(
+            'decode', 'bs', **decode_bs_bucket_cfg_defaults._asdict())
+        self.prompt_seq_bucket_cfg = read_bucket_settings(
+            'prompt', 'seq', **prompt_seq_bucket_cfg_defaults._asdict())
         self.decode_block_bucket_cfg = read_bucket_settings(
-            'decode',
-            'block', 
-            **decode_block_bucket_cfg_defaults._asdict()
-            )
+            'decode', 'block', **decode_block_bucket_cfg_defaults._asdict())
 
         self.graphed_buckets: Set[Any] = set()
 
@@ -738,6 +760,73 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                f"bs:{self.decode_bs_bucket_cfg}, "
                f"block:{self.decode_block_bucket_cfg}")
         logger.info(msg)
+
+        if getattr(self, 'prompt_buckets', None) is not None:
+            msg = (f"Loaded {len(self.prompt_buckets)} "
+                   "prompt buckets from file [bs, seq]: "
+                   f"{list(sorted(self.prompt_buckets))}")
+            logger.info(msg)
+
+        if getattr(self, 'decode_buckets', None) is not None:
+            msg = (f"Loaded {len(self.decode_buckets)} "
+                   f"decode buckets from file [bs, block]: "
+                   f"{list(sorted(self.decode_buckets))}")
+            logger.info(msg)
+
+    def serialize_bucket_settings(self, bucket_cfg_file):
+        import pandas as pd
+        import yaml
+
+        def bucket_cfg_to_dict(cfg):
+            return {'min': cfg[0], 'step': cfg[1], 'max': cfg[2]}
+
+        df = pd.DataFrame(
+            self.seen_configs,
+            columns=['batch_size', 'seq_or_block', 'is_prefill']).sort_values(
+                ['is_prefill', 'batch_size', 'seq_or_block'], ascending=False)
+        data = {}
+        data['buckets'] = df.to_dict(orient='records')
+        data['bucket_cfg'] = {
+            'prompt_bs_bucket_cfg':
+            bucket_cfg_to_dict(self.prompt_bs_bucket_cfg),
+            'prompt_seq_bucket_cfg':
+            bucket_cfg_to_dict(self.prompt_seq_bucket_cfg),
+            'decode_bs_bucket_cfg':
+            bucket_cfg_to_dict(self.decode_bs_bucket_cfg),
+            'decode_block_bucket_cfg':
+            bucket_cfg_to_dict(self.decode_block_bucket_cfg),
+        }
+        with open(bucket_cfg_file, 'w') as outfile:
+            yaml.dump(data, outfile, default_flow_style=False)
+        msg = f"Bucket calibration settings saved to {bucket_cfg_file}"
+        logger.info(msg)
+
+    def deserialize_bucket_settings(self, bucket_cfg_file):
+        import pandas as pd
+        import yaml
+        prompt_buckets = None
+        decode_buckets = None
+        try:
+            with open(bucket_cfg_file, 'r') as f:
+                data = yaml.safe_load(f)
+            # Load min,step,max from file
+            bucket_cfg = data['bucket_cfg']
+            # Load pre-generated buckets, if any
+            if 'buckets' in data:
+                df = pd.DataFrame.from_dict(data['buckets'])
+                prompt_buckets = df[df['is_prefill']][[
+                    'batch_size', 'seq_or_block'
+                ]].values.tolist()
+                prompt_buckets = [tuple(b) for b in prompt_buckets]
+                decode_buckets = df[~df['is_prefill']][[
+                    'batch_size', 'seq_or_block'
+                ]].values.tolist()
+                decode_buckets = [tuple(b) for b in decode_buckets]
+        except (FileNotFoundError, IOError, PermissionError):
+            msg = "Could not open file specified in VLLM_HPU_BUCKET_CFG: "
+            f"{bucket_cfg_file}. Falling back to default config."
+            logger.error(msg)
+        return bucket_cfg, (prompt_buckets, decode_buckets)
 
     def _prepare_prompt(
         self,
@@ -1558,8 +1647,9 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.profiler.start('internal', 'warmup')
         max_blocks = kv_caches[0][0].size(0)
         prompt_omitted_buckets = []
-        if not self.loaded_bucketing_config_from_file:
-            self.prompt_buckets, prompt_omitted_buckets = generate_prompt_buckets(
+        if getattr(self, 'prompt_buckets', None) is None:
+            self.prompt_buckets, prompt_omitted_buckets = \
+                generate_prompt_buckets(
                 self.prompt_bs_bucket_cfg, self.prompt_seq_bucket_cfg,
                 self.max_num_batched_tokens)
         if self.lora_config:
@@ -1574,14 +1664,14 @@ class HabanaModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         logger.info(msg)
 
         msg = (f"Omitted {len(prompt_omitted_buckets)} "
-            "prompt buckets due to exceeded token budget "
-            f"(max_num_batched_tokens={self.max_num_batched_tokens})")
+               "prompt buckets due to exceeded token budget "
+               f"(max_num_batched_tokens={self.max_num_batched_tokens})")
         logger.info(msg)
 
         msg = f"Omitted prompt buckets: {list(sorted(prompt_omitted_buckets))}"
         logger.debug(msg)
 
-        if not self.loaded_bucketing_config_from_file:
+        if getattr(self, 'decode_buckets', None) is None:
             self.decode_buckets = generate_decode_buckets(
                 self.decode_bs_bucket_cfg, self.decode_block_bucket_cfg,
                 max_blocks)
@@ -1873,8 +1963,10 @@ class HabanaModelRunner(
         self.seen_configs.add(cfg)
         if not seen and not warmup_mode:
             phase = 'prompt' if is_prompt else 'decode'
-            logger.warning("Configuration: (%s, %s, %s) was not warmed-up!",
-                           phase, batch_size, seq_len)
+            if not self.calibrate_buckets:
+                logger.warning(
+                    "Configuration: (%s, %s, %s) was not warmed-up!", phase,
+                    batch_size, seq_len)
 
     @torch.inference_mode()
     def execute_model(
@@ -1999,21 +2091,6 @@ class HabanaModelRunner(
             self._is_inc_finalized = True
 
     def __del__(self):
-        calibrate_buckets = os.environ.get('VLLM_HPU_CALIBRATE_BUCKETS', 'false') in ['true', '1']
-        if calibrate_buckets:
-            import pandas as pd
-            import yaml
-            df = pd.DataFrame(self.seen_configs, columns=['batch_size', 'seq_or_block', 'is_prefill']).sort_values(['is_prefill', 'batch_size','seq_or_block'], ascending=False)
-            data = {}
-            data['buckets'] = df.to_dict(orient='records')
-            data['bucket_cfg'] = {
-                'prompt_bs_bucket_cfg': self.prompt_bs_bucket_cfg,
-                'prompt_seq_bucket_cfg': self.prompt_seq_bucket_cfg,
-                'decode_bs_bucket_cfg': self.decode_bs_bucket_cfg,
-                'decode_block_bucket_cfg': self.decode_block_bucket_cfg,
-            }
-            with open('data.yml', 'w') as outfile:
-                yaml.dump(data, outfile, default_flow_style=False)
-
+        if self.calibrate_buckets:
+            self.serialize_bucket_settings(self.bucket_cfg_file)
         self.shutdown_inc()
-


### PR DESCRIPTION
This PR adds allows user to calibrate bucket usage and load bucket configuration from file. 

## Design
When `VLLM_HPU_CALIBRATE_BUCKETS=true` env var is passed, warmup will be disabled, and upon destruction, the server will store bucket configs and utilized buckets in YAML file (optionally defined in `VLLM_HPU_BUCKET_CFG` env var). 


An example YAML file looks as follows:
```
bucket_cfg:
  prompt_bs_bucket_cfg: {min: 1, step: 32, max: 64}
  prompt_seq_bucket_cfg: {min: 128, step: 128, max: 1280}
  decode_bs_bucket_cfg: {min: 1, step: 32, max: 16}
  decode_block_bucket_cfg: {min: 128, step: 128, max: 128}
buckets:
  decode:
  - [16, 128]
  - [8, 128]
  - [4, 128]
  - [2, 128]
  - [1, 128]
  prefill:
  - [64, 128]
  - [4, 1280]
  - [4, 1152]
  - [1, 1152]
```
Optionally, user can also emit CSV with buckets (useful for data analysis using external tools):
```
phase,batch_size,seq_or_block
prefill,64,128
prefill,4,1280
prefill,4,1152
prefill,1,1152
decode,16,128
decode,8,128
decode,4,128
decode,2,128
decode,1,128
```
In CSV mode there is no way to dump the `bucket_cfg` data.

- User can manually alter the file and change the bucket settings as needed. 
- (only YAML) Ranges of bucket parameters (min/max) in generated YAML file are updated to include used buckets - i.e. if a given workload uses prefills with sequence length of 1280, and default max prefill sequence length is 1024, it will be extended to 1280.
- (only YAML) User can also remove the "buckets" section and only provide bucket min/step/max settings, in which case buckets will be generated during runtime using provided settings - this can serve as an alternative for providing `VLLM_{phase}_{dim}_BUCKET_{param}` environment variables.
- (only YAML) User can also remove the "bucket_cfg" section and only provide the list of buckets. In that case, buckets might be out of range w.r.t. bucket settings.
- (only YAML) `VLLM_{phase}_{dim}_BUCKET_{param}` environment variables override values provided in the YAML file

### Usage
- If `VLLM_HPU_CALIBRATE_BUCKETS` is `true` or `1` and `VLLM_HPU_BUCKET_CFG` is not provided, calibration will happen, and calibration results will be saved to `hpu-buckets-{vllm_instance_id}.yaml`. 
- If `VLLM_HPU_CALIBRATE_BUCKETS` is `true` or `1` and `VLLM_HPU_BUCKET_CFG` is provided, calibration will happen, and calibration results will be saved to a file path defined by `VLLM_HPU_BUCKET_CFG`.  If extension of  `VLLM_HPU_BUCKET_CFG` is `.csv` (case insensitive), buckets will be saved in CSV format, if extension is `yml` or `yaml` (case insensitive), buckets and their ranges will be saved in YAML format.
- If `VLLM_HPU_CALIBRATE_BUCKETS` is **not** `true` or `1` and `VLLM_HPU_BUCKET_CFG` is provided, calibration will **not** happen, and bucket settings will be loaded from a file path defined by `VLLM_HPU_BUCKET_CFG` (both YAML and CSV supported)
- If `VLLM_HPU_CALIBRATE_BUCKETS` is **not** `true` or `1` and `VLLM_HPU_BUCKET_CFG` is **not** provided, calibration will **not** happen, and bucket generation will not be altered in any way **(default behavior)**

## Examples:

### Calibration with unspecified output file
Input:
```
VLLM_HPU_CALIBRATE_BUCKETS=true vllm serve ...
```
Output:
```
...
INFO 09-30 14:24:24 selector.py:147] Using HabanaAttention backend.
**INFO 09-30 14:24:24 habana_model_runner.py:575] Calibration results will be saved to hpu-buckets-vllm-instance-05d1c80d2f4541819d95b508117b130c.yaml**
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_MIN=1 (default:1)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_STEP=32 (default:32)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_MAX=64 (default:64)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_MIN=1 (default:1)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_STEP=32 (default:32)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_MAX=64 (default:64)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_MIN=128 (default:128)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_STEP=128 (default:128)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_MAX=1024 (default:1024)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_MIN=128 (default:128)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_STEP=128 (default:128)
INFO 09-30 14:24:24 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_MAX=2048 (default:2048)
INFO 09-30 14:24:24 habana_model_runner.py:758] Prompt bucket config (min, step, max_warmup) bs:[1, 32, 64], seq:[128, 128, 1024]
INFO 09-30 14:24:24 habana_model_runner.py:763] Decode bucket config (min, step, max_warmup) bs:[1, 32, 64], block:[128, 128, 2048]
...
INFO 09-30 14:24:35 habana_executor.py:87] # HPU blocks: 3184, # CPU blocks: 256
INFO 09-30 14:24:36 habana_worker.py:212] Initializing cache engine took 49.75 GiB of device memory (65.4 GiB/94.62 GiB used) and 1.984 GiB of host memory (541.3 GiB/1007 GiB used)
**INFO 09-30 14:24:36 habana_model_runner.py:1646] Skipping warmup...**
INFO 09-30 14:24:36 habana_executor.py:93] init_cache_engine took 49.75 GiB of device memory (65.4 GiB/94.62 GiB used) and 1.992 GiB of host memory (541.3 GiB/1007 GiB used)
...
**INFO 09-30 14:26:40 habana_model_runner.py:803] Bucket calibration settings saved to hpu-buckets-vllm-instance-05d1c80d2f4541819d95b508117b130c.yaml**
```

### Calibration with specified output file
Input:
```
VLLM_HPU_CALIBRATE_BUCKETS=true VLLM_HPU_BUCKET_CFG=blabla.yml vllm serve ...
```
Output log:
```
...
INFO 09-30 14:03:30 selector.py:147] Using HabanaAttention backend.
**INFO 09-30 14:03:30 habana_model_runner.py:575] Calibration results will be saved to blabla.yml**
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_MIN=1 (default:1)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_STEP=32 (default:32)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_MAX=64 (default:64)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_MIN=1 (default:1)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_STEP=32 (default:32)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_MAX=64 (default:64)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_MIN=128 (default:128)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_STEP=128 (default:128)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_MAX=1024 (default:1024)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_MIN=128 (default:128)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_STEP=128 (default:128)
INFO 09-30 14:03:30 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_MAX=2048 (default:2048)
INFO 09-30 14:03:30 habana_model_runner.py:758] Prompt bucket config (min, step, max_warmup) bs:[1, 32, 64], seq:[128, 128, 1024]
INFO 09-30 14:03:30 habana_model_runner.py:763] Decode bucket config (min, step, max_warmup) bs:[1, 32, 64], block:[128, 128, 2048]
...
INFO 09-30 14:03:42 habana_executor.py:87] # HPU blocks: 3184, # CPU blocks: 256
INFO 09-30 14:03:42 habana_worker.py:212] Initializing cache engine took 49.75 GiB of device memory (65.4 GiB/94.62 GiB used) and 1.971 GiB of host memory (537.7 GiB/1007 GiB used)
**INFO 09-30 14:03:42 habana_model_runner.py:1646] Skipping warmup...**
INFO 09-30 14:03:42 habana_executor.py:93] init_cache_engine took 49.75 GiB of device memory (65.4 GiB/94.62 GiB used) and 1.971 GiB of host memory (537.7 GiB/1007 GiB used)
...
**INFO 09-30 14:06:29 habana_model_runner.py:803] Bucket calibration settings saved to blabla.yml**
```

Calibration yaml:
```
bucket_cfg:
  prompt_bs_bucket_cfg: {min: 1, step: 32, max: 64}
  prompt_seq_bucket_cfg: {min: 128, step: 128, max: 1280}
  decode_bs_bucket_cfg: {min: 1, step: 32, max: 128}
  decode_block_bucket_cfg: {min: 128, step: 128, max: 1408}
buckets:
  decode:
  - [128, 1408]
  - [128, 1280]
  - [128, 1152]
  - [128, 1024]
  - [96, 1024]
  - [96, 896]
  - [96, 768]
  - [64, 640]
  - [64, 512]
  - [64, 384]
  - [32, 384]
  - [32, 256]
  - [16, 256]
  - [16, 128]
  - [8, 128]
  - [4, 128]
  - [2, 128]
  - [1, 128]
  prefill:
  - [64, 128]
  - [4, 1280]
  - [4, 1152]
  - [2, 1280]
  - [2, 1152]
  - [1, 1280]
  - [1, 1152]
```

### Loading calibration YAML
Input:
```
VLLM_HPU_BUCKET_CFG=blabla.yml vllm serve ...
```
Output log:
```
...
INFO 09-30 14:29:02 selector.py:147] Using HabanaAttention backend.
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_MIN=1 (VLLM_HPU_BUCKET_CFG:1)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_STEP=32 (VLLM_HPU_BUCKET_CFG:32)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_PROMPT_BS_BUCKET_MAX=64 (VLLM_HPU_BUCKET_CFG:64)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_MIN=1 (VLLM_HPU_BUCKET_CFG:1)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_STEP=32 (VLLM_HPU_BUCKET_CFG:32)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_DECODE_BS_BUCKET_MAX=64 (VLLM_HPU_BUCKET_CFG:64)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_MIN=128 (VLLM_HPU_BUCKET_CFG:128)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_STEP=128 (VLLM_HPU_BUCKET_CFG:128)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_PROMPT_SEQ_BUCKET_MAX=1024 (VLLM_HPU_BUCKET_CFG:1024)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_MIN=128 (VLLM_HPU_BUCKET_CFG:128)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_STEP=128 (VLLM_HPU_BUCKET_CFG:128)**
**INFO 09-30 14:29:02 habana_model_runner.py:99] VLLM_DECODE_BLOCK_BUCKET_MAX=2048 (VLLM_HPU_BUCKET_CFG:2048)**
INFO 09-30 14:29:02 habana_model_runner.py:758] Prompt bucket config (min, step, max_warmup) bs:[1, 32, 64], seq:[128, 128, 1024]
INFO 09-30 14:29:02 habana_model_runner.py:763] Decode bucket config (min, step, max_warmup) bs:[1, 32, 64], block:[128, 128, 2048]
**INFO 09-30 14:29:02 habana_model_runner.py:769] Loaded 7 prompt buckets from file [bs, seq]: [(1, 1152), (1, 1280), (2, 1152), (2, 1280), (4, 1152), (4, 1280), (64, 128)]**
**INFO 09-30 14:29:02 habana_model_runner.py:775] Loaded 18 decode buckets from file [bs, block]: [(1, 128), (2, 128), (4, 128), (8, 128), (16, 128), (16, 256), (32, 256), (32, 384), (64, 384), (64, 512), (64, 640), (96, 768), (96, 896), (96, 1024), (128, 1024), (128, 1152), (128, 1280), (128, 1408)]**
...
INFO 09-30 14:29:13 habana_executor.py:87] # HPU blocks: 3184, # CPU blocks: 256
INFO 09-30 14:29:14 habana_worker.py:212] Initializing cache engine took 49.75 GiB of device memory (65.4 GiB/94.62 GiB used) and 1.982 GiB of host memory (550.4 GiB/1007 GiB used)
INFO 09-30 14:29:14 habana_model_runner.py:1665] Generated 7 prompt buckets [bs, seq]: [(1, 1152), (1, 1280), (2, 1152), (2, 1280), (4, 1152), (4, 1280), (64, 128)]
INFO 09-30 14:29:14 habana_model_runner.py:1670] Omitted 0 prompt buckets due to exceeded token budget (max_num_batched_tokens=4096)
INFO 09-30 14:29:14 habana_model_runner.py:1684] Generated 18 decode buckets [bs, total_blocks]: [(1, 128), (2, 128), (4, 128), (8, 128), (16, 128), (16, 256), (32, 256), (32, 384), (64, 384), (64, 512), (64, 640), (96, 768), (96, 896), (96, 1024), (128, 1024), (128, 1152), (128, 1280), (128, 1408)]
INFO 09-30 14:29:14 habana_model_runner.py:1568] [Warmup][Prompt][1/7] batch_size:1 seq_len:1152 free_mem:29.23 GiB
...
INFO 09-30 14:29:19 habana_model_runner.py:1568] [Warmup][Prompt][7/7] batch_size:64 seq_len:128 free_mem:29.23 GiB
INFO 09-30 14:29:19 habana_model_runner.py:1568] [Warmup][Decode][1/18] batch_size:1 num_blocks:128 free_mem:29.23 GiB
...
INFO 09-30 14:29:27 habana_model_runner.py:1568] [Warmup][Decode][18/18] batch_size:128 num_blocks:1408 free_mem:29.23 GiB
INFO 09-30 14:29:27 habana_model_runner.py:1741] Using 21.33 GiB/29.23 GiB of free device memory for HPUGraphs, 6.399 GiB for prompt and 14.93 GiB for decode (VLLM_GRAPH_PROMPT_RATIO=0.3)
INFO 09-30 14:29:27 habana_model_runner.py:1568] [Warmup][Graph/Prompt][1/7] batch_size:1 num_blocks:1152 free_mem:29.23 GiB
...
INFO 09-30 14:29:30 habana_model_runner.py:1568] [Warmup][Graph/Prompt][7/7] batch_size:64 num_blocks:128 free_mem:29.17 GiB
INFO 09-30 14:29:30 habana_model_runner.py:1568] [Warmup][Graph/Decode][1/18] batch_size:128 num_blocks:1024 free_mem:29.16 GiB
...
INFO 09-30 14:29:38 habana_model_runner.py:1568] [Warmup][Graph/Decode][18/18] batch_size:1 num_blocks:128 free_mem:29.15 GiB
INFO 09-30 14:29:38 habana_model_runner.py:1632] Graph/Prompt captured:7 (100.0%) used_mem:64.04 MiB buckets:[(1, 1152), (1, 1280), (2, 1152), (2, 1280), (4, 1152), (4, 1280), (64, 128)]
INFO 09-30 14:29:38 habana_model_runner.py:1632] Graph/Decode captured:18 (100.0%) used_mem:11.23 MiB buckets:[(1, 128), (2, 128), (4, 128), (8, 128), (16, 128), (16, 256), (32, 256), (32, 384), (64, 384), (64, 512), (64, 640), (96, 768), (96, 896), (96, 1024), (128, 1024), (128, 1152), (128, 1280), (128, 1408)]
INFO 09-30 14:29:38 habana_model_runner.py:1789] Warmup finished in 25 secs, allocated 75.27 MiB of device memory
...

```


### Default behavior:

Input:
```
vllm serve ...
```

Output log:
```
INFO 09-30 14:31:52 habana_executor.py:87] # HPU blocks: 3184, # CPU blocks: 256
INFO 09-30 14:31:53 habana_worker.py:212] Initializing cache engine took 49.75 GiB of device memory (65.4 GiB/94.62 GiB used) and 1.978 GiB of host memory (538.9 GiB/1007 GiB used)
INFO 09-30 14:31:53 habana_model_runner.py:1665] Generated 31 prompt buckets [bs, seq]: [(1, 128), (1, 256), (1, 384), (1, 512), (1, 640), (1, 768), (1, 896), (1, 1024), (2, 128), (2, 256), (2, 384), (2, 512), (2, 640), (2, 768), (2, 896), (2, 1024), (4, 128), (4, 256), (4, 384), (4, 512), (4, 640), (4, 768), (4, 896), (4, 1024), (8, 128), (8, 256), (8, 384), (8, 512), (16, 128), (16, 256), (32, 128)]
INFO 09-30 14:31:53 habana_model_runner.py:1670] Omitted 25 prompt buckets due to exceeded token budget (max_num_batched_tokens=4096)
INFO 09-30 14:31:53 habana_model_runner.py:1684] Generated 112 decode buckets [bs, total_blocks]: [(1, 128), (1, 256), (1, 384), (1, 512), (1, 640), (1, 768), (1, 896), (1, 1024), (1, 1152), (1, 1280), (1, 1408), (1, 1536), (1, 1664), (1, 1792), (1, 1920), (1, 2048), (2, 128), (2, 256), (2, 384), (2, 512), (2, 640), (2, 768), (2, 896), (2, 1024), (2, 1152), (2, 1280), (2, 1408), (2, 1536), (2, 1664), (2, 1792), (2, 1920), (2, 2048), (4, 128), (4, 256), (4, 384), (4, 512), (4, 640), (4, 768), (4, 896), (4, 1024), (4, 1152), (4, 1280), (4, 1408), (4, 1536), (4, 1664), (4, 1792), (4, 1920), (4, 2048), (8, 128), (8, 256), (8, 384), (8, 512), (8, 640), (8, 768), (8, 896), (8, 1024), (8, 1152), (8, 1280), (8, 1408), (8, 1536), (8, 1664), (8, 1792), (8, 1920), (8, 2048), (16, 128), (16, 256), (16, 384), (16, 512), (16, 640), (16, 768), (16, 896), (16, 1024), (16, 1152), (16, 1280), (16, 1408), (16, 1536), (16, 1664), (16, 1792), (16, 1920), (16, 2048), (32, 128), (32, 256), (32, 384), (32, 512), (32, 640), (32, 768), (32, 896), (32, 1024), (32, 1152), (32, 1280), (32, 1408), (32, 1536), (32, 1664), (32, 1792), (32, 1920), (32, 2048), (64, 128), (64, 256), (64, 384), (64, 512), (64, 640), (64, 768), (64, 896), (64, 1024), (64, 1152), (64, 1280), (64, 1408), (64, 1536), (64, 1664), (64, 1792), (64, 1920), (64, 2048)]
INFO 09-30 14:31:53 habana_model_runner.py:1568] [Warmup][Prompt][1/31] batch_size:4 seq_len:1024 free_mem:29.23 GiB
...
INFO 09-30 14:32:12 habana_model_runner.py:1568] [Warmup][Prompt][31/31] batch_size:1 seq_len:128 free_mem:29.23 GiB
INFO 09-30 14:32:12 habana_model_runner.py:1568] [Warmup][Decode][1/112] batch_size:64 num_blocks:2048 free_mem:29.23 GiB
...
INFO 09-30 14:32:56 habana_model_runner.py:1568] [Warmup][Decode][112/112] batch_size:1 num_blocks:128 free_mem:29.23 GiB
INFO 09-30 14:32:57 habana_model_runner.py:1741] Using 21.33 GiB/29.23 GiB of free device memory for HPUGraphs, 6.399 GiB for prompt and 14.93 GiB for decode (VLLM_GRAPH_PROMPT_RATIO=0.3)
INFO 09-30 14:32:57 habana_model_runner.py:1568] [Warmup][Graph/Prompt][1/31] batch_size:1 num_blocks:128 free_mem:29.23 GiB
...
INFO 09-30 14:33:09 habana_model_runner.py:1568] [Warmup][Graph/Prompt][31/31] batch_size:4 num_blocks:1024 free_mem:29.16 GiB
INFO 09-30 14:33:10 habana_model_runner.py:1568] [Warmup][Graph/Decode][1/112] batch_size:64 num_blocks:128 free_mem:29.14 GiB
...
INFO 09-30 14:33:57 habana_model_runner.py:1568] [Warmup][Graph/Decode][112/112] batch_size:1 num_blocks:2048 free_mem:29.1 GiB
INFO 09-30 14:33:57 habana_model_runner.py:1632] Graph/Prompt captured:31 (100.0%) used_mem:85.03 MiB buckets:[(1, 128), (1, 256), (1, 384), (1, 512), (1, 640), (1, 768), (1, 896), (1, 1024), (2, 128), (2, 256), (2, 384), (2, 512), (2, 640), (2, 768), (2, 896), (2, 1024), (4, 128), (4, 256), (4, 384), (4, 512), (4, 640), (4, 768), (4, 896), (4, 1024), (8, 128), (8, 256), (8, 384), (8, 512), (16, 128), (16, 256), (32, 128)]
INFO 09-30 14:33:57 habana_model_runner.py:1632] Graph/Decode captured:112 (100.0%) used_mem:45.65 MiB buckets:[(1, 128), (1, 256), (1, 384), (1, 512), (1, 640), (1, 768), (1, 896), (1, 1024), (1, 1152), (1, 1280), (1, 1408), (1, 1536), (1, 1664), (1, 1792), (1, 1920), (1, 2048), (2, 128), (2, 256), (2, 384), (2, 512), (2, 640), (2, 768), (2, 896), (2, 1024), (2, 1152), (2, 1280), (2, 1408), (2, 1536), (2, 1664), (2, 1792), (2, 1920), (2, 2048), (4, 128), (4, 256), (4, 384), (4, 512), (4, 640), (4, 768), (4, 896), (4, 1024), (4, 1152), (4, 1280), (4, 1408), (4, 1536), (4, 1664), (4, 1792), (4, 1920), (4, 2048), (8, 128), (8, 256), (8, 384), (8, 512), (8, 640), (8, 768), (8, 896), (8, 1024), (8, 1152), (8, 1280), (8, 1408), (8, 1536), (8, 1664), (8, 1792), (8, 1920), (8, 2048), (16, 128), (16, 256), (16, 384), (16, 512), (16, 640), (16, 768), (16, 896), (16, 1024), (16, 1152), (16, 1280), (16, 1408), (16, 1536), (16, 1664), (16, 1792), (16, 1920), (16, 2048), (32, 128), (32, 256), (32, 384), (32, 512), (32, 640), (32, 768), (32, 896), (32, 1024), (32, 1152), (32, 1280), (32, 1408), (32, 1536), (32, 1664), (32, 1792), (32, 1920), (32, 2048), (64, 128), (64, 256), (64, 384), (64, 512), (64, 640), (64, 768), (64, 896), (64, 1024), (64, 1152), (64, 1280), (64, 1408), (64, 1536), (64, 1664), (64, 1792), (64, 1920), (64, 2048)]
INFO 09-30 14:33:57 habana_model_runner.py:1789] Warmup finished in 124 secs, allocated 130.7 MiB of device memory
```


Warmup time and number of buckets has drastically decreased, as only buckets used at least once by given workload are used, and the remaining ones are discarded.
