### PR TITLE
Enable patching matmuls in block2batch and batch2block

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,5 +8,5 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@0063520
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@250622e
 

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -113,6 +113,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         self.matmul_qk = Matmul()
         self.softmax = Softmax()
         self.matmul_av = Matmul()
+        self.batch2block_matmul = Matmul()
+        self.block2batch_matmul = Matmul()
         self.k_cache = VLLMKVCache()
         self.v_cache = VLLMKVCache()
         self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
@@ -251,6 +253,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                 scale=self.scale,
                 matmul_qk_op=self.matmul_qk,
                 matmul_av_op=self.matmul_av,
+                batch2block_matmul_op=self.batch2block_matmul,
+                block2batch_matmul_op=self.block2batch_matmul,
                 keys_fetch_func=self.k_cache.fetch_from_cache,
                 values_fetch_func=self.v_cache.fetch_from_cache)
         # Reshape the output tensor.


### PR DESCRIPTION
Enable patching matmuls in block2batch and batch2block, only for the batch2block before the qk_matmul and the block2batch after the av_matmul.