### PR TITLE
Reduce block fragmentation

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -133,33 +133,40 @@ def run_vllm(
         sampling_params.append(
             SamplingParams(
                 n=n,
-                temperature=1.0,
+                temperature=0.0,
                 top_p=1.0,
                 ignore_eos=True,
                 max_tokens=output_len,
             ))
+    # from vllm.utils import Device
+    # for i in range(5):
+    #     start = time.perf_counter()
+    #     llm.generate(prompts, sampling_params, use_tqdm=True)
+    #     end = time.perf_counter()
+        # print(llm.llm_engine.scheduler[0].block_manager.block_allocator._allocators[Device.GPU]._free_block_indices)
 
     use_beam_search = False
 
-    if not use_beam_search:
-        start = time.perf_counter()
-        llm.generate(prompts, sampling_params, use_tqdm=True)
-        end = time.perf_counter()
-    else:
-        prompts = [prompt for prompt, _, _ in requests]
-        # output_len should be the same for all requests.
-        output_len = requests[0][2]
-        for prompt, input_len, _output_len in requests:
-            assert _output_len == output_len
-        start = time.perf_counter()
-        llm.beam_search(
-            prompts,
-            BeamSearchParams(
-                beam_width=n,
-                max_tokens=output_len,
-                ignore_eos=True,
-            ))
-        end = time.perf_counter()
+    for i in range(3):
+        if not use_beam_search:
+            start = time.perf_counter()
+            llm.generate(prompts, sampling_params, use_tqdm=True)
+            end = time.perf_counter()
+        else:
+            prompts = [prompt for prompt, _, _ in requests]
+            # output_len should be the same for all requests.
+            output_len = requests[0][2]
+            for prompt, input_len, _output_len in requests:
+                assert _output_len == output_len
+            start = time.perf_counter()
+            llm.beam_search(
+                prompts,
+                BeamSearchParams(
+                    beam_width=n,
+                    max_tokens=output_len,
+                    ignore_eos=True,
+                ))
+            end = time.perf_counter()
     return end - start
 
 

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -133,40 +133,33 @@ def run_vllm(
         sampling_params.append(
             SamplingParams(
                 n=n,
-                temperature=0.0,
+                temperature=1.0,
                 top_p=1.0,
                 ignore_eos=True,
                 max_tokens=output_len,
             ))
-    # from vllm.utils import Device
-    # for i in range(5):
-    #     start = time.perf_counter()
-    #     llm.generate(prompts, sampling_params, use_tqdm=True)
-    #     end = time.perf_counter()
-        # print(llm.llm_engine.scheduler[0].block_manager.block_allocator._allocators[Device.GPU]._free_block_indices)
 
     use_beam_search = False
 
-    for i in range(3):
-        if not use_beam_search:
-            start = time.perf_counter()
-            llm.generate(prompts, sampling_params, use_tqdm=True)
-            end = time.perf_counter()
-        else:
-            prompts = [prompt for prompt, _, _ in requests]
-            # output_len should be the same for all requests.
-            output_len = requests[0][2]
-            for prompt, input_len, _output_len in requests:
-                assert _output_len == output_len
-            start = time.perf_counter()
-            llm.beam_search(
-                prompts,
-                BeamSearchParams(
-                    beam_width=n,
-                    max_tokens=output_len,
-                    ignore_eos=True,
-                ))
-            end = time.perf_counter()
+    if not use_beam_search:
+        start = time.perf_counter()
+        llm.generate(prompts, sampling_params, use_tqdm=True)
+        end = time.perf_counter()
+    else:
+        prompts = [prompt for prompt, _, _ in requests]
+        # output_len should be the same for all requests.
+        output_len = requests[0][2]
+        for prompt, input_len, _output_len in requests:
+            assert _output_len == output_len
+        start = time.perf_counter()
+        llm.beam_search(
+            prompts,
+            BeamSearchParams(
+                beam_width=n,
+                max_tokens=output_len,
+                ignore_eos=True,
+            ))
+        end = time.perf_counter()
     return end - start
 
 

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -1,4 +1,4 @@
-from collections import deque
+import heapq
 from typing import Deque, FrozenSet, Iterable, List, Optional, Tuple
 
 from vllm.core.block.common import (BlockPool, CopyOnWriteTracker, RefCounter,
@@ -6,7 +6,6 @@ from vllm.core.block.common import (BlockPool, CopyOnWriteTracker, RefCounter,
 from vllm.core.block.interfaces import Block, BlockAllocator, BlockId, Device
 
 Refcount = int
-import heapq
 
 
 class NaiveBlockAllocator(BlockAllocator):

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -6,6 +6,7 @@ from vllm.core.block.common import (BlockPool, CopyOnWriteTracker, RefCounter,
 from vllm.core.block.interfaces import Block, BlockAllocator, BlockId, Device
 
 Refcount = int
+import heapq
 
 
 class NaiveBlockAllocator(BlockAllocator):
@@ -36,7 +37,8 @@ class NaiveBlockAllocator(BlockAllocator):
         if block_ids is None:
             block_ids = range(num_blocks)
 
-        self._free_block_indices: Deque[BlockId] = deque(block_ids)
+        self._free_block_indices: Deque[BlockId] = block_ids[:]
+        heapq.heapify(self._free_block_indices)
         self._all_block_indices = frozenset(block_ids)
         assert len(self._all_block_indices) == num_blocks
 
@@ -129,7 +131,7 @@ class NaiveBlockAllocator(BlockAllocator):
         if not self._free_block_indices:
             raise BlockAllocator.NoFreeBlocksError()
 
-        block_id = self._free_block_indices.popleft()
+        block_id = heapq.heappop(self._free_block_indices)
         self._refcounter.incr(block_id)
         return block_id
 
@@ -139,7 +141,7 @@ class NaiveBlockAllocator(BlockAllocator):
 
         refcount = self._refcounter.decr(block_id)
         if refcount == 0:
-            self._free_block_indices.appendleft(block_id)
+            heapq.heappush(self._free_block_indices, block_id)
 
         block.block_id = None
 


### PR DESCRIPTION
Change `NaiveBlockAllocator` to use a priority queue so that we always allocate the lowest block id first. 

This further increases the performance of contiguous paged attention.

- [ ] Add an option or env variable to enable/disable this behavior. (Not sure if this is necessary)