### PR TITLE
Set vllm-hpu-extension to 4312768

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@48d0303
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@4312768


### PR DESCRIPTION
This PR updates vllm-hpu-extension head to 4312768. https://github.com/HabanaAI/vllm-hpu-extension/pull/51