### PR TITLE
Generator bypass for dummy init

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -604,11 +604,11 @@ def initialize_dummy_weights(
                 continue
             
             if current_platform.is_hpu():
-                # HPU device does not support torch.Generator()
-                param.uniform_(low, high)
-                continue
-
-            generator = torch.Generator(device=param.data.device)
+                import habana_frameworks.torch.hpu.random as htrandom
+                generator = htrandom.default_generators[0]
+            else:
+                generator = torch.Generator(device=param.data.device)
+                
             generator.manual_seed(seed)
             if torch.finfo(param.data.dtype).bits < 16:
                 # uniform_ doesn't support < 16-bit datatypes (FP8)

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -602,6 +602,11 @@ def initialize_dummy_weights(
                 # XLA device does not support torch.Generator()
                 param.uniform_(low, high)
                 continue
+            
+            if current_platform.is_hpu():
+                # HPU device does not support torch.Generator()
+                param.uniform_(low, high)
+                continue
 
             generator = torch.Generator(device=param.data.device)
             generator.manual_seed(seed)

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -602,13 +602,13 @@ def initialize_dummy_weights(
                 # XLA device does not support torch.Generator()
                 param.uniform_(low, high)
                 continue
-            
+
             if current_platform.is_hpu():
                 import habana_frameworks.torch.hpu.random as htrandom
                 generator = htrandom.default_generators[0]
             else:
                 generator = torch.Generator(device=param.data.device)
-                
+
             generator.manual_seed(seed)
             if torch.finfo(param.data.dtype).bits < 16:
                 # uniform_ doesn't support < 16-bit datatypes (FP8)


### PR DESCRIPTION
Dummy parameter initialization (load_format='dummy') is not working on hpu due to torch.generator not being supported. This PR fixes the issue by bypassing the generator.

