### PR TITLE
Set vllm-hpu-extension to 36c7f9c

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@bb56d3b
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@36c7f9c


### PR DESCRIPTION
This includes: https://github.com/HabanaAI/vllm-hpu-extension/pull/8
(BlockSoftmax: fix guard value for fp16)