### PR TITLE
Timeout adjusted in MLLMEngine

### DIFF
--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -33,7 +33,6 @@ CONFIG_TYPE = Union[ModelConfig, DecodingConfig, ParallelConfig,
 
 logger = init_logger(__name__)
 
-POLLING_TIMEOUT_MS = 10000
 HEALTHY_RESPONSE = (pickle.dumps(VLLM_RPC_SUCCESS_STR), )
 
 
@@ -207,7 +206,7 @@ class MQLLMEngine:
             self._alive()
             if not self.engine.has_unfinished_requests():
                 # Poll until there is work to do.
-                while self.input_socket.poll(timeout=POLLING_TIMEOUT_MS) == 0:
+                while self.input_socket.poll(timeout=VLLM_RPC_TIMEOUT) == 0:
                     self._alive()
                     self.engine.do_log_stats()
                     logger.debug("Waiting for new requests in engine loop.")


### PR DESCRIPTION
Currently in Multiprocess LLMEngine there is a polling timeout fixed to 10000 ms . This may not be good when
we are running torch compiled models that happen to compile (we did not have particular configuration -- shape -- model warmed up during warmup phase). So torch compilation if happens after warmup then 10000ms is not enough. So It would be good to have a way to modify fixed timeout.

Changes disscussed here are replacing fixed timeout of 10000 ms with value as provided with VLLM_RPC_TIMEOUT .

Please suggest if separate env var should be made.

