### PR TITLE
Enable splitting qkv and gate_up

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -737,6 +737,7 @@ class CacheConfig:
             prefix caching enabled.
         enable_prefix_caching: Whether to enable prefix caching.
         cpu_offload_gb: Size of the CPU offload buffer in GiB.
+        split_qk_v: Whether to split qk and v calculations.
     """
 
     def __init__(
@@ -750,6 +751,7 @@ class CacheConfig:
         sliding_window: Optional[int] = None,
         enable_prefix_caching: bool = False,
         cpu_offload_gb: float = 0,
+        split_qk_v: bool = False,
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -760,7 +762,7 @@ class CacheConfig:
         self.sliding_window = sliding_window
         self.enable_prefix_caching = enable_prefix_caching
         self.cpu_offload_gb = cpu_offload_gb
-
+        self.split_qk_v = split_qk_v
         self._verify_args()
         self._verify_cache_dtype()
         self._verify_prefix_caching()

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -738,6 +738,7 @@ class CacheConfig:
         enable_prefix_caching: Whether to enable prefix caching.
         cpu_offload_gb: Size of the CPU offload buffer in GiB.
         split_qk_v: Whether to split qk and v calculations.
+        split_gate_up: Whether to split gate and up calculations.
     """
 
     def __init__(
@@ -752,6 +753,7 @@ class CacheConfig:
         enable_prefix_caching: bool = False,
         cpu_offload_gb: float = 0,
         split_qk_v: bool = False,
+        split_gate_up: bool = False,
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -763,6 +765,7 @@ class CacheConfig:
         self.enable_prefix_caching = enable_prefix_caching
         self.cpu_offload_gb = cpu_offload_gb
         self.split_qk_v = split_qk_v
+        self.split_gate_up = split_gate_up
         self._verify_args()
         self._verify_cache_dtype()
         self._verify_prefix_caching()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -123,6 +123,7 @@ class EngineArgs:
     swap_space: float = 4  # GiB
     cpu_offload_gb: float = 0  # GiB
     gpu_memory_utilization: float = 0.90
+    split_qk_v: bool = False
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: int = 256
     max_num_prefill_seqs: Optional[int] = None
@@ -501,7 +502,11 @@ class EngineArgs:
             type=int,
             default=None,
             help='If specified, ignore GPU profiling result and use this number'
-            ' of GPU blocks. Used for testing preemption.')
+            'of GPU blocks. Used for testing preemption.')
+        parser.add_argument('--split-qk-v',
+                            action='store_true',
+                            default=EngineArgs.split_qk_v,
+                            help='Whether to separate qk and v calculations.')
         parser.add_argument('--max-num-batched-tokens',
                             type=int,
                             default=EngineArgs.max_num_batched_tokens,
@@ -1050,6 +1055,7 @@ class EngineArgs:
             cache_dtype=self.kv_cache_dtype,
             is_attention_free=model_config.is_attention_free,
             num_gpu_blocks_override=self.num_gpu_blocks_override,
+            split_qk_v=self.split_qk_v,
             sliding_window=model_config.get_sliding_window(),
             enable_prefix_caching=self.enable_prefix_caching,
             cpu_offload_gb=self.cpu_offload_gb,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -124,6 +124,7 @@ class EngineArgs:
     cpu_offload_gb: float = 0  # GiB
     gpu_memory_utilization: float = 0.90
     split_qk_v: bool = False
+    split_gate_up: bool = False
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: int = 256
     max_num_prefill_seqs: Optional[int] = None
@@ -507,6 +508,10 @@ class EngineArgs:
                             action='store_true',
                             default=EngineArgs.split_qk_v,
                             help='Whether to separate qk and v calculations.')
+        parser.add_argument('--split-gate-up',
+                            action='store_true',
+                            default=EngineArgs.split_gate_up,
+                            help='Whether to separate gate and up calculations.')
         parser.add_argument('--max-num-batched-tokens',
                             type=int,
                             default=EngineArgs.max_num_batched_tokens,
@@ -1056,6 +1061,7 @@ class EngineArgs:
             is_attention_free=model_config.is_attention_free,
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             split_qk_v=self.split_qk_v,
+            split_gate_up=self.split_gate_up,
             sliding_window=model_config.get_sliding_window(),
             enable_prefix_caching=self.enable_prefix_caching,
             cpu_offload_gb=self.cpu_offload_gb,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -249,22 +249,8 @@ class LLMEngine:
         )
 
         logger.info(
-            "Initializing an LLM engine (v%s) with config: "
-            "model=%r, speculative_config=%r, tokenizer=%r, "
-            "skip_tokenizer_init=%s, tokenizer_mode=%s, revision=%s, "
-            "override_neuron_config=%s, tokenizer_revision=%s, "
-            "trust_remote_code=%s, dtype=%s, max_seq_len=%d, "
-            "download_dir=%r, load_format=%s, tensor_parallel_size=%d, "
-            "pipeline_parallel_size=%d, "
-            "disable_custom_all_reduce=%s, quantization=%s, "
-            "weights_load_device=%s, enforce_eager=%s, kv_cache_dtype=%s, "
-            "quantization_param_path=%s, device_config=%s, "
-            "decoding_config=%r, observability_config=%r, "
-            "seed=%d, served_model_name=%s, "
-            "num_scheduler_steps=%d, chunked_prefill_enabled=%s "
-            "multi_step_stream_outputs=%s, enable_prefix_caching=%s, "
-            "use_async_output_proc=%s, use_cached_outputs=%s, "
-            "mm_processor_kwargs=%s, pooler_config=%r, split_qk_v=%s)",
+            "Initializing an LLM engine (v%s) with config: %r,"
+            "use_cached_outputs=%s, ",
             VLLM_VERSION,
             vllm_config,
             use_cached_outputs,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -340,9 +340,9 @@ class LLMEngine:
                     "enforce_eager":
                     self.model_config.enforce_eager,
                     "disable_custom_all_reduce":
-                    parallel_config.disable_custom_all_reduce,
+                    self.parallel_config.disable_custom_all_reduce,
                     "split_qk_v":
-                    cache_config.split_qk_v,
+                    self.cache_config.split_qk_v,
                 })
 
         if self.tokenizer:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -329,6 +329,8 @@ class LLMEngine:
                     self.parallel_config.disable_custom_all_reduce,
                     "split_qk_v":
                     self.cache_config.split_qk_v,
+                    "split_gate_up":
+                    self.cache_config.split_gate_up,
                 })
 
         if self.tokenizer:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -249,8 +249,22 @@ class LLMEngine:
         )
 
         logger.info(
-            "Initializing an LLM engine (v%s) with config: %r,"
-            "use_cached_outputs=%s, ",
+            "Initializing an LLM engine (v%s) with config: "
+            "model=%r, speculative_config=%r, tokenizer=%r, "
+            "skip_tokenizer_init=%s, tokenizer_mode=%s, revision=%s, "
+            "override_neuron_config=%s, tokenizer_revision=%s, "
+            "trust_remote_code=%s, dtype=%s, max_seq_len=%d, "
+            "download_dir=%r, load_format=%s, tensor_parallel_size=%d, "
+            "pipeline_parallel_size=%d, "
+            "disable_custom_all_reduce=%s, quantization=%s, "
+            "weights_load_device=%s, enforce_eager=%s, kv_cache_dtype=%s, "
+            "quantization_param_path=%s, device_config=%s, "
+            "decoding_config=%r, observability_config=%r, "
+            "seed=%d, served_model_name=%s, "
+            "num_scheduler_steps=%d, chunked_prefill_enabled=%s "
+            "multi_step_stream_outputs=%s, enable_prefix_caching=%s, "
+            "use_async_output_proc=%s, use_cached_outputs=%s, "
+            "mm_processor_kwargs=%s, pooler_config=%r, split_qk_v=%s)",
             VLLM_VERSION,
             vllm_config,
             use_cached_outputs,
@@ -326,7 +340,9 @@ class LLMEngine:
                     "enforce_eager":
                     self.model_config.enforce_eager,
                     "disable_custom_all_reduce":
-                    self.parallel_config.disable_custom_all_reduce,
+                    parallel_config.disable_custom_all_reduce,
+                    "split_qk_v":
+                    cache_config.split_qk_v,
                 })
 
         if self.tokenizer:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -669,8 +669,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                  skip_bias_add: bool = False,
                  params_dtype: Optional[torch.dtype] = None,
                  quant_config: Optional[QuantizationConfig] = None,
-                 prefix: str = "",
-                 split_qk_v: bool = False):
+                 prefix: str = ""):
         self.hidden_size = hidden_size
         self.head_size = head_size
         self.total_num_heads = total_num_heads
@@ -687,19 +686,16 @@ class QKVParallelLinear(ColumnParallelLinear):
         else:
             self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
             self.num_kv_head_replicas = 1
-        self.split_qk_v = split_qk_v
         self.q_size = self.num_heads * self.head_size * tp_size
         self.kv_size = self.num_kv_heads * self.head_size * tp_size
         input_size = self.hidden_size
         self.output_sizes = [
             self.q_size,  # q_proj
         ]
-        if split_qk_v:
-            output_size = (self.num_heads) * tp_size * self.head_size
-        else:
-            output_size = (self.num_heads +
-                           2 * self.num_kv_heads) * tp_size * self.head_size
-            self.output_sizes.append(self.kv_size)  # v_proj
+
+        output_size = (self.num_heads +
+                        2 * self.num_kv_heads) * tp_size * self.head_size
+        self.output_sizes.append(self.kv_size)  # v_proj
 
         super().__init__(input_size=input_size,
                          output_size=output_size,
@@ -709,24 +705,6 @@ class QKVParallelLinear(ColumnParallelLinear):
                          params_dtype=params_dtype,
                          quant_config=quant_config,
                          prefix=prefix)
-
-        if split_qk_v:
-            self.k_proj = ColumnParallelLinear(input_size=input_size,
-                                    output_size=self.kv_size,
-                                    bias=bias,
-                                    gather_output=False,
-                                    skip_bias_add=skip_bias_add,
-                                    params_dtype=params_dtype,
-                                    quant_config=quant_config,
-                                    prefix=prefix)
-            self.v_proj = ColumnParallelLinear(input_size=input_size,
-                                               output_size=self.kv_size,
-                                               bias=bias,
-                                               gather_output=False,
-                                               skip_bias_add=skip_bias_add,
-                                               params_dtype=params_dtype,
-                                               quant_config=quant_config,
-                                               prefix=prefix)
 
     def _get_shard_offset_mapping(self, loaded_shard_id: str):
         shard_offset_mapping = {
@@ -938,20 +916,16 @@ class QKVParallelLinear(ColumnParallelLinear):
                 orig_qkv_offsets = {
                     "q": (0, self.num_heads * self.head_size),
                 }
-                if self.split_qk_v:
-                    orig_qkv_offsets["total"] = (
-                        (self.num_heads) * self.head_size,
-                        0)
-                else:
-                    orig_qkv_offsets["k"] = (
-                        (self.num_heads) * self.head_size,
-                        self.num_kv_heads * self.head_size)
-                    orig_qkv_offsets["v"] = (
-                        (self.num_heads + self.num_kv_heads) * self.head_size,
-                        self.num_kv_heads * self.head_size)
-                    orig_qkv_offsets["total"] = (
-                        (self.num_heads + 2 * self.num_kv_heads) *
-                        self.head_size, 0)
+
+                orig_qkv_offsets["k"] = (
+                    (self.num_heads) * self.head_size,
+                    self.num_kv_heads * self.head_size)
+                orig_qkv_offsets["v"] = (
+                    (self.num_heads + self.num_kv_heads) * self.head_size,
+                    self.num_kv_heads * self.head_size)
+                orig_qkv_offsets["total"] = (
+                    (self.num_heads + 2 * self.num_kv_heads) *
+                    self.head_size, 0)
                 shard_size, shard_offset = adjust_bitsandbytes_4bit_shard(
                     param, orig_qkv_offsets, loaded_shard_id)
 
@@ -990,15 +964,6 @@ class QKVParallelLinear(ColumnParallelLinear):
 
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
-
-    def forward(self, input_):
-        q, output_bias = super().forward(input_)
-        if not self.split_qk_v:
-            return q, output_bias
-        k, _ = self.k_proj(input_)
-        v, _ = self.v_proj(input_)
-        return q, k, v, output_bias
-
 
 class RowParallelLinear(LinearBase):
     """Linear layer with row parallelism.

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -669,7 +669,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                  skip_bias_add: bool = False,
                  params_dtype: Optional[torch.dtype] = None,
                  quant_config: Optional[QuantizationConfig] = None,
-                 prefix: str = ""):
+                 prefix: str = "",
+                 split_qk_v: bool = False):
         self.hidden_size = hidden_size
         self.head_size = head_size
         self.total_num_heads = total_num_heads
@@ -686,14 +687,19 @@ class QKVParallelLinear(ColumnParallelLinear):
         else:
             self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
             self.num_kv_head_replicas = 1
+        self.split_qk_v = split_qk_v
+        self.q_size = self.num_heads * self.head_size * tp_size
+        self.kv_size = self.num_kv_heads * self.head_size * tp_size
         input_size = self.hidden_size
-        output_size = (self.num_heads +
-                       2 * self.num_kv_heads) * tp_size * self.head_size
         self.output_sizes = [
-            self.num_heads * self.head_size * tp_size,  # q_proj
-            self.num_kv_heads * self.head_size * tp_size,  # k_proj
-            self.num_kv_heads * self.head_size * tp_size,  # v_proj 
+            self.q_size,  # q_proj
         ]
+        if split_qk_v:
+            output_size = (self.num_heads) * tp_size * self.head_size
+        else:
+            output_size = (self.num_heads +
+                           2 * self.num_kv_heads) * tp_size * self.head_size
+            self.output_sizes.append(self.kv_size)  # v_proj
 
         super().__init__(input_size=input_size,
                          output_size=output_size,
@@ -703,6 +709,24 @@ class QKVParallelLinear(ColumnParallelLinear):
                          params_dtype=params_dtype,
                          quant_config=quant_config,
                          prefix=prefix)
+
+        if split_qk_v:
+            self.k_proj = ColumnParallelLinear(input_size=input_size,
+                                    output_size=self.kv_size,
+                                    bias=bias,
+                                    gather_output=False,
+                                    skip_bias_add=skip_bias_add,
+                                    params_dtype=params_dtype,
+                                    quant_config=quant_config,
+                                    prefix=prefix)
+            self.v_proj = ColumnParallelLinear(input_size=input_size,
+                                               output_size=self.kv_size,
+                                               bias=bias,
+                                               gather_output=False,
+                                               skip_bias_add=skip_bias_add,
+                                               params_dtype=params_dtype,
+                                               quant_config=quant_config,
+                                               prefix=prefix)
 
     def _get_shard_offset_mapping(self, loaded_shard_id: str):
         shard_offset_mapping = {
@@ -913,15 +937,21 @@ class QKVParallelLinear(ColumnParallelLinear):
             if use_bitsandbytes_4bit:
                 orig_qkv_offsets = {
                     "q": (0, self.num_heads * self.head_size),
-                    "k": (self.num_heads * self.head_size,
-                          self.num_kv_heads * self.head_size),
-                    "v":
-                    ((self.num_heads + self.num_kv_heads) * self.head_size,
-                     self.num_kv_heads * self.head_size),
-                    "total":
-                    ((self.num_heads + 2 * self.num_kv_heads) * self.head_size,
-                     0)
                 }
+                if self.split_qk_v:
+                    orig_qkv_offsets["total"] = (
+                        (self.num_heads) * self.head_size,
+                        0)
+                else:
+                    orig_qkv_offsets["k"] = (
+                        (self.num_heads) * self.head_size,
+                        self.num_kv_heads * self.head_size)
+                    orig_qkv_offsets["v"] = (
+                        (self.num_heads + self.num_kv_heads) * self.head_size,
+                        self.num_kv_heads * self.head_size)
+                    orig_qkv_offsets["total"] = (
+                        (self.num_heads + 2 * self.num_kv_heads) *
+                        self.head_size, 0)
                 shard_size, shard_offset = adjust_bitsandbytes_4bit_shard(
                     param, orig_qkv_offsets, loaded_shard_id)
 
@@ -960,6 +990,14 @@ class QKVParallelLinear(ColumnParallelLinear):
 
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
+
+    def forward(self, input_):
+        q, output_bias = super().forward(input_)
+        if not self.split_qk_v:
+            return q, output_bias
+        k, _ = self.k_proj(input_)
+        v, _ = self.v_proj(input_)
+        return q, k, v, output_bias
 
 
 class RowParallelLinear(LinearBase):

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -151,7 +151,6 @@ class LlamaAttention(nn.Module):
         self.split_qk_v = cache_config.split_qk_v
 
         if self.split_qk_v:
-            print("Using split qk_v")
             self.q_proj = ColumnParallelLinear(input_size=self.hidden_size,
                                                output_size=self.hidden_size,
                                                bias=bias,

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -601,10 +601,6 @@ class LlamaModel(nn.Module):
 
                 param = params_dict[name]
                 weight_loader = param.weight_loader
-                if self.split_qk_v and (shard_id == "v" or shard_id == "k" or shard_id == "q") :
-                    weight_loader(param, loaded_weight)
-                else:
-                    weight_loader(param, loaded_weight, shard_id)
 
                 break
             else:

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -476,6 +476,8 @@ class LlamaModel(nn.Module):
             residual = intermediate_tensors["residual"]
 
         if is_hpu:
+            for i in range(self.start_layer, self.end_layer):
+                self.layers[i].self_attn.rotary_emb.prepare_cos_sin(positions)
             import habana_frameworks.torch as htorch
             htorch.core.mark_step()
 

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -82,6 +82,9 @@ class LlamaMLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.gate_up_proj",
         )
+        split_enable = bool(os.environ.get('VLLM_TP_SPLIT_ENABLE', '1'))
+        split_size = int(os.environ.get('VLLM_TP_SPLIT_SIZE', '2'))
+        split_threshold = int(os.environ.get('VLLM_TP_SPLIT_THRESHOLD', '128'))
         self.down_proj = RowParallelLinear(
             input_size=intermediate_size,
             output_size=hidden_size,

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -601,7 +601,7 @@ class LlamaModel(nn.Module):
 
                 param = params_dict[name]
                 weight_loader = param.weight_loader
-
+                weight_loader(param, loaded_weight, shard_id)
                 break
             else:
                 # Skip loading extra bias for GPTQ models.

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -82,9 +82,6 @@ class LlamaMLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.gate_up_proj",
         )
-        split_enable = bool(os.environ.get('VLLM_TP_SPLIT_ENABLE', '1'))
-        split_size = int(os.environ.get('VLLM_TP_SPLIT_SIZE', '2'))
-        split_threshold = int(os.environ.get('VLLM_TP_SPLIT_THRESHOLD', '128'))
         self.down_proj = RowParallelLinear(
             input_size=intermediate_size,
             output_size=hidden_size,


### PR DESCRIPTION
Enable splitting qkv and gate_up into separate columnparallellinear layers, instead of overwriting qkvparallellinear and mergedcolumnparallellinear layers.