### PR TITLE
Remove workaround added to resolve multi-card stall issue

### DIFF
--- a/tests/lora/test_llama_hpu.py
+++ b/tests/lora/test_llama_hpu.py
@@ -1,4 +1,3 @@
-from multiprocessing import Process
 from typing import List
 
 from conftest import cleanup
@@ -78,23 +77,12 @@ def _test_llama_lora(sql_lora_files, tp_size):
 
 
 def test_llama_lora_1x(sql_lora_files):
-    p = Process(target=_test_llama_lora, args=(sql_lora_files, 1))
-    p.start()
-    p.join()
-    assert p.exitcode == 0
+    _test_llama_lora(sql_lora_files, 1)
 
 
 def test_llama_lora_2x(sql_lora_files):
-    # Work-around to resolve stalling issue in multi-card scenario
-    p = Process(target=_test_llama_lora, args=(sql_lora_files, 2))
-    p.start()
-    p.join()
-    assert p.exitcode == 0
+    _test_llama_lora(sql_lora_files, 2)
 
 
 def test_llama_lora_4x(sql_lora_files):
-    # Work-around to resolve stalling issue in multi-card scenario
-    p = Process(target=_test_llama_lora, args=(sql_lora_files, 4))
-    p.start()
-    p.join()
-    assert p.exitcode == 0
+    _test_llama_lora(sql_lora_files, 4)

--- a/tests/lora/test_multilora_hpu.py
+++ b/tests/lora/test_multilora_hpu.py
@@ -1,4 +1,3 @@
-from multiprocessing import Process
 from typing import List, Optional, Tuple
 
 from vllm import EngineArgs, LLMEngine, RequestOutput, SamplingParams
@@ -107,24 +106,12 @@ def _test_llama_multilora(sql_lora_files, tp_size):
 
 
 def test_llama_multilora_1x(sql_lora_files):
-    # Work-around to resolve stalling issue in multi-card scenario
-    p = Process(target=_test_llama_multilora, args=(sql_lora_files, 1))
-    p.start()
-    p.join()
-    assert p.exitcode == 0
+    _test_llama_multilora(sql_lora_files, 1)
 
 
 def test_llama_multilora_2x(sql_lora_files):
-    # Work-around to resolve stalling issue in multi-card scenario
-    p = Process(target=_test_llama_multilora, args=(sql_lora_files, 2))
-    p.start()
-    p.join()
-    assert p.exitcode == 0
+    _test_llama_multilora(sql_lora_files, 2)
 
 
 def test_llama_multilora_4x(sql_lora_files):
-    # Work-around to resolve stalling issue in multi-card scenario
-    p = Process(target=_test_llama_multilora, args=(sql_lora_files, 4))
-    p.start()
-    p.join()
-    assert p.exitcode == 0
+    _test_llama_multilora(sql_lora_files, 4)


### PR DESCRIPTION
This PR removes additional `multiprocessing.Process` objects creates as a workaround for resolving multi card stall issue.