### PR TITLE
Enable roberta embedding

### DIFF
--- a/README_GAUDI.md
+++ b/README_GAUDI.md
@@ -366,7 +366,7 @@ Additionally, there are HPU PyTorch Bridge environment variables impacting vLLM 
 
 - `PT_HPU_LAZY_MODE`: if `0`, PyTorch Eager backend for Gaudi will be used, if `1` PyTorch Lazy backend for Gaudi will be used. `1` is the default.
 - `PT_HPU_ENABLE_LAZY_COLLECTIVES` must be set to `true` for tensor parallel inference with HPU Graphs.
-- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava, roberta models.
+- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava and roberta models.
 
 # Quantization, FP8 Inference and Model Calibration Process
 

--- a/README_GAUDI.md
+++ b/README_GAUDI.md
@@ -366,7 +366,7 @@ Additionally, there are HPU PyTorch Bridge environment variables impacting vLLM 
 
 - `PT_HPU_LAZY_MODE`: if `0`, PyTorch Eager backend for Gaudi will be used, if `1` PyTorch Lazy backend for Gaudi will be used. `1` is the default.
 - `PT_HPU_ENABLE_LAZY_COLLECTIVES` must be set to `true` for tensor parallel inference with HPU Graphs.
-- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava model.
+- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava, roberta models.
 
 # Quantization, FP8 Inference and Model Calibration Process
 

--- a/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
+++ b/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
@@ -363,7 +363,7 @@ Additionally, there are HPU PyTorch Bridge environment variables impacting vLLM 
 
 - `PT_HPU_LAZY_MODE`: if `0`, PyTorch Eager backend for Gaudi will be used, if `1` PyTorch Lazy backend for Gaudi will be used. `1` is the default.
 - `PT_HPU_ENABLE_LAZY_COLLECTIVES` must be set to `true` for tensor parallel inference with HPU Graphs.
-- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava, roberta models.
+- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava and roberta models.
 
 ## Quantization, FP8 Inference and Model Calibration Process
 

--- a/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
+++ b/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
@@ -363,7 +363,7 @@ Additionally, there are HPU PyTorch Bridge environment variables impacting vLLM 
 
 - `PT_HPU_LAZY_MODE`: if `0`, PyTorch Eager backend for Gaudi will be used, if `1` PyTorch Lazy backend for Gaudi will be used. `1` is the default.
 - `PT_HPU_ENABLE_LAZY_COLLECTIVES` must be set to `true` for tensor parallel inference with HPU Graphs.
-- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava model.
+- `PT_HPUGRAPH_DISABLE_TENSOR_CACHE` must be set to `false` for llava, roberta models.
 
 ## Quantization, FP8 Inference and Model Calibration Process
 

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -120,6 +120,7 @@ class RobertaEmbedding(nn.Module):
 # Adapted from transformers
 def create_position_ids_from_input_ids(input_ids,
                                        padding_idx,
+                                       seq_len,
                                        past_key_values_length=0):
     """
     Replace non-padding symbols with their position numbers.

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -93,7 +93,8 @@ class RobertaEmbedding(nn.Module):
             pos_list.append(position_ids[offset])
             token_list.append(input_ids[offset])
 
-        for index, (positions, tokens, seq_len) in enumerate(zip(pos_list, token_list, seq_lens)):
+        for index, (positions, tokens,
+                    seq_len) in enumerate(zip(pos_list, token_list, seq_lens)):
             # Verify assumption that incoming position are
             # always a sequence from 0 to N.
             expected_pos = torch.arange(positions.size()[0],
@@ -102,7 +103,8 @@ class RobertaEmbedding(nn.Module):
             valid_input_mask = expected_pos < seq_len.to('cpu')
             expected_pos = expected_pos * valid_input_mask
             assert torch.equal(positions.to('cpu'), expected_pos)
-            position_ids[index] = create_position_ids_from_input_ids(tokens, self.padding_idx, seq_len)
+            position_ids[index] = create_position_ids_from_input_ids(
+                tokens, self.padding_idx, seq_len)
 
         # Position embeddings.
         position_embeddings = self.position_embeddings(position_ids)

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -99,10 +99,10 @@ class RobertaEmbedding(nn.Module):
             # always a sequence from 0 to N.
             expected_pos = torch.arange(positions.size()[0],
                                         dtype=torch.long,
-                                        device='cpu')
-            valid_input_mask = expected_pos < seq_len.to('cpu')
+                                        device=inputs_embeds.device)
+            valid_input_mask = expected_pos < seq_len
             expected_pos = expected_pos * valid_input_mask
-            assert torch.equal(positions.to('cpu'), expected_pos)
+            assert torch.equal(positions, expected_pos)
             position_ids[index] = create_position_ids_from_input_ids(
                 tokens, self.padding_idx, seq_len)
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -864,9 +864,10 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     def _maybe_wrap_in_hpu_graph(self, *args, **kwargs):
         return htorch.hpu.wrap_in_hpu_graph(
-            HpuModelAdapter(*args, **kwargs), disable_tensor_cache=True, dry_run=False
-        ) if htorch.utils.internal.is_lazy() else HpuModelAdapter(
-            *args, **kwargs)
+            HpuModelAdapter(*args, **kwargs),
+            disable_tensor_cache=True,
+            dry_run=False) if htorch.utils.internal.is_lazy(
+            ) else HpuModelAdapter(*args, **kwargs)
 
     def get_model(self) -> nn.Module:
         if isinstance(self.model, HpuModelAdapter):

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -864,7 +864,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     def _maybe_wrap_in_hpu_graph(self, *args, **kwargs):
         return htorch.hpu.wrap_in_hpu_graph(
-            HpuModelAdapter(*args, **kwargs), disable_tensor_cache=True
+            HpuModelAdapter(*args, **kwargs), disable_tensor_cache=True, dry_run=False
         ) if htorch.utils.internal.is_lazy() else HpuModelAdapter(
             *args, **kwargs)
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -864,10 +864,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     def _maybe_wrap_in_hpu_graph(self, *args, **kwargs):
         return htorch.hpu.wrap_in_hpu_graph(
-            HpuModelAdapter(*args, **kwargs),
-            disable_tensor_cache=True,
-            dry_run=False) if htorch.utils.internal.is_lazy(
-            ) else HpuModelAdapter(*args, **kwargs)
+            HpuModelAdapter(*args, **kwargs), disable_tensor_cache=True
+        ) if htorch.utils.internal.is_lazy() else HpuModelAdapter(
+            *args, **kwargs)
 
     def get_model(self) -> nn.Module:
         if isinstance(self.model, HpuModelAdapter):


### PR DESCRIPTION
We set position_ids and input_ids as [batch_size, bucket_size] on hpu so need to modify the current roberta embedding forward function.

e.g. position_id on gpu
[0,1,2,3,4,5,6,7]
but position_id on hpu
[0,1,2,3,4,5,6,7,0,0,0,.....0,0] which size is 128 with padding in this case.

One thing I noticed is torch.equal() on hpu is not working properly and I have to run it on cpu.
That code is nothing but checking pre-condition but we will need to investigate it.

This PR has a dependency on https://github.com/HabanaAI/vllm-fork/pull/758

Update-
We found that the issue is from dry_run=True in hpu_graph. I think we should disable it.

From pt-integration team,

```
`disable_tensor_cache=True` is an experimental feature and should be used with caution. While some models can work with this flag directly, others need to pass the cache_tensors_list alongside disable_tensor_cache=True to ensure that certain tensors are not freed.
When `disable_tensor_cache=True` is enabled, it will free all tensors except user outputs and view tensors. However, certain tensors, such as in-place tensors, cannot be identified by hpugraph and will also be freed. To prevent this, these tensors must be specified in the cache_tensors_list.
Also, when `disable_tensor_cache=True` is enabled, dry_run is enabled by default.
when dry run is enabled, the intermediate values/SingleHpugraphs are not evaluated until the full graph is captured, so the necessary marksteps/evaluation happening internally will not update the values. eg: local_scalar_dense
So this can lead to accuracy issues.
```

Update2-
'disable_tensor_cache' is configurable by `PT_HPUGRAPH_DISABLE_TENSOR_CACHE`. I reverted my change and commented it to README.