### PR TITLE
update vllm_hpu_extension commit to 24039a3

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,5 +8,5 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@0063520
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@24039a3
 


### PR DESCRIPTION
to fix part of the https://github.com/HabanaAI/vllm-fork/issues/443

update the vllm_hpu_extension commit id to https://github.com/HabanaAI/vllm-hpu-extension/pull/26/commits/24039a3e0abc9f1b90345018ccab5c711e6c042a

