### PR TITLE
[HPU] Add mark_step configurable for the decoder layer. 

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -328,9 +328,6 @@ class Qwen2Model(nn.Module):
                 attn_metadata,
                 residual,
             )
-            if current_platform.is_hpu():
-                htorch.core.mark_step()
-
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({
                 "hidden_states": hidden_states,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -279,10 +279,11 @@ def flatten(in_list):
 
 
 def get_decoder_layer_suffix(model_type):
-    # This sets the suffix for the hidden layer name which is controlled by VLLM_CONFIG_HIDDEN_LAYERS.
-    # The default suffix is "DecoderLayer," which is applicable for most language models such as LLaMA, Qwen, and BART.
-    # If the model's decoder layer name differs from the default, it will need to be specified here.
-    # For example, for the GPT-BigCode model, this value should be set to "BigCodeBlock".
+    # This sets the suffix for the hidden layer name, which is controlled by
+    # VLLM_CONFIG_HIDDEN_LAYERS. The default suffix is "DecoderLayer," which is
+    # applicable for most language models such as LLaMA, Qwen, and BART. If the
+    # model's decoder layer name differs from the default, it will need to
+    # be specified here.
     decoder_layer_table = {
         "gpt_bigcode": "BigCodeBlock",
     }

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -765,12 +765,12 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 self.model = self.model.to("hpu")
                 htcore.mark_step()
 
-            hidden_layer_markstep = int(
+            hidden_layer_markstep_interval = int(
                 os.getenv('VLLM_CONFIG_HIDDEN_LAYERS', '1'))
             hideen_layer_suffix = os.getenv('VLLM_CONFIG_HIDDEN_LAYERS_SUFFIX',
-                                            'DecodeLayer')
+                                            'DecoderLayer')
             modify_decoder_layer(self.model, hideen_layer_suffix,
-                                 hidden_layer_markstep)
+                                 hidden_layer_markstep_interval)
             torch.hpu.synchronize()
 
             with HabanaMemoryProfiler() as m_wrap:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -277,10 +277,18 @@ def gather_list(input, indices, v):
 def flatten(in_list):
     return list(itertools.chain(*in_list))
 
-def modify_decoder_layer(module: torch.nn.Module,  n=1, counter=[0], suffix="DecoderLayer"):
+
+def modify_decoder_layer(module: torch.nn.Module,
+                         n=1,
+                         counter=None,
+                         suffix="DecoderLayer"):
+
     def forward_hook(module, args, output):
         htorch.core.mark_step()
         return output
+
+    if counter is None:
+        counter = [0]
 
     for child_name, child_module in module.named_children():
         if child_module.__class__.__name__.endswith(suffix):
@@ -288,7 +296,8 @@ def modify_decoder_layer(module: torch.nn.Module,  n=1, counter=[0], suffix="Dec
             if counter[0] % n == 0:
                 child_module.register_forward_hook(forward_hook)
         else:
-            modify_decoder_layer(child_module,  n, counter)
+            modify_decoder_layer(child_module, n, counter)
+
 
 class HpuModelAdapter:
 


### PR DESCRIPTION
We are seeing 10% performance regression in the llama-based model due to https://github.com/vllm-project/vllm/pull/10239. The mark_step() function needs to be configured differently for each model to achieve the best performance. For some models, mark_step() for every decoder step would be optimal, but for other models, it's better to run it every n-th step. We are adding a counter to only register the hook for every n-th step, which can be configured with VLLM_CONFIG_HIDDEN_LAYERS

