### PR TITLE
[Installation]: Avoid ModuleNotFound:setuptools-scm error

### DIFF
--- a/docs/source/getting_started/gaudi-installation.rst
+++ b/docs/source/getting_started/gaudi-installation.rst
@@ -76,6 +76,7 @@ To build and install vLLM from source, run:
 
    $ git clone https://github.com/vllm-project/vllm.git
    $ cd vllm
+   $ pip install -r requirements-hpu.txt
    $ python setup.py develop
 
 
@@ -86,6 +87,7 @@ Currently, the latest features and performance optimizations are developed in Ga
    $ git clone https://github.com/HabanaAI/vllm-fork.git
    $ cd vllm-fork
    $ git checkout habana_main
+   $ pip install -r requirements-hpu.txt
    $ python setup.py develop
 
 


### PR DESCRIPTION
Current instructions for setup using standalone docker (not using Dockerfile) is missing the pip install -r requirements-hpu.txt instruction. A new user using this method for setup will encounter :

```
File "/root/vllm/setup.py", line 15, in <module>
    from setuptools_scm import get_version
ModuleNotFoundError: No module named 'setuptools_scm'
```
This PR fixes that.