### PR TITLE
[BUG_FIX] 405B WARMUP failed on "FATAL ERROR :: MODULE:PT_LAZY Error, ValidateSyncInputTensors tensor_data is empty"

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -204,7 +204,7 @@ def generate_decode_buckets(bs_bucket_config, blocks_bucket_config,
     bs_buckets = warmup_range(bs_bucket_config)
     block_buckets = warmup_range(blocks_bucket_config)
     bmin, bstep, bmax = blocks_bucket_config
-    last_bucket = max_blocks
+    last_bucket = round_up(max_blocks, bstep)
     for bs in bs_buckets:
         for blocks in block_buckets:
             if blocks >= last_bucket:


### PR DESCRIPTION
Fix an error report when warming up 405B model

==== Background ====
Mlperf team met this error when running 405B FP8 model on 8cards G2, due to insufficient device memory, last bucket got a faulty size as 2862, which is N * block_size and did not round up.
This later triggers an error that fetched K, V can not apply with block_bias.
```
block_bias shape is [3072, 128]
key is fetched based on block_list and shape is [2862, 128, ...]
```


