### PR TITLE
Improve RMSNorm to support 2D inputs

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -113,11 +113,18 @@ class RMSNorm(CustomOp):
             orig_shape = x.shape
             residual += x.view(residual.shape)
             # Note: HPUFusedRMSNorm requires 3D tensors as inputs
+            residual_shape = residual.shape
+            if len(residual_shape) == 2:
+                residual = residual.unsqueeze(0)
             x = HPUFusedRMSNorm.apply(residual, self.weight,
                                       self.variance_epsilon)
-            return x.view(orig_shape), residual
+            return x.view(orig_shape), residual.view(residual_shape)
 
+        orig_shape = x.shape
+        if len(orig_shape) == 2:
+            x = x.unsqueeze(0)
         x = HPUFusedRMSNorm.apply(x, self.weight, self.variance_epsilon)
+        x = x.view(orig_shape)
         return x
 
     def forward_xpu(


### PR DESCRIPTION
SGLang may call vLLM RMSNorm kernel, and pass 2D inputs in shape [num_tokens, hidden_size].
In this PR, we unsqueeze the 2D inputs to 3D to meet HPUFusedRMSNorm requirements
