### PR TITLE
[BUG FIX] attn_bias cause results with all '!'

### DIFF
--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -198,6 +198,11 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                                                      attn_bias.shape[-1])
                     attn_bias = attn_bias.tile((1, self.num_kv_heads, 1, 1))
                     attn_bias.add_(position_bias)
+                # update attn_bias to None if Any inf or nan exists
+                attn_bias_inf = not torch.all(torch.isinf(attn_bias) == False)
+                attn_bias_nan = not torch.all(torch.isnan(attn_bias) == False)
+                if attn_bias_inf or attn_bias_nan:
+                    attn_bias = None
 
                 out = ops.prompt_attention(
                     query.view(query_shape),


### PR DESCRIPTION
Issue reported in https://jira.habana-labs.com/browse/SW-211554

with #561 enabled, tested with llama models will see output as below
![image](https://github.com/user-attachments/assets/780f52da-4c60-4d83-9bb2-5868cc7ea21b)

Main reason is some attn_bias are -inf as below. 
```
attn_bias is  tensor([[[[0., 0., 0.,  ..., 0., 0., 0.],
          [0., 0., 0.,  ..., -inf, -inf, -inf],
          [0., 0., 0.,  ..., 0., 0., 0.],
          ...,
          [-inf, -inf, -inf,  ..., -inf, -inf, -inf],
          [0., 0., 0.,  ..., -inf, -inf, -inf],
          [-inf, -inf, -inf,  ..., -inf, -inf, -inf]]]], device='hpu:0',
       dtype=torch.bfloat16) attn_bias_inf is  tensor(False, device='hpu:0') attn_bias_nan is tensor(False, device='hpu:0')
```