### PR TITLE
Remove constraints for bucket creation during warmup in LoRA

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -672,9 +672,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     def _setup_buckets(self) -> None:
         align_bs = lambda x: min(self.max_num_seqs, x)
         max_bucket_cfg = 64
-        if self.lora_config and \
-            max_bucket_cfg > self.max_num_batched_tokens // self.block_size:
-            max_bucket_cfg = self.max_num_batched_tokens // self.block_size
         #FIXME: The default values should be max_model_len
         max_prompt_seq = 1024
         max_decode_seq = 2048
@@ -1480,11 +1477,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.prompt_buckets, prompt_omitted_buckets = generate_prompt_buckets(
             self.prompt_bs_bucket_cfg, self.prompt_seq_bucket_cfg,
             self.max_num_batched_tokens)
-        if self.lora_config:
-            self.prompt_buckets[:] = [
-                bucket for bucket in self.prompt_buckets
-                if self._is_valid_bucket(bucket)
-            ]
 
         msg = (
             f"Generated {len(self.prompt_buckets)} "
@@ -1502,11 +1494,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.decode_buckets = generate_decode_buckets(
             self.decode_bs_bucket_cfg, self.decode_block_bucket_cfg,
             max_blocks)
-        if self.lora_config:
-            self.decode_buckets[:] = [
-                bucket for bucket in self.decode_buckets
-                if self._is_valid_bucket(bucket)
-            ]
         logger.info("Generated %d decode buckets [bs, total_blocks]: %s",
                     len(self.decode_buckets),
                     list(sorted(self.decode_buckets)))


### PR DESCRIPTION
This PR removes LoRA constraints during bucket creation in warm-up.  Fixes high drop in decode throughput when LoRA is enabled for a given configuration.