### PR TITLE
Dockerfile.hpu: set build type to release, add CFLAGS,CXXFLAGS

### DIFF
--- a/Dockerfile.hpu
+++ b/Dockerfile.hpu
@@ -11,6 +11,8 @@ ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
 RUN VLLM_TARGET_DEVICE=hpu \
     CMAKE_BUILD_TYPE=Release \
+    CFLAGS="-march=haswell" \
+    CXXFLAGS="$CLAGS $CXXFLAGS" \
     python3 setup.py install
 
 WORKDIR /workspace/

--- a/Dockerfile.hpu
+++ b/Dockerfile.hpu
@@ -9,7 +9,9 @@ RUN pip install -v -r requirements-hpu.txt
 ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
-RUN VLLM_TARGET_DEVICE=hpu python3 setup.py install
+RUN VLLM_TARGET_DEVICE=hpu \
+    CMAKE_BUILD_TYPE=Release \
+    python3 setup.py install
 
 WORKDIR /workspace/
 


### PR DESCRIPTION
- When not setting `CMAKE_BUILD_TYPE=Release`, the default behaviour is to build a debug version: https://github.com/HabanaAI/vllm-fork/blob/habana_main/setup.py#L126-L131
- Setting `-mhaswell` should optimize the build
