### PR TITLE
fix Mixtral8x7b torch.compile multinode recompilations

### DIFF
--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -5,7 +5,3 @@ from .interface import Platform, PlatformEnum
 
 class HpuPlatform(Platform):
     _enum = PlatformEnum.HPU
-
-    @staticmethod
-    def inference_mode():
-        return torch.no_grad()

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -272,7 +272,7 @@ def precompute_indices_and_offsets(block_size, slot_mapping, is_prompt):
     slot_mapping = slot_mapping.flatten()
     indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
     if is_prompt:
-        indices = indices.unflatten(0, (-1, block_size))[:, 0]
+        indices = indices.unflatten(0, (-1, block_size))[:, 0].clone()
         offsets = None
     else:
         offsets = torch.fmod(slot_mapping, block_size)


### PR DESCRIPTION
FIX [SW-210801]
Remove recompilations for Mixtral8x7b model when running with torch.compile:
- torch.inference mode is enabled during warmup, but not during inference due to being overwritten with torch.no_grad - results in recompilation due to mismatch in dispatch keys
- block_indices are created as a view by indexing, what results in recompilations due to the mismatch in strides after warmup

