### PR TITLE
[1.19] Set vllm-hpu-extension to ecdf38e

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@ac9740d
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@ecdf38e


### PR DESCRIPTION
Sets vllm-hpu-extension to the newly created v1.19.0 branch