### PR TITLE
prevent multiple imports of habana_frameworks

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -8,14 +8,11 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-if importlib.util.find_spec("habana_frameworks") is None:
-   try:
-       import habana_frameworks.torch.hpu as hthpu
-   except ImportError:
-       try:
-            import vllm._C
-       except ImportError as e:
-            logger.warning("Failed to import from vllm._C with %r", e)
+try:
+    if importlib.util.find_spec("habana_frameworks") is None:
+        import vllm._C
+except ImportError as e:
+    logger.warning("Failed to import from vllm._C with %r", e)
 
 with contextlib.suppress(ImportError):
     import vllm._moe_C

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2,18 +2,20 @@ import contextlib
 import functools
 from typing import List, Optional, Tuple, Type
 import torch
+import importlib.util
 
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-try:
-    import habana_frameworks.torch.hpu as hthpu
-except ImportError:
-    try:
-        import vllm._C
-    except ImportError as e:
-        logger.warning("Failed to import from vllm._C with %r", e)
+if importlib.util.find_spec("habana_frameworks") is None:
+   try:
+       import habana_frameworks.torch.hpu as hthpu
+   except ImportError:
+       try:
+            import vllm._C
+       except ImportError as e:
+            logger.warning("Failed to import from vllm._C with %r", e)
 
 with contextlib.suppress(ImportError):
     import vllm._moe_C


### PR DESCRIPTION
when using vllm apis directly and tp>2 , it causes multiple imports of habana_frameworks resulting in a crash.
adding a check to prevent the multiple imports

issue doesnt occur when running command line tests.
issue only occurs with a diff customer when using script and calling vllm apis directly.