### PR TITLE
Contiguous PA

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@c2801bb
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@6cb6e19

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1031,7 +1031,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 if block_mapping[b] is None:
                     block_mapping[b] = i
                     block_usage[b] = self.block_size
-        block_mapping = [b if b is not None else 0 for b in block_mapping]
+        block_mapping = [b if b is not None else -1 for b in block_mapping]
 
         for bt, sl in zip(block_tables, slot_mapping):
             if bt:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -203,7 +203,7 @@ def generate_decode_buckets(bs_bucket_config, blocks_bucket_config,
     for bs in bs_buckets:
         for blocks in block_buckets:
             if blocks > last_bucket:
-                buckets.append((bs, last_bucket))    
+                buckets.append((bs, last_bucket))
                 break
             buckets.append((bs, blocks))
     return list(sorted(buckets, key=lambda b: (b[0] * b[1], b[1], b[0])))
@@ -1008,15 +1008,13 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         max_idx = max(block_list)
         max_blocks = max(max_idx + 1, len(block_list))
         block_bucket_size = find_bucket(
-            max_blocks, self.bucketing_global_state.decode_block_bucket_cfg
-        )
-        block_bucket_size = min(
-            block_bucket_size, self.cache_config.num_gpu_blocks
-        )
+            max_blocks, self.bucketing_global_state.decode_block_bucket_cfg)
+        block_bucket_size = min(block_bucket_size,
+                                self.cache_config.num_gpu_blocks)
 
-        block_mapping = [None] * block_bucket_size
-        block_usage = [None] * block_bucket_size
-        block_scales = [None] * block_bucket_size
+        block_mapping: List[Union[None, int]] = [None] * block_bucket_size
+        block_usage: List[Union[None, int]] = [None] * block_bucket_size
+        block_scales: List[Union[None, float]] = [None] * block_bucket_size
 
         for i, bt in enumerate(block_tables):
             if bt:
@@ -1039,7 +1037,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         block_list = pad_list(block_list, block_bucket_size, _PAD_BLOCK_ID)
         block_groups = pad_list(block_mapping, block_bucket_size,
                                 len(block_tables))
-        
         block_list = torch.tensor(block_list,
                                   dtype=torch.int,
                                   device=self.device)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -199,10 +199,11 @@ def generate_decode_buckets(bs_bucket_config, blocks_bucket_config,
     bs_buckets = warmup_range(bs_bucket_config)
     block_buckets = warmup_range(blocks_bucket_config)
     bmin, bstep, bmax = blocks_bucket_config
-    last_bucket = round_up(max_blocks, bstep)
+    last_bucket = max_blocks
     for bs in bs_buckets:
         for blocks in block_buckets:
             if blocks > last_bucket:
+                buckets.append((bs, last_bucket))    
                 break
             buckets.append((bs, blocks))
     return list(sorted(buckets, key=lambda b: (b[0] * b[1], b[1], b[0])))

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1021,6 +1021,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         max_idx = max(block_list)
         max_blocks = max(max_idx + 1, len(block_list))
         block_bucket_size = find_bucket(max_blocks, self.decode_block_bucket_cfg)
+        block_bucket_size = min(block_bucket_size, self.cache_config.num_gpu_blocks)
 
         block_mapping = [None] * block_bucket_size
         block_usage = [None] * block_bucket_size
@@ -1032,7 +1033,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         block_mapping = [b if b is not None else 0 for b in block_mapping]
 
         for bt, sl in zip(block_tables, slot_mapping):
-            block_usage[bt[-1]] = sl[-1] % self.block_size + 1
+            if bt:
+                block_usage[bt[-1]] = sl[-1] % self.block_size + 1
         block_usage = [u if u is not None else 0 for u in block_usage]                
 
         block_bucket_size = find_bucket(

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1007,8 +1007,12 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         max_idx = max(block_list)
         max_blocks = max(max_idx + 1, len(block_list))
-        block_bucket_size = find_bucket(max_blocks, self.bucketing_global_state.decode_block_bucket_cfg)
-        block_bucket_size = min(block_bucket_size, self.cache_config.num_gpu_blocks)
+        block_bucket_size = find_bucket(
+            max_blocks, self.bucketing_global_state.decode_block_bucket_cfg
+        )
+        block_bucket_size = min(
+            block_bucket_size, self.cache_config.num_gpu_blocks
+        )
 
         block_mapping = [None] * block_bucket_size
         block_usage = [None] * block_bucket_size
@@ -1030,7 +1034,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         for bt, sl in zip(block_tables, slot_mapping):
             if bt:
                 block_usage[bt[-1]] = sl[-1] % self.block_size + 1
-        block_usage = [u if u is not None else 1 for u in block_usage]                
+        block_usage = [u if u is not None else 1 for u in block_usage]
 
         block_list = pad_list(block_list, block_bucket_size, _PAD_BLOCK_ID)
         block_groups = pad_list(block_mapping, block_bucket_size,


### PR DESCRIPTION
Contiguous cache fetching to avoid using costly gather operation. Requires changes in vllm-hpu-extension (https://github.com/HabanaAI/vllm-hpu-extension/pull/17) to work.

Introduces redundant calculations in decoding phase. In all tested cases improves performance over the entire run (5-12%). For even better performance cache defragmentation is required. Only compatible with v2-block-manager.