### PR TITLE
Add async copying to input preparation

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -963,19 +963,19 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         else:
             prefix_block_list_tensor = None
 
-        input_tokens = make_tensor_with_pad(input_tokens,
+        input_tokens = make_tensor_with_pad(input_tokens,  # type: ignore
                                             max_len=max_prompt_len,
                                             pad=0,
                                             dtype=torch.long,
                                             device='cpu')
 
-        input_positions = make_tensor_with_pad(input_positions,
+        input_positions = make_tensor_with_pad(input_positions,  # type: ignore
                                                max_len=max_prompt_len,
                                                pad=0,
                                                dtype=torch.long,
                                                device='cpu')
 
-        slot_mapping = make_tensor_with_pad(slot_mapping,
+        slot_mapping = make_tensor_with_pad(slot_mapping,  # type: ignore
                                             max_len=max_prompt_len,
                                             pad=_PAD_SLOT_ID,
                                             dtype=torch.long,
@@ -1102,14 +1102,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 block_tables.append(block_table)
 
         if output is None:
-            input_tokens = torch.tensor(input_tokens,
+            input_tokens = torch.tensor(input_tokens,  # type: ignore
                                         dtype=torch.long,
                                         device='cpu')
         else:
             real_batch_size = len(seq_group_metadata_list)
             input_tokens = output[:real_batch_size]
 
-        input_positions = torch.tensor(input_positions,
+        input_positions = torch.tensor(input_positions,  # type: ignore
                                        dtype=torch.long,
                                        device='cpu')
 
@@ -1153,16 +1153,16 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         block_groups = padding_fn(block_groups, -1)
         block_usage = padding_fn(block_usage, 1)
 
-        block_list = torch.tensor(block_list,
+        block_list = torch.tensor(block_list,  # type: ignore
                                   dtype=torch.int,
                                   device='cpu')
-        block_groups = torch.tensor(block_groups,
+        block_groups = torch.tensor(block_groups,  # type: ignore
                                     dtype=torch.int,
                                     device='cpu')
-        block_usage = torch.tensor(block_usage,
+        block_usage = torch.tensor(block_usage,  # type: ignore
                                    dtype=self.model_config.dtype,
                                    device='cpu')
-        slot_mapping = torch.tensor(slot_mapping,
+        slot_mapping = torch.tensor(slot_mapping,  # type: ignore
                                     dtype=torch.long,
                                     device='cpu')
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -963,19 +963,19 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         else:
             prefix_block_list_tensor = None
 
-        input_tokens = make_tensor_with_pad(input_tokens,  # type: ignore
+        input_tokens = make_tensor_with_pad(input_tokens,
                                             max_len=max_prompt_len,
                                             pad=0,
                                             dtype=torch.long,
                                             device='cpu')
 
-        input_positions = make_tensor_with_pad(input_positions,  # type: ignore
+        input_positions = make_tensor_with_pad(input_positions,
                                                max_len=max_prompt_len,
                                                pad=0,
                                                dtype=torch.long,
                                                device='cpu')
 
-        slot_mapping = make_tensor_with_pad(slot_mapping,  # type: ignore
+        slot_mapping = make_tensor_with_pad(slot_mapping,
                                             max_len=max_prompt_len,
                                             pad=_PAD_SLOT_ID,
                                             dtype=torch.long,
@@ -992,10 +992,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if prefix_block_list_tensor:
             prefix_block_list_tensor = prefix_block_list_tensor.to(
               self.device, non_blocking=True)
-        input_tokens = input_tokens.to(self.device, non_blocking=True)
-        input_positions = input_positions.to(self.device, non_blocking=True)
-        slot_mapping = slot_mapping.to(self.device, non_blocking=True)
-        seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
+        input_tokens = input_tokens.to(  # type: ignore
+            self.device, non_blocking=True)
+        input_positions = input_positions.to(  # type: ignore
+            self.device, non_blocking=True)
+        slot_mapping = slot_mapping.to(  # type: ignore
+            self.device, non_blocking=True)
+        seq_lens_tensor = seq_lens_tensor.to(
+            self.device, non_blocking=True)
         context_lens_tensor = context_lens_tensor.to(
           self.device, non_blocking=True)
 
@@ -1102,14 +1106,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 block_tables.append(block_table)
 
         if output is None:
-            input_tokens = torch.tensor(input_tokens,  # type: ignore
+            input_tokens = torch.tensor(input_tokens,
                                         dtype=torch.long,
                                         device='cpu')
         else:
             real_batch_size = len(seq_group_metadata_list)
             input_tokens = output[:real_batch_size]
 
-        input_positions = torch.tensor(input_positions,  # type: ignore
+        input_positions = torch.tensor(input_positions,
                                        dtype=torch.long,
                                        device='cpu')
 
@@ -1153,25 +1157,31 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         block_groups = padding_fn(block_groups, -1)
         block_usage = padding_fn(block_usage, 1)
 
-        block_list = torch.tensor(block_list,  # type: ignore
+        block_list = torch.tensor(block_list,
                                   dtype=torch.int,
                                   device='cpu')
-        block_groups = torch.tensor(block_groups,  # type: ignore
+        block_groups = torch.tensor(block_groups,
                                     dtype=torch.int,
                                     device='cpu')
-        block_usage = torch.tensor(block_usage,  # type: ignore
+        block_usage = torch.tensor(block_usage,
                                    dtype=self.model_config.dtype,
                                    device='cpu')
-        slot_mapping = torch.tensor(slot_mapping,  # type: ignore
+        slot_mapping = torch.tensor(slot_mapping,
                                     dtype=torch.long,
                                     device='cpu')
 
-        input_tokens = input_tokens.to(self.device, non_blocking=True)
-        input_positions = input_positions.to(self.device, non_blocking=True)
-        block_list = block_list.to(self.device, non_blocking=True)
-        block_groups = block_groups.to(self.device, non_blocking=True)
-        block_usage = block_usage.to(self.device, non_blocking=True)
-        slot_mapping = slot_mapping.to(self.device, non_blocking=True)
+        input_tokens = input_tokens.to(  # type: ignore
+            self.device, non_blocking=True)
+        input_positions = input_positions.to(  # type: ignore
+            self.device, non_blocking=True)
+        block_list = block_list.to(  # type: ignore
+            self.device, non_blocking=True)
+        block_groups = block_groups.to(  # type: ignore
+            self.device, non_blocking=True)
+        block_usage = block_usage.to(  # type: ignore
+            self.device, non_blocking=True)
+        slot_mapping = slot_mapping.to(  # type: ignore
+            self.device, non_blocking=True)
 
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=False,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -960,7 +960,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
             prefix_block_list_tensor = torch.tensor(prefix_block_list,
                                                     dtype=torch.long,
-                                                    device='cpu')
+                                                    device='cpu',
+                                                    pin_memory=self.pin_memory)
         else:
             prefix_block_list_tensor = None
 
@@ -968,27 +969,32 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                             max_len=max_prompt_len,
                                             pad=0,
                                             dtype=torch.long,
-                                            device='cpu')
+                                            device='cpu',
+                                            pin_memory=self.pin_memory)
 
         input_positions = make_tensor_with_pad(input_positions,
                                                max_len=max_prompt_len,
                                                pad=0,
                                                dtype=torch.long,
-                                               device='cpu')
+                                               device='cpu',
+                                               pin_memory=self.pin_memory)
 
         slot_mapping = make_tensor_with_pad(slot_mapping,
                                             max_len=max_prompt_len,
                                             pad=_PAD_SLOT_ID,
                                             dtype=torch.long,
-                                            device='cpu')
+                                            device='cpu',
+                                            pin_memory=self.pin_memory)
 
         seq_lens_tensor = torch.tensor(seq_lens,
                                        dtype=torch.long,
-                                       device='cpu')
+                                       device='cpu',
+                                       pin_memory=self.pin_memory)
 
         context_lens_tensor = torch.tensor(context_lens,
                                            dtype=torch.long,
-                                           device='cpu')
+                                           device='cpu',
+                                           pin_memory=self.pin_memory)
 
         if prefix_block_list_tensor:
             prefix_block_list_tensor = prefix_block_list_tensor.to(
@@ -1108,14 +1114,16 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if output is None:
             input_tokens = torch.tensor(input_tokens,
                                         dtype=torch.long,
-                                        device='cpu')
+                                        device='cpu',
+                                        pin_memory=self.pin_memory)
         else:
             real_batch_size = len(seq_group_metadata_list)
             input_tokens = output[:real_batch_size]
 
         input_positions = torch.tensor(input_positions,
                                        dtype=torch.long,
-                                       device='cpu')
+                                       device='cpu',
+                                       pin_memory=self.pin_memory)
 
         num_decode_tokens = sum(seq_lens)
 
@@ -1157,16 +1165,22 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         block_groups = padding_fn(block_groups, -1)
         block_usage = padding_fn(block_usage, 1)
 
-        block_list = torch.tensor(block_list, dtype=torch.int, device='cpu')
+        block_list = torch.tensor(block_list,
+                                  dtype=torch.int,
+                                  device='cpu',
+                                  pin_memory=self.pin_memory)
         block_groups = torch.tensor(block_groups,
                                     dtype=torch.int,
-                                    device='cpu')
+                                    device='cpu',
+                                    pin_memory=self.pin_memory)
         block_usage = torch.tensor(block_usage,
                                    dtype=self.model_config.dtype,
-                                   device='cpu')
+                                   device='cpu',
+                                   pin_memory=self.pin_memory)
         slot_mapping = torch.tensor(slot_mapping,
                                     dtype=torch.long,
-                                    device='cpu')
+                                    device='cpu',
+                                    pin_memory=self.pin_memory)
 
         input_tokens = input_tokens.to(  # type: ignore
             self.device, non_blocking=True)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -960,8 +960,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
             prefix_block_list_tensor = torch.tensor(prefix_block_list,
                                                     dtype=torch.long,
-                                                    device='cpu',
-                                                    pin_memory=self.pin_memory)
+                                                    device='cpu')
         else:
             prefix_block_list_tensor = None
 
@@ -969,32 +968,27 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                             max_len=max_prompt_len,
                                             pad=0,
                                             dtype=torch.long,
-                                            device='cpu',
-                                            pin_memory=self.pin_memory)
+                                            device='cpu')
 
         input_positions = make_tensor_with_pad(input_positions,
                                                max_len=max_prompt_len,
                                                pad=0,
                                                dtype=torch.long,
-                                               device='cpu',
-                                               pin_memory=self.pin_memory)
+                                               device='cpu')
 
         slot_mapping = make_tensor_with_pad(slot_mapping,
                                             max_len=max_prompt_len,
                                             pad=_PAD_SLOT_ID,
                                             dtype=torch.long,
-                                            device='cpu',
-                                            pin_memory=self.pin_memory)
+                                            device='cpu')
 
         seq_lens_tensor = torch.tensor(seq_lens,
                                        dtype=torch.long,
-                                       device='cpu',
-                                       pin_memory=self.pin_memory)
+                                       device='cpu')
 
         context_lens_tensor = torch.tensor(context_lens,
                                            dtype=torch.long,
-                                           device='cpu',
-                                           pin_memory=self.pin_memory)
+                                           device='cpu')
 
         if prefix_block_list_tensor:
             prefix_block_list_tensor = prefix_block_list_tensor.to(
@@ -1114,16 +1108,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if output is None:
             input_tokens = torch.tensor(input_tokens,
                                         dtype=torch.long,
-                                        device='cpu',
-                                        pin_memory=self.pin_memory)
+                                        device='cpu')
         else:
             real_batch_size = len(seq_group_metadata_list)
             input_tokens = output[:real_batch_size]
 
         input_positions = torch.tensor(input_positions,
                                        dtype=torch.long,
-                                       device='cpu',
-                                       pin_memory=self.pin_memory)
+                                       device='cpu')
 
         num_decode_tokens = sum(seq_lens)
 
@@ -1165,22 +1157,16 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         block_groups = padding_fn(block_groups, -1)
         block_usage = padding_fn(block_usage, 1)
 
-        block_list = torch.tensor(block_list,
-                                  dtype=torch.int,
-                                  device='cpu',
-                                  pin_memory=self.pin_memory)
+        block_list = torch.tensor(block_list, dtype=torch.int, device='cpu')
         block_groups = torch.tensor(block_groups,
                                     dtype=torch.int,
-                                    device='cpu',
-                                    pin_memory=self.pin_memory)
+                                    device='cpu')
         block_usage = torch.tensor(block_usage,
                                    dtype=self.model_config.dtype,
-                                   device='cpu',
-                                   pin_memory=self.pin_memory)
+                                   device='cpu')
         slot_mapping = torch.tensor(slot_mapping,
                                     dtype=torch.long,
-                                    device='cpu',
-                                    pin_memory=self.pin_memory)
+                                    device='cpu')
 
         input_tokens = input_tokens.to(  # type: ignore
             self.device, non_blocking=True)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -278,17 +278,6 @@ def flatten(in_list):
     return list(itertools.chain(*in_list))
 
 
-def precompute_indices_and_offsets(block_size, slot_mapping, is_prompt):
-    slot_mapping = slot_mapping.flatten()
-    indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
-    if is_prompt:
-        indices = indices.unflatten(0, (-1, block_size))[:, 0]
-        offsets = None
-    else:
-        offsets = torch.fmod(slot_mapping, block_size)
-    return indices, offsets
-
-
 class HpuModelAdapter:
 
     def __init__(self, model, block_size, dtype, enforce_eager):
@@ -382,6 +371,18 @@ class HpuModelAdapter:
         metadata = metadata._replace(block_scales=block_scales)
         return metadata
 
+    def _set_indices_and_offsets(self, metadata, block_size, is_prompt):
+        slot_mapping = metadata.slot_mapping.flatten()
+        indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
+        if is_prompt:
+            indices = indices.unflatten(0, (-1, block_size))[:, 0]
+            offsets = None
+        else:
+            offsets = torch.fmod(slot_mapping, block_size)
+        metadata = metadata._replace(block_offsets=offsets)
+        metadata = metadata._replace(block_indices=indices)
+        return metadata
+
     def _update_metadata(self, attn_metadata, batch_size, seq_len, device,
                          dtype):
         if attn_metadata.is_prompt:
@@ -391,6 +392,8 @@ class HpuModelAdapter:
             attn_metadata = self._set_block_mapping(attn_metadata, batch_size,
                                                     device, dtype)
             attn_metadata = self._set_block_scales(attn_metadata, device)
+        attn_metadata = self._set_indices_and_offsets(
+            attn_metadata, self.block_size, attn_metadata.is_prompt)
         return attn_metadata
 
     def forward(self, *args, **kwargs):
@@ -956,7 +959,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
             prefix_block_list_tensor = torch.tensor(prefix_block_list,
                                                     dtype=torch.long,
-                                                    device=self.device)
+                                                    device='cpu')
         else:
             prefix_block_list_tensor = None
 
@@ -964,37 +967,43 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                             max_len=max_prompt_len,
                                             pad=0,
                                             dtype=torch.long,
-                                            device=self.device)
+                                            device='cpu')
 
         input_positions = make_tensor_with_pad(input_positions,
                                                max_len=max_prompt_len,
                                                pad=0,
                                                dtype=torch.long,
-                                               device=self.device)
+                                               device='cpu')
 
         slot_mapping = make_tensor_with_pad(slot_mapping,
                                             max_len=max_prompt_len,
                                             pad=_PAD_SLOT_ID,
                                             dtype=torch.long,
-                                            device=self.device)
+                                            device='cpu')
 
         seq_lens_tensor = torch.tensor(seq_lens,
                                        dtype=torch.long,
-                                       device=self.device)
+                                       device='cpu')
 
         context_lens_tensor = torch.tensor(context_lens,
                                            dtype=torch.long,
-                                           device=self.device)
+                                           device='cpu')
 
-        block_indices, block_offsets = precompute_indices_and_offsets(
-            self.block_size, slot_mapping, True)
+        if prefix_block_list_tensor:
+            prefix_block_list_tensor = prefix_block_list_tensor.to(self.device, non_blocking=True)
+        input_tokens = input_tokens.to(self.device, non_blocking=True)
+        input_positions = input_positions.to(self.device, non_blocking=True)
+        slot_mapping = slot_mapping.to(self.device, non_blocking=True)
+        seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
+        context_lens_tensor = context_lens_tensor.to(self.device, non_blocking=True)
+
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=True,
             block_list=prefix_block_list_tensor,
             block_mapping=None,
             block_usage=None,
-            block_indices=block_indices,
-            block_offsets=block_offsets,
+            block_indices=None,
+            block_offsets=None,
             block_scales=None,
             block_groups=None,
             attn_bias=None,
@@ -1093,14 +1102,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if output is None:
             input_tokens = torch.tensor(input_tokens,
                                         dtype=torch.long,
-                                        device=self.device)
+                                        device='cpu')
         else:
             real_batch_size = len(seq_group_metadata_list)
             input_tokens = output[:real_batch_size]
 
         input_positions = torch.tensor(input_positions,
                                        dtype=torch.long,
-                                       device=self.device)
+                                       device='cpu')
 
         num_decode_tokens = sum(seq_lens)
 
@@ -1143,27 +1152,31 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         block_list = torch.tensor(block_list,
                                   dtype=torch.int,
-                                  device=self.device)
+                                  device='cpu')
         block_groups = torch.tensor(block_groups,
                                     dtype=torch.int,
-                                    device=self.device)
+                                    device='cpu')
         block_usage = torch.tensor(block_usage,
                                    dtype=self.model_config.dtype,
-                                   device=self.device)
+                                   device='cpu')
         slot_mapping = torch.tensor(slot_mapping,
                                     dtype=torch.long,
-                                    device=self.device)
+                                    device='cpu')
 
-        block_indices, block_offsets = precompute_indices_and_offsets(
-            self.block_size, slot_mapping, False)
+        input_tokens = input_tokens.to(self.device, non_blocking=True)
+        input_positions = input_positions.to(self.device, non_blocking=True)
+        block_list = block_list.to(self.device, non_blocking=True)
+        block_groups = block_groups.to(self.device, non_blocking=True)
+        block_usage = block_usage.to(self.device, non_blocking=True)
+        slot_mapping = slot_mapping.to(self.device, non_blocking=True)
 
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=False,
             block_list=block_list,
             block_mapping=None,
             block_usage=block_usage,
-            block_indices=block_indices,
-            block_offsets=block_offsets,
+            block_indices=None,
+            block_offsets=None,
             block_scales=None,
             block_groups=block_groups,
             attn_bias=None,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -379,7 +379,7 @@ class HpuModelAdapter:
             offsets = None
         else:
             offsets = torch.fmod(slot_mapping, block_size)
-        metadata = metadata._replace(block_offsets=offsets, 
+        metadata = metadata._replace(block_offsets=offsets,
                                      block_indices=indices)
         return metadata
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -392,8 +392,8 @@ class HpuModelAdapter:
             attn_metadata = self._set_block_mapping(attn_metadata, batch_size,
                                                     device, dtype)
             attn_metadata = self._set_block_scales(attn_metadata, device)
-        attn_metadata = self._set_indices_and_offsets(attn_metadata, 
-                                                      self.block_size, 
+        attn_metadata = self._set_indices_and_offsets(attn_metadata,
+                                                      self.block_size,
                                                       attn_metadata.is_prompt)
         return attn_metadata
 
@@ -1000,7 +1000,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         slot_mapping = slot_mapping.to(  # type: ignore
             self.device, non_blocking=True)
         seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
-        context_lens_tensor = context_lens_tensor.to(self.device, 
+        context_lens_tensor = context_lens_tensor.to(self.device,
                                                      non_blocking=True)
 
         attn_metadata = self.attn_backend.make_metadata(

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -379,8 +379,8 @@ class HpuModelAdapter:
             offsets = None
         else:
             offsets = torch.fmod(slot_mapping, block_size)
-        metadata = metadata._replace(block_offsets=offsets)
-        metadata = metadata._replace(block_indices=indices)
+        metadata = metadata._replace(block_offsets=offsets, 
+                                     block_indices=indices)
         return metadata
 
     def _update_metadata(self, attn_metadata, batch_size, seq_len, device,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -990,12 +990,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                            device='cpu')
 
         if prefix_block_list_tensor:
-            prefix_block_list_tensor = prefix_block_list_tensor.to(self.device, non_blocking=True)
+            prefix_block_list_tensor = prefix_block_list_tensor.to(
+              self.device, non_blocking=True)
         input_tokens = input_tokens.to(self.device, non_blocking=True)
         input_positions = input_positions.to(self.device, non_blocking=True)
         slot_mapping = slot_mapping.to(self.device, non_blocking=True)
         seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
-        context_lens_tensor = context_lens_tensor.to(self.device, non_blocking=True)
+        context_lens_tensor = context_lens_tensor.to(
+          self.device, non_blocking=True)
 
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=True,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -392,8 +392,9 @@ class HpuModelAdapter:
             attn_metadata = self._set_block_mapping(attn_metadata, batch_size,
                                                     device, dtype)
             attn_metadata = self._set_block_scales(attn_metadata, device)
-        attn_metadata = self._set_indices_and_offsets(
-            attn_metadata, self.block_size, attn_metadata.is_prompt)
+        attn_metadata = self._set_indices_and_offsets(attn_metadata, 
+                                                      self.block_size, 
+                                                      attn_metadata.is_prompt)
         return attn_metadata
 
     def forward(self, *args, **kwargs):
@@ -991,17 +992,16 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         if prefix_block_list_tensor:
             prefix_block_list_tensor = prefix_block_list_tensor.to(
-              self.device, non_blocking=True)
+                self.device, non_blocking=True)
         input_tokens = input_tokens.to(  # type: ignore
             self.device, non_blocking=True)
         input_positions = input_positions.to(  # type: ignore
             self.device, non_blocking=True)
         slot_mapping = slot_mapping.to(  # type: ignore
             self.device, non_blocking=True)
-        seq_lens_tensor = seq_lens_tensor.to(
-            self.device, non_blocking=True)
-        context_lens_tensor = context_lens_tensor.to(
-          self.device, non_blocking=True)
+        seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
+        context_lens_tensor = context_lens_tensor.to(self.device, 
+                                                     non_blocking=True)
 
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=True,
@@ -1157,9 +1157,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         block_groups = padding_fn(block_groups, -1)
         block_usage = padding_fn(block_usage, 1)
 
-        block_list = torch.tensor(block_list,
-                                  dtype=torch.int,
-                                  device='cpu')
+        block_list = torch.tensor(block_list, dtype=torch.int, device='cpu')
         block_groups = torch.tensor(block_groups,
                                     dtype=torch.int,
                                     device='cpu')


### PR DESCRIPTION
This PR introduces async copying into _prepare_prompt and _prepare_decode, which makes copying faster.
It also moves precompute_indices_and_offsets funtion into forward to avoid unnecessary H2D copying.