### PR TITLE
[SW-216666] - add fp8 to the hpu supported quantization list

### DIFF
--- a/docs/source/features/quantization/supported_hardware.md
+++ b/docs/source/features/quantization/supported_hardware.md
@@ -76,7 +76,7 @@ The table below shows the compatibility of various quantization implementations 
   - ✅︎
   - ✅︎
   - ✗
-  - ✗
+  - ✅︎
   - ✗
   - ✗
   - ✗

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -21,7 +21,7 @@ class HpuPlatform(Platform):
     dispatch_key: str = "HPU"
     ray_device_key: str = "HPU"
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
-    supported_quantization: list[str] = ["inc"]
+    supported_quantization: list[str] = ["fp8", "inc"]
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,


### PR DESCRIPTION
This is required for running the already quantized models with hpu, using the fp8 quantization method (and not "inc").
