### PR TITLE
Sarkar/v1.19.0  optimized topk=1 + handle_duplicates=0

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -409,7 +409,7 @@ class ApplyToppTopkScalar:
             new_logits = torch.full(logits.shape,
                             -float("inf"),
                             device=logits.device)
-            vals, idx = torch.max(logits, dim=1)
+            vals, idx = torch.max(logits, keepdim=True, dim=1)
             new_logits.scatter_(1, idx, vals.to(new_logits.dtype))
             return new_logits
         if k > ApplyToppTopkScalar._padded_k:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -411,7 +411,7 @@ class ApplyToppTopkScalar:
                             device=logits.device)
             vals, idx = torch.max(logits, dim=1)
             new_logits.scatter_(1, idx, vals.to(new_logits.dtype))
-        return new_logits
+            return new_logits
         if k > ApplyToppTopkScalar._padded_k:
             ApplyToppTopkScalar._padded_k = min(k + self._increment,
                                                 logits.shape[1])

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -405,18 +405,13 @@ class ApplyToppTopkScalar:
         self._increment = increment
 
     def __call__(self, logits: torch.Tensor, p: float, k: int):
-        if k==1:
-            # optimization for k==1 case.
-            if ApplyToppTopkScalar._handle_duplicates:
-                mask = logits != torch.max(logits, dim=1, keepdim=True).values
-                new_logits = torch.where(mask, -float("inf"), logits)
-            else:
-                new_logits = torch.full(logits.shape,
-                                -float("inf"),
-                                device=logits.device)
-                vals, idx = torch.max(logits, dim=1)
-                new_logits.scatter_(1, idx, vals.to(new_logits.dtype))
-            return new_logits
+        if k==1 and not ApplyToppTopkScalar._handle_duplicates:
+            new_logits = torch.full(logits.shape,
+                            -float("inf"),
+                            device=logits.device)
+            vals, idx = torch.max(logits, dim=1)
+            new_logits.scatter_(1, idx, vals.to(new_logits.dtype))
+        return new_logits
         if k > ApplyToppTopkScalar._padded_k:
             ApplyToppTopkScalar._padded_k = min(k + self._increment,
                                                 logits.shape[1])


### PR DESCRIPTION
We have a case where topk=1, and topp=<1.

Adding special handling for the case topk=1 and handle_duplicate=0 (by default handle_duplicate=0, to support num-scheduling-steps)



