### PR TITLE
Lora manager tests fix

### DIFF
--- a/tests/lora/test_lora_manager_hpu.py
+++ b/tests/lora/test_lora_manager_hpu.py
@@ -1,6 +1,7 @@
 import os
 from typing import Dict, List
 
+import habana_frameworks.torch  # noqa: F401
 import pytest
 import torch
 from safetensors.torch import load_file


### PR DESCRIPTION
This PR solves the "ModuleNotFoundError: No Module named torch.hpu" in test_lora_manager_hpu.py::test_from_lora_tensors by importing "habana_frameworks.hpu" to lora model.
