### PR TITLE
Set tokenizers version to <0.20.2

### DIFF
--- a/.jenkins/requirements-test-hpu.txt
+++ b/.jenkins/requirements-test-hpu.txt
@@ -1,2 +1,3 @@
 lm_eval
 pytest
+tokenizers<0.20.2


### PR DESCRIPTION
0.20.2 had some changes that break lm_eval API