### PR TITLE
Dev/kpietkun/regional compilation

### DIFF
--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -28,7 +28,7 @@ stages:
         flavor: g3
         command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-fp8.txt -t 1
       - name: gsm8k_small_g3_tp2_fp8
-        flavor: g3
+        flavor: g3.s
         command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-fp8.txt -t 2
   - name: test_gsm8k_mss
     steps:

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -44,3 +44,8 @@ stages:
       - name: gsm8k_small_g2_tp2_mss
         flavor: g2.s
         command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-mss.txt -t 2
+  - name: test_gsm8k_spec_decode
+    steps:
+      - name: gsm8k_small_g2_tp1_spec_decode
+        flavor: g2
+        command: cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-mss.txt -t 1

--- a/README_GAUDI.md
+++ b/README_GAUDI.md
@@ -247,6 +247,7 @@ INFO 08-02 17:38:43 hpu_executor.py:91] init_cache_engine took 37.92 GiB of devi
 - `VLLM_HPU_LOG_STEP_GRAPH_COMPILATION_ALL`: if `true`, will log graph compilations per each vLLM engine step, always, even if there were none. Disabled by default.
 - `VLLM_HPU_LOG_STEP_CPU_FALLBACKS`: if `true`, will log cpu fallbacks per each vLLM engine step, only when there was any. Disabled by default.
 - `VLLM_HPU_LOG_STEP_CPU_FALLBACKS_ALL`: if `true`, will log cpu fallbacks per each vLLM engine step, always, even if there were none. Disabled by default.
+- `VLLM_REGIONAL_COMPILATION`: if `false`, turn off regional complation (when using torch.compile execution mode).
 
 **Performance tuning knobs:**
 

--- a/collect_env.py
+++ b/collect_env.py
@@ -39,6 +39,8 @@ SystemEnv = namedtuple(
         'cuda_module_loading',
         'nvidia_driver_version',
         'nvidia_gpu_models',
+        'habana_hpu_models',
+        'habana_driver_version',
         'cudnn_version',
         'pip_version',  # 'pip' or 'pip3'
         'pip_packages',
@@ -252,6 +254,37 @@ def get_nvidia_smi():
                 smi = '"{}"'.format(candidate_smi)
                 break
     return smi
+
+
+def get_hpu_info():
+    try:
+        command = ["hl-smi", "-q", "-d", "PRODUCT"]
+        lines = subprocess.Popen(command, stdout=subprocess.PIPE, universal_newlines=True).stdout.readlines()
+        lines = [l.strip('\t') for l in lines]
+        hpu_count = None
+        hpu_model = None
+        hpu_driver = None
+        model_re = re.compile(r'Product Name.+?: (.+)')
+        count_re = re.compile(r'Attached AIPs.+?: (\d+)')
+        driver_re = re.compile(r'Driver Version.+?: (.+)')
+        for line in lines:            
+            if hpu_c := count_re.match(line):
+                hpu_count = hpu_c.group(1)
+
+            if hpu_m := model_re.match(line):
+                hpu_model = hpu_m.group(1)
+
+            if hpu_d := driver_re.match(line):
+                hpu_driver = hpu_d.group(1)
+
+            if hpu_model and hpu_count and hpu_driver:
+                break
+
+        if hpu_model is None:
+            return ('N/A', hpu_driver)
+        return (f'{hpu_count}x {hpu_model}', hpu_driver)
+    except:
+        return ('N/A', 'N/A')
 
 
 def get_rocm_version(run_lambda):
@@ -568,6 +601,7 @@ def get_env_info():
     vllm_version = get_vllm_version()
     vllm_build_flags = summarize_vllm_build_flags()
     gpu_topo = get_gpu_topo(run_lambda)
+    hpu_info = get_hpu_info()
 
     return SystemEnv(
         torch_version=version_str,
@@ -583,6 +617,8 @@ def get_env_info():
         nvidia_gpu_models=get_gpu_info(run_lambda),
         nvidia_driver_version=get_nvidia_driver_version(run_lambda),
         cudnn_version=get_cudnn_version(run_lambda),
+        habana_hpu_models=hpu_info[0],
+        habana_driver_version=hpu_info[1],
         hip_compiled_version=hip_compiled_version,
         hip_runtime_version=hip_runtime_version,
         miopen_runtime_version=miopen_runtime_version,
@@ -626,6 +662,8 @@ CUDA_MODULE_LOADING set to: {cuda_module_loading}
 GPU models and configuration: {nvidia_gpu_models}
 Nvidia driver version: {nvidia_driver_version}
 cuDNN version: {cudnn_version}
+HPU devices: {habana_hpu_models}
+HPU driver version: {habana_driver_version}
 HIP runtime version: {hip_runtime_version}
 MIOpen runtime version: {miopen_runtime_version}
 Is XNNPACK available: {is_xnnpack_available}

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,5 +8,5 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@ac9740d
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@50e10ea
 neural-compressor @ git+https://github.com/intel/neural-compressor.git@b196432

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -346,9 +346,10 @@ class DefaultModelLoader(BaseModelLoader):
             if model_config.quantization is None and loaded_weights is not None:
                 weights_not_loaded = weights_to_load - loaded_weights
                 if weights_not_loaded:
-                    raise ValueError(
-                        "Following weights were not initialized from "
-                        f"checkpoint: {weights_not_loaded}")
+                    warning_msg = f"Following weights were not initialized \
+                            from checkpoint: {weights_not_loaded}"
+
+                    logger.warning(warning_msg)
 
             for _, module in model.named_modules():
                 quant_method = getattr(module, "quant_method", None)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -538,6 +538,11 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self._set_gc_threshold()
         self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
                                                 'true').lower() == 'true'
+        if vllm_config.speculative_config is not None \
+            and self.use_contiguous_pa:
+            raise ValueError(
+                "Speculative decoding is not supported with "
+                "contiguous PA, please set VLLM_CONTIGUOUS_PA=false")
         # For multi-step scheduling
         self.cached_step_outputs: List[torch.Tensor] = []
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -178,7 +178,7 @@ class HpuModelAdapter:
         self.dtype = dtype
         if not is_fake_hpu() and not htorch.utils.internal.is_lazy(
         ) and not enforce_eager:
-            if os.getenv("PT_REGIONAL_COMPILATION", 1):
+            if os.getenv('VLLM_REGIONAL_COMPILATION', 'true').lower() == 'true':
                 self.regional_compilation_layers_list = [RMSNorm, VocabParallelEmbedding]
                 self._regional_compilation(self.model)
             else:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1568,9 +1568,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.bucketing_ctx.generate_decode_buckets(max_blocks)
 
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
-            cache_size_limit = 3 * len(
-                self.bucketing_ctx.prompt_buckets) + 3 * len(
-                    self.bucketing_ctx.decode_buckets) + 1
+            cache_size_limit = 1 + 3 * (
+                len(self.bucketing_ctx.prompt_buckets) +
+                len(self.bucketing_ctx.decode_buckets))
             torch._dynamo.config.cache_size_limit = max(
                 cache_size_limit, torch._dynamo.config.cache_size_limit)
             # Multiply by 8 to follow the original default ratio between

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -36,7 +36,8 @@ from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.sampler import SamplerOutput
-from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding)
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.models import supports_multimodal
 from vllm.model_executor.sampling_metadata import SequenceGroupToSample
@@ -178,23 +179,32 @@ class HpuModelAdapter:
         self.dtype = dtype
         if not is_fake_hpu() and not htorch.utils.internal.is_lazy(
         ) and not enforce_eager:
-            if os.getenv('VLLM_REGIONAL_COMPILATION', 'true').lower() == 'true':
-                self.regional_compilation_layers_list = [RMSNorm, VocabParallelEmbedding]
+            if os.getenv('VLLM_REGIONAL_COMPILATION',
+                         'true').lower() == 'true':
+                self.regional_compilation_layers_list = [
+                    RMSNorm, VocabParallelEmbedding
+                ]
                 self._regional_compilation(self.model)
             else:
                 self.model = torch.compile(self.model,
                                            backend='hpu_backend',
                                            dynamic=False)
 
-    def _regional_compilation(self, module, parent_module=None, module_name=None):
+    def _regional_compilation(self,
+                              module,
+                              parent_module=None,
+                              module_name=None):
         if isinstance(module, torch.nn.ModuleList):
             for children_name, children_module in module.named_children():
                 self._compile_region(module, children_name, children_module)
-        elif any(isinstance(module, layer) for layer in self.regional_compilation_layers_list):
+        elif any(
+                isinstance(module, layer)
+                for layer in self.regional_compilation_layers_list):
             self._compile_region(parent_module, module_name, module)
         else:
             for children_name, children_module in module.named_children():
-                self._regional_compilation(children_module, module, children_name)
+                self._regional_compilation(children_module, module,
+                                           children_name)
 
     def _compile_region(self, model, name, module):
         module = torch.compile(module, backend='hpu_backend', dynamic=False)
@@ -1558,8 +1568,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.bucketing_ctx.generate_decode_buckets(max_blocks)
 
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
-            cache_size_limit = 3 * len(self.bucketing_ctx.prompt_buckets) + 3 * len(
-                self.bucketing_ctx.decode_buckets) + 1
+            cache_size_limit = 3 * len(
+                self.bucketing_ctx.prompt_buckets) + 3 * len(
+                    self.bucketing_ctx.decode_buckets) + 1
             torch._dynamo.config.cache_size_limit = max(
                 cache_size_limit, torch._dynamo.config.cache_size_limit)
             # Multiply by 8 to follow the original default ratio between


### PR DESCRIPTION
Add support for regional compilation. It is turned on by default, but can be turned off with VLLM_REGIONAL_COMPILATION env variable. It works only for torch.compile execution mode. It significantly speeds up warmup time and slightly increases throughput.

Change is already merged to habana_main. Creating this PR after request from QA
