### PR TITLE
Disable enforcing eager mode for mllama and deepseek_v3 on hpu

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -608,8 +608,9 @@ class ModelConfig:
                                           self.max_model_len)
 
         MODEL_NOT_SUPPORT_CUDA_GRAPH = ['deepseek_v3', 'mllama']
+        from vllm.platforms import current_platform
         if (self.hf_config.model_type in MODEL_NOT_SUPPORT_CUDA_GRAPH
-                and not self.enforce_eager):
+                and not self.enforce_eager and not current_platform.is_hpu()):
             logger.warning(
                 "CUDA graph is not supported for %s yet, fallback to the eager "
                 "mode.", self.hf_config.model_type)


### PR DESCRIPTION
PR disables enforcing eager mode when launching mllama or deepseek_v3 on hpu, which was introduced by https://github.com/vllm-project/vllm/pull/12127