### PR TITLE
Fix performance of top_p and top_k calculations

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -268,7 +268,8 @@ class Sampler(nn.Module):
         if do_top_p_top_k and flashinfer_top_k_top_p_sampling is None:
             # If we have a scalar p and k, we can use the optimized version.
             if self._scalar_p_and_k.any():
-                logits = self._apply_top_k_top_p_opt(logits, self._top_p_scalar.item(),
+                logits = self._apply_top_k_top_p_opt(logits,
+                                                     self._top_p_scalar.item(),
                                                      self._top_k_scalar.item())
             else:
                 logits = _apply_top_k_top_p(logits, sampling_tensors.top_ps,

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -267,12 +267,12 @@ class Sampler(nn.Module):
 
         if do_top_p_top_k and flashinfer_top_k_top_p_sampling is None:
             # If we have a scalar p and k, we can use the optimized version.
-            logits = torch.where(
-                self._scalar_p_and_k,
-                self._apply_top_k_top_p_opt(logits, self._top_p_scalar,
-                                            self._top_k_scalar),
-                _apply_top_k_top_p(logits, sampling_tensors.top_ps,
-                                   sampling_tensors.top_ks))
+            if self._scalar_p_and_k.any():
+                logits = self._apply_top_k_top_p_opt(logits, self._top_p_scalar.item(),
+                                                     self._top_k_scalar.item())
+            else:
+                logits = _apply_top_k_top_p(logits, sampling_tensors.top_ps,
+                                            sampling_tensors.top_ks)
 
         if do_min_p:
             logits = _apply_min_p(logits, sampling_tensors.min_ps)


### PR DESCRIPTION
This change is fixing the performance issue I have introduced in the PR #414 -- due to the usage of `torch.where` both functions have been called. Now we will run only the selected one.