### PR TITLE
add renormalize param for FusedMOE

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -235,7 +235,7 @@ class FusedMoE(torch.nn.Module):
             from vllm.model_executor.layers.quantization.inc import INCConfig
             selected_fused_moe = (StaticFusedMOE if isinstance(
                 quant_config, INCConfig) else DynamicFusedMOE)
-            self.hpu_static_fused_moe = selected_fused_moe(self.num_experts)
+            self.hpu_static_fused_moe = selected_fused_moe(self.num_experts, renormalize=renormalize)
 
         if quant_config is None:
             self.quant_method: Optional[QuantizeMethodBase] = (


### PR DESCRIPTION
Add renormalize parameter for FusedMOE cause whether to normalize routing_weights depends on the **_norm_topk_prob_** attrib in model's config.json file. Some models such as Qwen2-MoE is set to false.

**_Note: This PR should depend on [this](https://github.com/HabanaAI/vllm-hpu-extension/pull/70) one in vllm-hpu-extension. So pls also help review it first._**