### PR TITLE
TP parallel seq_len

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -303,7 +303,7 @@ class LlamaAttention(nn.Module):
         attn_metadata: AttentionMetadata,
     ) -> torch.Tensor:
         q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v, kv_cache, attn_metadata, **kwargs)
+        attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         batch_size = attn_output.size(0)
         seq_len = attn_output.size(1)
         split_size = get_split_size(seq_len, batch_size, self.split_size)
@@ -346,7 +346,7 @@ class LlamaAttention(nn.Module):
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
                                 dim=-1)
         q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v, kv_cache, attn_metadata, **kwargs)
+        attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         if ((seq_len*batch_size)//split_size>=2) and do_split:
             attn_output = attn_output.view(1, -1, self.q_size)
             attn_list = torch.split(attn_output, split_size, 1)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -132,6 +132,8 @@ class LlamaMLP(nn.Module):
         seq_len = x.size(1)
         if (seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE==0:
             x = x.view(-1,VLLM_MLP_SIZE_OVERRIDE,self.hidden_size)
+        elif (seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE_2==0:
+            x = x.view(-1,VLLM_MLP_SIZE_OVERRIDE_2,self.hidden_size)
         if self.split_gate_up:
             x = nn.functional.silu(self.gate_proj(x)[0]) * self.up_proj(x)[0]
         else:
@@ -141,7 +143,7 @@ class LlamaMLP(nn.Module):
         # Separate split for down is not implemented yet
         x, _ = self.down_proj(x)
 
-        if (seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE==0:
+        if ((seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE==0) or ((seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE_2==0):
             x = x.view(batch_size,seq_len,self.hidden_size)
         return x
 


### PR DESCRIPTION
TP parallel (overlap all-reduce with compute) for the sequence length dimension. Can be controlled using VLLM_TP_SPLIT_SIZE_BY_SEQ (recommend 2048 or 4). Expected performance gain is ~6% first-token latency for 405b TP=8 seq_len=16384. Also allows better control of overriding mlp shapes using VLLM_MLP_SIZE_OVERRIDE (instead of the hard-coded 512).
