### PR TITLE
[bugfix] fix RuntimeError on apc

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -971,7 +971,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         # Note: num_prefill_tokens is calculated using the length of
         # input_tokens after padding.
         num_prefill_tokens = input_tokens_tensor.numel()
-        if prefix_block_list_tensor:
+        if prefix_block_list_tensor is not None:
             prefix_block_list_tensor = prefix_block_list_tensor.to(
                 self.device, non_blocking=True)
         input_tokens_tensor = input_tokens_tensor.to(  # type: ignore


### PR DESCRIPTION
This PR fixes a bug that results in the following RuntimeError when APC is enabled.
```
ERROR 12-19 02:30:05 engine.py:140]   File "/workspace/vllm/worker/hpu_model_runner.py", line 854, in _prepare_prompt
ERROR 12-19 02:30:05 engine.py:140]     if prefix_block_list_tensor:
ERROR 12-19 02:30:05 engine.py:140] RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```