### PR TITLE
Expand supported attention head sizes

### DIFF
--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -28,7 +28,7 @@ class HPUPagedAttention:
 
     @staticmethod
     def get_supported_head_sizes() -> List[int]:
-        return list(range(1,257))
+        return list(range(1, 257))
 
     @staticmethod
     def get_kv_cache_shape(

--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -28,7 +28,7 @@ class HPUPagedAttention:
 
     @staticmethod
     def get_supported_head_sizes() -> List[int]:
-        return [64, 80, 96, 112, 128, 256]
+        return list(range(1,257))
 
     @staticmethod
     def get_kv_cache_shape(


### PR DESCRIPTION
There's no reason for current attention head sizes restrictions - we theoretically can support any size with current implementations. This patch fixes that.
