### PR TITLE
seed_everything function doesn't handle HPU

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -413,6 +413,9 @@ def seed_everything(seed: int) -> None:
     if is_xpu():
         torch.xpu.manual_seed_all(seed)
 
+    if current_platform.is_hpu():
+        torch.hpu.manual_seed_all(seed)
+
 
 def random_uuid() -> str:
     return str(uuid.uuid4().hex)


### PR DESCRIPTION
This PR adds manual seed setting for HPU in the function `seed_everything`.

Previously the torch.manual_seed was getting set to the given seed, which got removed in the following PR https://github.com/HabanaAI/vllm-fork/commit/6ffa3f314c59e42238f1c5f923ff2839e0af9698