### PR TITLE
Add models-tiny CI step with Llama3.2-1B

### DIFF
--- a/.jenkins/lm-eval-harness/configs/Meta-Llama-3.2-1B-Instruct.yaml
+++ b/.jenkins/lm-eval-harness/configs/Meta-Llama-3.2-1B-Instruct.yaml
@@ -1,0 +1,15 @@
+# FIXME(kzawora): these scores were generated using vLLM on HPU, we need to confirm them on HF
+# VLLM_SKIP_WARMUP=true bash run-lm-eval-gsm-cot-llama-vllm-baseline.sh -m "/mnt/weka/data/pytorch/llama3.1/Meta-Llama-3.1-8B-Instruct" -b 128 -l 1319 -f 8 -t 1
+model_name: "/mnt/weka/data/pytorch/llama3.2/Meta-Llama-3.2-1B-Instruct/e9f8effbab1cbdc515c11ee6e098e3d5a9f51e14/"
+tasks:
+- name: "gsm8k_cot_llama"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.4572
+  - name: "exact_match,flexible-extract"
+    value: 0.4549
+limit: null
+num_fewshot: 8
+dtype: "bfloat16"
+fewshot_as_multiturn: true
+apply_chat_template: true

--- a/.jenkins/lm-eval-harness/configs/models-tiny.txt
+++ b/.jenkins/lm-eval-harness/configs/models-tiny.txt
@@ -1,0 +1,1 @@
+Meta-Llama-3.2-1B-Instruct.yaml

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -2,6 +2,14 @@
 stages:
   - name: test_gsm8k_small_models
     steps:
+      - name: gsm8k_tiny_g3_tp1
+        flavor: g3
+        command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-tiny.txt -t 1
+      - name: gsm8k_small_g2_tp1
+        flavor: g2
+        command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-tiny.txt -t 1
+  - name: test_gsm8k_small_models
+    steps:
       - name: gsm8k_small_g3_tp1
         flavor: g3
         command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1


### PR DESCRIPTION
This PR adds pipeline step with llama3.2-1b inference, executed on g2 and g3. The goal is to make a very small correctness check and if needed, fail fast before allocating more resources for the remainder of the pipeline.