### PR TITLE
Update requirements-hpu.txt

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@7329a11
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@0766759

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@8caa008
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@d05c0a7

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@0766759
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@7329a11

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@0766759
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@eed5f85

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@062a622
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@6826776

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@eed5f85
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@062a622

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@fffc2c0
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@0766759

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@6826776
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@8caa008

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@4312768
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@fffc2c0


### PR DESCRIPTION
remove expert_max hard code (https://github.com/HabanaAI/vllm-fork/pull/47)
vLLM-Ext: Full enabling of ALiBi (https://github.com/HabanaAI/vllm-fork/pull/34)
Add version inference via setuptools-scm (https://github.com/HabanaAI/vllm-fork/pull/58)
Revert "vLLM-Ext: Full enabling of ALiBi (https://github.com/HabanaAI/vllm-fork/pull/34)" (https://github.com/HabanaAI/vllm-fork/pull/59)
Remove punica_hpu.py from vllm_hpu_extension (https://github.com/HabanaAI/vllm-fork/pull/66)
Removed previous (not-pipelined) pa implementation (https://github.com/HabanaAI/vllm-fork/pull/72)
Add flag to enable running softmax in fp32 (https://github.com/HabanaAI/vllm-fork/pull/71)
Update calibration readme link (https://github.com/HabanaAI/vllm-fork/pull/73)
allow lm_head quantization in calibration process (https://github.com/HabanaAI/vllm-fork/pull/65)
Pad to bmin if value is less (https://github.com/HabanaAI/vllm-fork/pull/67)
Update pyproject.toml  (https://github.com/HabanaAI/vllm-fork/pull/75)