### PR TITLE
Fix sporadic issue in async_engine/test_api_server tests

### DIFF
--- a/tests/async_engine/test_api_server.py
+++ b/tests/async_engine/test_api_server.py
@@ -96,7 +96,7 @@ def test_api_server(api_server, tokenizer_pool_size: int,
 
         # check cancellation stats
         # give it some times to update the stats
-        time.sleep(1)
+        time.sleep(3)
 
         num_aborted_requests = requests.get(
             "http://localhost:8000/stats").json()["num_aborted_requests"]


### PR DESCRIPTION
Fix the sporadic issue with not enough time to update statistics data in test_api_server test.

The requests are always canceled succesfully, but given time to update statistics was too short to work reliable.
