### PR TITLE
Set vllm-hpu-extension to fb36408

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,5 +8,5 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@bc01901
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@fb36408
 neural-compressor @ git+https://github.com/intel/neural-compressor.git@b196432


### PR DESCRIPTION
Set vllm-hpu-extension to fb36408, that includes support for non-GQA workloads in PipelinedPA