### PR TITLE
Set vllm-hpu-extension to 50e10ea

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,5 +8,5 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@ac9740d
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@50e10ea
 neural-compressor @ git+https://github.com/intel/neural-compressor.git@b196432


### PR DESCRIPTION
Update vllm-hpu-extension to 50e10ea, that introduces PipelinedPA:
https://github.com/HabanaAI/vllm-hpu-extension/pull/42