### PR TITLE
Update vllm-hpu-extension; fix for compile recompilations due to @cac…

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@e534851
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@bac2a62


### PR DESCRIPTION
Decorator @cache and "and" operator used by enabled_flags causes recompilations in torch compile. 
