### PR TITLE
Regional compilation support

### DIFF
--- a/README_GAUDI.md
+++ b/README_GAUDI.md
@@ -247,6 +247,7 @@ INFO 08-02 17:38:43 hpu_executor.py:91] init_cache_engine took 37.92 GiB of devi
 - `VLLM_HPU_LOG_STEP_GRAPH_COMPILATION_ALL`: if `true`, will log graph compilations per each vLLM engine step, always, even if there were none. Disabled by default.
 - `VLLM_HPU_LOG_STEP_CPU_FALLBACKS`: if `true`, will log cpu fallbacks per each vLLM engine step, only when there was any. Disabled by default.
 - `VLLM_HPU_LOG_STEP_CPU_FALLBACKS_ALL`: if `true`, will log cpu fallbacks per each vLLM engine step, always, even if there were none. Disabled by default.
+- `VLLM_REGIONAL_COMPILATION`: if `false`, turn off regional complation (when using torch.compile execution mode).
 
 **Performance tuning knobs:**
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -178,7 +178,7 @@ class HpuModelAdapter:
         self.dtype = dtype
         if not is_fake_hpu() and not htorch.utils.internal.is_lazy(
         ) and not enforce_eager:
-            if os.getenv("PT_REGIONAL_COMPILATION", 1):
+            if os.getenv('VLLM_REGIONAL_COMPILATION', 'true').lower() == 'true':
                 self.regional_compilation_layers_list = [RMSNorm, VocabParallelEmbedding]
                 self._regional_compilation(self.model)
             else:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1568,9 +1568,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.bucketing_ctx.generate_decode_buckets(max_blocks)
 
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
-            cache_size_limit = 3 * len(
-                self.bucketing_ctx.prompt_buckets) + 3 * len(
-                    self.bucketing_ctx.decode_buckets) + 1
+            cache_size_limit = 1 + 3 * (
+                len(self.bucketing_ctx.prompt_buckets) +
+                len(self.bucketing_ctx.decode_buckets))
             torch._dynamo.config.cache_size_limit = max(
                 cache_size_limit, torch._dynamo.config.cache_size_limit)
             # Multiply by 8 to follow the original default ratio between

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -36,7 +36,8 @@ from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.sampler import SamplerOutput
-from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding)
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import supports_multimodal
 from vllm.model_executor.sampling_metadata import SequenceGroupToSample
@@ -178,23 +179,32 @@ class HpuModelAdapter:
         self.dtype = dtype
         if not is_fake_hpu() and not htorch.utils.internal.is_lazy(
         ) and not enforce_eager:
-            if os.getenv('VLLM_REGIONAL_COMPILATION', 'true').lower() == 'true':
-                self.regional_compilation_layers_list = [RMSNorm, VocabParallelEmbedding]
+            if os.getenv('VLLM_REGIONAL_COMPILATION',
+                         'true').lower() == 'true':
+                self.regional_compilation_layers_list = [
+                    RMSNorm, VocabParallelEmbedding
+                ]
                 self._regional_compilation(self.model)
             else:
                 self.model = torch.compile(self.model,
                                            backend='hpu_backend',
                                            dynamic=False)
 
-    def _regional_compilation(self, module, parent_module=None, module_name=None):
+    def _regional_compilation(self,
+                              module,
+                              parent_module=None,
+                              module_name=None):
         if isinstance(module, torch.nn.ModuleList):
             for children_name, children_module in module.named_children():
                 self._compile_region(module, children_name, children_module)
-        elif any(isinstance(module, layer) for layer in self.regional_compilation_layers_list):
+        elif any(
+                isinstance(module, layer)
+                for layer in self.regional_compilation_layers_list):
             self._compile_region(parent_module, module_name, module)
         else:
             for children_name, children_module in module.named_children():
-                self._regional_compilation(children_module, module, children_name)
+                self._regional_compilation(children_module, module,
+                                           children_name)
 
     def _compile_region(self, model, name, module):
         module = torch.compile(module, backend='hpu_backend', dynamic=False)
@@ -1558,8 +1568,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.bucketing_ctx.generate_decode_buckets(max_blocks)
 
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
-            cache_size_limit = 3 * len(self.bucketing_ctx.prompt_buckets) + 3 * len(
-                self.bucketing_ctx.decode_buckets) + 1
+            cache_size_limit = 3 * len(
+                self.bucketing_ctx.prompt_buckets) + 3 * len(
+                    self.bucketing_ctx.decode_buckets) + 1
             torch._dynamo.config.cache_size_limit = max(
                 cache_size_limit, torch._dynamo.config.cache_size_limit)
             # Multiply by 8 to follow the original default ratio between


### PR DESCRIPTION
Add support for regional compilation. It is turned on by default, but can be turned off with `VLLM_REGIONAL_COMPILATION` env variable. It works only for torch.compile execution mode. It significantly speeds up warmup time and slightly increases throughput.