### PR TITLE
[BUG FIX] [SPEC DECODE] 0.6.4 rebase cause incorrectness in spec decode, fix in this PR

### DIFF
--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -44,3 +44,8 @@ stages:
       - name: gsm8k_small_g2_tp2_mss
         flavor: g2.s
         command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-mss.txt -t 2
+  - name: test_gsm8k_spec_decode
+    steps:
+      - name: gsm8k_small_g2_tp1_spec_decode
+        flavor: g2
+        command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-mss.txt -t 1

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -346,9 +346,9 @@ class DefaultModelLoader(BaseModelLoader):
             if model_config.quantization is None and loaded_weights is not None:
                 weights_not_loaded = weights_to_load - loaded_weights
                 if weights_not_loaded:
-                    raise ValueError(
-                        "Following weights were not initialized from "
-                        f"checkpoint: {weights_not_loaded}")
+                    logger.warning(
+                        "Following weights were not initialized from ",
+                        "checkpoint:", weights_not_loaded)
 
             for _, module in model.named_modules():
                 quant_method = getattr(module, "quant_method", None)

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -346,9 +346,10 @@ class DefaultModelLoader(BaseModelLoader):
             if model_config.quantization is None and loaded_weights is not None:
                 weights_not_loaded = weights_to_load - loaded_weights
                 if weights_not_loaded:
-                    logger.warning(
-                        "Following weights were not initialized from ",
-                        "checkpoint:", weights_not_loaded)
+                    warning_msg = f"Following weights were not initialized \
+                            from checkpoint: {weights_not_loaded}"
+
+                    logger.warning(warning_msg)
 
             for _, module in model.named_modules():
                 quant_method = getattr(module, "quant_method", None)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -660,6 +660,11 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self._set_gc_threshold()
         self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
                                                 'true').lower() == 'true'
+        if vllm_config.speculative_config is not None \
+            and self.use_contiguous_pa:
+            raise ValueError(
+                "Speculative decoding is not supported with "
+                "contiguous PA, please set VLLM_CONTIGUOUS_PA=false")
         # For multi-step scheduling
         self.cached_step_outputs: List[torch.Tensor] = []
 

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -71,6 +71,11 @@ class HPUWorker(LocalOrDistributedWorkerBase):
                 not in ["medusa", "mlp_speculator", "eagle"]) \
                     else {"return_hidden_states": True}
 
+        # use VLLM_CONTIGUOUS_PA=false for speculative decoding
+        # otherwise, result is faulty
+        if speculative_config is not None:
+            os.environ["VLLM_CONTIGUOUS_PA"] = "false"
+
         ModelRunnerClass: Type[HPUModelRunner] = HPUModelRunner
         if model_runner_cls is not None:
             ModelRunnerClass = model_runner_cls

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -71,11 +71,6 @@ class HPUWorker(LocalOrDistributedWorkerBase):
                 not in ["medusa", "mlp_speculator", "eagle"]) \
                     else {"return_hidden_states": True}
 
-        # use VLLM_CONTIGUOUS_PA=false for speculative decoding
-        # otherwise, result is faulty
-        if speculative_config is not None:
-            os.environ["VLLM_CONTIGUOUS_PA"] = "false"
-
         ModelRunnerClass: Type[HPUModelRunner] = HPUModelRunner
         if model_runner_cls is not None:
             ModelRunnerClass = model_runner_cls


### PR DESCRIPTION
Noticed that Spec Decode went incorrect after rebase to 0.6.4

Identified root cause and fixed in the PR
1. incorrect return value position in batch_expansion.py
2. ContinuousPA generates faulty result in spec decode

CI added: https://github.com/HabanaAI/vllm-fork/pull/524