### PR TITLE
Multilora regression test (compile mode) fix

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -352,6 +352,8 @@ class LlamaModel(nn.Module):
                                             kv_caches[i - self.start_layer],
                                             attn_metadata, residual)
             if is_hpu and i % self.config_hidden_layers == 0:
+                torch._dynamo.graph_break()
+            else:
                 htorch.core.mark_step()
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -352,9 +352,10 @@ class LlamaModel(nn.Module):
                                             kv_caches[i - self.start_layer],
                                             attn_metadata, residual)
             if is_hpu and i % self.config_hidden_layers == 0:
-                torch._dynamo.graph_break()
-            else:
-                htorch.core.mark_step()
+                if htorch.utils.internal.is_lazy():
+                    htorch.core.mark_step()
+                else:
+                    torch._dynamo.graph_break()
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({
                 "hidden_states": hidden_states,


### PR DESCRIPTION
This PR adds dynamo graph breaks after each decoder layer to fix the regression (incorrect output) in multi-lora unit test.
