### PR TITLE
Set vllm-hpu-extension to 6ac93fb

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@4312768
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@6ac93fb

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -6,6 +6,6 @@ ray
 triton
 pandas
 tabulate
-setuptools>=64
+setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@6ac93fb
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@d05c0a7

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -6,6 +6,6 @@ ray
 triton
 pandas
 tabulate
-setuptools>=61
+setuptools>=64
 setuptools-scm>=8
 vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@6ac93fb


### PR DESCRIPTION
remove expert_max hard code (#47)
vLLM-Ext: Full enabling of ALiBi (#34)
Add version inference via setuptools-scm (#58)
Revert "vLLM-Ext: Full enabling of ALiBi (#34)" (#59)
Remove punica_hpu.py from vllm_hpu_extension (#66)
Removed previous (not-pipelined) pa implementation (#72)
Add flag to enable running softmax in fp32 (#71)
Update calibration readme link (#73)
allow lm_head quantization in calibration process (#65)
Pad to bmin if value is less (#67)
Update pyproject.toml (https://github.com/HabanaAI/vllm-fork/pull/75)