### PR TITLE
Remove if blocks smaller than bs in generate_decode_buckets

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -202,8 +202,6 @@ def generate_decode_buckets(bs_bucket_config, blocks_bucket_config,
     last_bucket = round_up(max_blocks, bstep)
     for bs in bs_buckets:
         for blocks in block_buckets:
-            if blocks < bs:
-                continue
             if blocks > last_bucket:
                 break
             buckets.append((bs, blocks))


### PR DESCRIPTION
With this check while running decode_block_bucket_min=128 and bs>128 it will skip buckets smaller than bs. Then during the run buckets that got skipped can be used by vllm and are being warmed-up which is causing perf drop & they are not run as hpu graphs.

This change is removing said check.