### PR TITLE
Skip empty steps in multi step sheduling

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2235,7 +2235,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         for i, seq_group_metadata in enumerate(
                                 seq_group_metadata_list):
                             # Skip empty steps
-                            seq_group_metadata.state.current_step += (num_steps - 2)
+                            seq_group_metadata.state.current_step += (
+                                num_steps - 2)
                             # Cache the original output token ids
                             cache_orig_output_tokens_len.append({})
                             for j, data in seq_group_metadata.seq_data.items():

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2232,9 +2232,11 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         else:
                             raise RuntimeError(
                                 "seq_group_metadata_list is uninitialized")
-                        # Cache the original output token ids
                         for i, seq_group_metadata in enumerate(
                                 seq_group_metadata_list):
+                            # Skip empty steps
+                            seq_group_metadata.state.current_step += (num_steps - 2)
+                            # Cache the original output token ids
                             cache_orig_output_tokens_len.append({})
                             for j, data in seq_group_metadata.seq_data.items():
                                 cache_orig_output_tokens_len[i][j] = \


### PR DESCRIPTION
This change allows to skip empty steps in multistep scenario. We are currently wasting host time on launching n-2 empty steps.
This PR removes it. The gain will be visible after device time optimizations, as we are currently limited by HPU calculations inside multistep.