### PR TITLE
[SW-206682] Add host traces to high-level profilings

### DIFF
--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -115,6 +115,7 @@ class HPUWorker(LocalOrDistributedWorkerBase):
             self.profiler = None
 
     def full_trace_handler(self, dir_name, use_gzip=False):
+
         def handler_fn(prof) -> None:
             if not os.path.isdir(dir_name):
                 try:

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -114,11 +114,11 @@ class HPUWorker(LocalOrDistributedWorkerBase):
                     with open(file_path) as f:
                         pytorch_trace = json.load(f)
                     base = pytorch_trace['baseTimeNanoseconds'] / 1000
-                    profiler = self.model_runner.profiler
+                    events = self.model_runner.profiler.profiling_trace_events
                     while True:
                         try:
-                            event_str = profiler.profiling_trace_events.get_nowait()
-                            event = json.loads(event_str[:-1]) # remove tail ','
+                            event_str = events.get_nowait()
+                            event = json.loads(event_str[:-1])
                             event['ts'] = event['ts'] - base
                             pytorch_trace['traceEvents'].append(event)
                         except queue.Empty:

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -3,9 +3,11 @@
 ###############################################################################
 
 import gc
+import gzip
 import json
 import os
 import queue
+import time
 from typing import List, Optional, Set, Tuple, Type
 
 import habana_frameworks.torch as htorch  # noqa:F401
@@ -91,86 +93,72 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         self.hpu_cache: Optional[List[List[torch.tensor]]] = None
         # Torch profiler. Enabled and configured through env vars:
         # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
-        if os.getenv('VLLM_PROFILER_ENABLED'
-                      ) == 'full' and envs.VLLM_TORCH_PROFILER_DIR:
-            torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
-            logger.info("Full profiling enabled. Traces will be saved to: %s",
-                        torch_profiler_trace_dir)
-
-            def custom_handler(dir_name: str):
-                import os
-                import time
-
-                def handler_fn(prof) -> None:
-                    if not os.path.isdir(dir_name):
-                        try:
-                            os.makedirs(dir_name, exist_ok=True)
-                        except Exception as e:
-                            raise RuntimeError("Can't create directory: " +
-                                               dir_name) from e
-                    file_name = f"vllm.{time.time_ns()}.pt.trace.json"
-                    file_path = os.path.join(dir_name, file_name)
-                    prof.export_chrome_trace(file_path)
-                    with open(file_path) as f:
-                        pytorch_trace = json.load(f)
-                    base = pytorch_trace['baseTimeNanoseconds'] / 1000
-                    events = self.model_runner.profiler.profiling_trace_events
-                    while True:
-                        try:
-                            event_str = events.get_nowait()
-                            event = json.loads(event_str[:-1])
-                            event['ts'] = event['ts'] - base
-                            pytorch_trace['traceEvents'].append(event)
-                        except queue.Empty:
-                            break
-                    pytorch_trace['traceEvents'].append({
-                        "args": {
-                            "name": "vLLM"
-                        },
-                        "name": "process_name",
-                        "ph": "M",
-                        "pid": 1,
-                        "tid": 0,
-                        "ts": 0.0
-                    })
-                    pytorch_trace['traceEvents'].append({
-                        "args": {
-                            "name": "internal"
-                        },
-                        "name": "thread_name",
-                        "ph": "M",
-                        "pid": 1,
-                        "tid": 3,
-                        "ts": 0.0
-                    })
-
-                    with open(file_path, "w") as outfile:
-                        outfile.write(json.dumps(pytorch_trace))
-                    logger.info("Saved full profiling to %s", file_path)
-                return handler_fn
-
-            self.profiler = torch.profiler.profile(
-                activities=[
-                    torch.profiler.ProfilerActivity.CPU,
-                    torch.profiler.ProfilerActivity.HPU,
-                ],
-                with_stack=False,
-                on_trace_ready=custom_handler(torch_profiler_trace_dir))
-
-        elif envs.VLLM_TORCH_PROFILER_DIR:
+        if envs.VLLM_TORCH_PROFILER_DIR:
             torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
             logger.info("Profiling enabled. Traces will be saved to: %s",
                         torch_profiler_trace_dir)
+
+            if os.getenv('VLLM_PROFILER_ENABLED') == 'full':
+                fn = self.full_trace_handler
+                with_stack = False
+            else:
+                fn = torch.profiler.tensorboard_trace_handler
+                with_stack = True
             self.profiler = torch.profiler.profile(
                 activities=[
                     torch.profiler.ProfilerActivity.CPU,
                     torch.profiler.ProfilerActivity.HPU,
                 ],
-                with_stack=True,
-                on_trace_ready=torch.profiler.tensorboard_trace_handler(
-                    torch_profiler_trace_dir, use_gzip=True))
+                with_stack=with_stack,
+                on_trace_ready=fn(torch_profiler_trace_dir, use_gzip=True))
         else:
             self.profiler = None
+
+    def full_trace_handler(self, dir_name, use_gzip=False):
+        def handler_fn(prof) -> None:
+            if not os.path.isdir(dir_name):
+                try:
+                    os.makedirs(dir_name, exist_ok=True)
+                except Exception as e:
+                    raise RuntimeError("Can't create directory: " +
+                                       dir_name) from e
+            file_name = f"vllm.{time.time_ns()}.pt.trace.json"
+            file_path = os.path.join(dir_name, file_name)
+            prof.export_chrome_trace(file_path)
+            with open(file_path) as f:
+                pytorch_trace = json.load(f)
+            os.remove(file_path)
+            base = pytorch_trace['baseTimeNanoseconds'] / 1000
+            events = self.model_runner.profiler.profiling_trace_events
+            while True:
+                try:
+                    event_str = events.get_nowait()
+                    event = json.loads(event_str[:-1])
+                    event['ts'] = event['ts'] - base
+                    pytorch_trace['traceEvents'].append(event)
+                except queue.Empty:
+                    break
+
+            pytorch_trace['traceEvents'].append({
+                "args": {
+                    "name": "vLLM"
+                },
+                "name": "process_name",
+                "ph": "M",
+                "pid": 1,
+                "tid": 0,
+                "ts": 0.0
+            })
+            if use_gzip:
+                file_path = file_path + ".gz"
+                with gzip.open(file_path, 'wt', encoding="ascii") as zipfile:
+                    json.dump(pytorch_trace, zipfile)
+            else:
+                with open(file_path, "w") as outfile:
+                    outfile.write(json.dumps(pytorch_trace))
+            logger.info("Saved full profiling to %s", file_path)
+
+        return handler_fn
 
     def start_profile(self):
         if self.profiler is None:

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -3,7 +3,9 @@
 ###############################################################################
 
 import gc
+import json
 import os
+import queue
 from typing import List, Optional, Set, Tuple, Type
 
 import habana_frameworks.torch as htorch  # noqa:F401
@@ -89,7 +91,53 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         self.hpu_cache: Optional[List[List[torch.tensor]]] = None
         # Torch profiler. Enabled and configured through env vars:
         # VLLM_TORCH_PROFILER_DIR=/path/to/save/trace
-        if envs.VLLM_TORCH_PROFILER_DIR:
+        if os.getenv('VLLM_PROFILER_ENABLED') == 'full' and envs.VLLM_TORCH_PROFILER_DIR:
+            torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
+            logger.info("Full profiling enabled. Traces will be saved to: %s",
+                        torch_profiler_trace_dir)
+
+            def custom_handler(dir_name: str):
+                import os
+                import time
+
+                def handler_fn(prof) -> None:
+                    if not os.path.isdir(dir_name):
+                        try:
+                            os.makedirs(dir_name, exist_ok=True)
+                        except Exception as e:
+                            raise RuntimeError("Can't create directory: " + dir_name) from e
+                    file_name = f"vllm.{time.time_ns()}.pt.trace.json"
+                    file_path = os.path.join(dir_name, file_name)
+                    prof.export_chrome_trace(file_path)
+                    with open(file_path) as f:
+                        pytorch_trace = json.load(f)
+                    base = pytorch_trace['baseTimeNanoseconds'] / 1000
+
+                    while True:
+                        try:
+                            event_str = self.model_runner.profiler.profiling_trace_events.get_nowait()
+                            event = json.loads(event_str[:-1]) # remove comma at the end
+                            event['ts'] = event['ts'] - base
+                            pytorch_trace['traceEvents'].append(event)
+                        except queue.Empty:
+                            break
+                    pytorch_trace['traceEvents'].append({"args":{"name":"vLLM"},"name":"process_name","ph":"M","pid":1,"tid":0,"ts":0.0})
+                    pytorch_trace['traceEvents'].append({"args":{"name":"internal"},"name":"thread_name","ph":"M","pid":1,"tid":3,"ts":0.0})
+
+                    with open(file_path, "w") as outfile:
+                        outfile.write(json.dumps(pytorch_trace))
+                    logger.info("Saved full profiling to %s", file_path)
+                return handler_fn
+
+            self.profiler = torch.profiler.profile(
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.HPU,
+                ],
+                with_stack=False,
+                on_trace_ready=custom_handler(torch_profiler_trace_dir))
+
+        elif envs.VLLM_TORCH_PROFILER_DIR:
             torch_profiler_trace_dir = envs.VLLM_TORCH_PROFILER_DIR
             logger.info("Profiling enabled. Traces will be saved to: %s",
                         torch_profiler_trace_dir)
@@ -107,7 +155,14 @@ class HPUWorker(LocalOrDistributedWorkerBase):
     def start_profile(self):
         if self.profiler is None:
             raise RuntimeError("Profiler is not enabled.")
-        self.profiler.start()
+        with self.model_runner.profiler.record_event('internal', 'start_profiler'):
+            # Clean up the queue
+            while True:
+                try:
+                    _ = self.model_runner.profiler.profiling_trace_events.get_nowait()
+                except queue.Empty:
+                    break
+            self.profiler.start()
 
     def stop_profile(self):
         if self.profiler is None:


### PR DESCRIPTION
WIP

run vllm server with 
```HABANA_PROF_CONFIG=$PWD/cfg.json VLLM_TORCH_PROFILER_DIR=$PWD HABANA_PROFILE=1 VLLM_PROFILER_ENABLED=full ```

cfg.json:
```
{
    "Plugins": [
        {
            "lib": "libhost_profiler.so",
            "name": "HostProfiler",
            "values": {
                "api_group": {
                    "HCCL": {
                        "value": false
                    },
                    "HLTHUNK": {
                        "value": false
                    },
                    "SYNAPSE": {
                        "value": false
                    }
                },
                "start_disabled": {
                    "value": true
                }
            },
            "enable": true
        },
        {
            "lib": "libhw_trace.so",
            "name": "HwTrace",
            "values": {
                "generalOptions": {
                    "traceBufferSize": {
                        "value": "0x8000000"
                    },
                    "profilePhase": {
                        "value": "profileApi"
                    }
                },
                "archProfileUnits": {
                    "gaudi3": {
                        "CS": {
                            "enable": {
                                "value": false
                            },
                            "Gaudi3CSAdvancedProfiling": {
                                "value": 0
                            }
                        }
                    }
                }
            },
            "enable": false
        }
    ]
}
```

Start profiling with:
```
curl -X POST http://localhost:8080/start_profile
```

Stop profiling with:
```
curl -X POST http://localhost:8080/stop_profile
```