### PR TITLE
Fix multiprocessing executor shutdown

### DIFF
--- a/vllm/executor/multiproc_hpu_executor.py
+++ b/vllm/executor/multiproc_hpu_executor.py
@@ -42,6 +42,9 @@ class MultiprocessingHPUExecutor(MultiprocessingGPUExecutor):
             f"please ensure that world_size ({world_size}) "
             f"is less than than max local hpu count ({hpu_device_count})")
 
+    def __del__(self):
+        self.shutdown()
+
 
 class MultiprocessingHPUExecutorAsync(MultiprocessingHPUExecutor,
                                       MultiprocessingGPUExecutorAsync):

--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -15,6 +15,7 @@ import torch
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.triton_utils.importing import HAS_TRITON
 from vllm.utils import cuda_is_initialized
 
@@ -290,6 +291,22 @@ def set_multiprocessing_worker_envs(parallel_config):
                        "the `spawn` multiprocessing start method. Setting "
                        "VLLM_WORKER_MULTIPROC_METHOD to 'spawn'.")
         os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+    if (current_platform.is_hpu()
+            and parallel_config.distributed_executor_backend == 'mp'
+            and envs.VLLM_WORKER_MULTIPROC_METHOD == 'fork'):
+        if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD", None) is not None:
+            logger.warning("On HPU, VLLM_WORKER_MULTIPROC_METHOD=fork might "
+                           "cause application hangs on exit. Using "
+                           "VLLM_WORKER_MULTIPROC_METHOD=fork anyway, "
+                           "as it was explicitly requested.")
+        else:
+            logger.warning("On HPU, VLLM_WORKER_MULTIPROC_METHOD=fork might "
+                           "cause application hangs on exit. Setting "
+                           "VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. "
+                           "To override that behavior, please set "
+                           "VLLM_WORKER_MULTIPROC_METHOD=fork explicitly.")
+            os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
     # Configure thread parallelism if OMP_NUM_THREADS isn't set
     #


### PR DESCRIPTION
With this patch, mp executor does not hang at the end of application out of the box, and exits gracefully.