### PR TITLE
Hotfix recompilations caused by unified attention for hpu

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -135,6 +135,14 @@ class Attention(nn.Module):
         kv_cache: torch.Tensor,
         attn_metadata: AttentionMetadata,
     ) -> torch.Tensor:
+        if current_platform.is_hpu() and self.use_direct_call:
+            forward_context: ForwardContext = get_forward_context()
+            attn_metadata = forward_context.attn_metadata
+            kv_cache = self.kv_cache[forward_context.virtual_engine]
+            return self.impl.forward(query, key, value, kv_cache,
+                                     attn_metadata, self._k_scale,
+                                     self._v_scale)
+
         if self.use_output:
             output = torch.empty_like(query)
             hidden_size = query.size(-1)


### PR DESCRIPTION

This is a hotfix for recompilation issues caused by upstream change 0f8cafe. The unified_attention uses layer_name to retrieve the layer from the ForwardContext, which causes dynamo to recompile each Attention layer.

HOTFIX #12410 

