### PR TITLE
[Deepseek r1] improve latenct cache by save last 64 in key cache and 512 in value cache

### DIFF
--- a/scripts/run_static-online.sh
+++ b/scripts/run_static-online.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 tp_parrallel=8
-bs=96
 in_len=1024
 out_len=1024
 multi_step=1
 total_len=$((in_len + out_len))
+bs=96
+num_prompts=300
+request_rate=1
+gpu_utils=0.9
+ep_size=1
+moe_n_slice=4
+log_name="static-online-gaudi3-${gpu_utils}util-TPparallel${tp_parrallel}-EP${ep_size}-loop${moe_n_slice}moegroups-multistep${multi_step}_nprompt${num_prompts}_rrate${request_rate}_bs${bs}_i${in_len}_o${out_len}"
+
 VLLM_DECODE_BLOCK_BUCKET_MIN=$((in_len * bs / 128))
 VLLM_DECODE_BLOCK_BUCKET_MAX=$((total_len * bs / 128 + 128))
 
@@ -15,11 +22,10 @@ tokenizer="/data/models/DeepSeek-R1/"
 model_name="DeepSeek-R1"
 
 HABANA_VISIBLE_DEVICES="ALL" \
-VLLM_MOE_N_SLICE=4 \
+VLLM_MOE_N_SLICE=${moe_n_slice} \
+VLLM_EP_SIZE=${ep_size} \
 VLLM_MLA_DISABLE_REQUANTIZATION=1 \
 PT_HPU_ENABLE_LAZY_COLLECTIVES="true" \
-VLLM_RAY_DISABLE_LOG_TO_DRIVER="1" \
-RAY_IGNORE_UNHANDLED_ERRORS="1" \
 VLLM_PROMPT_BS_BUCKET_MIN=1 \
 VLLM_PROMPT_BS_BUCKET_MAX=${bs} \
 VLLM_PROMPT_SEQ_BUCKET_MIN=${in_len} \
@@ -38,14 +44,14 @@ python -m vllm.entrypoints.openai.api_server \
     --use-v2-block-manager \
     --num_scheduler_steps ${multi_step}\
     --max-model-len 2048 \
-    --distributed_executor_backend ray \
-    --gpu_memory_utilization 0.9 \
-    --trust_remote_code 2>&1 | tee benchmark_logs/serving.log &
+    --distributed_executor_backend mp \
+    --gpu_memory_utilization ${gpu_utils} \
+    --trust_remote_code 2>&1 | tee benchmark_logs/${log_name}_serving.log &
 pid=$(($!-1))
 
 until [[ "$n" -ge 100 ]] || [[ $ready == true ]]; do
     n=$((n+1))
-    if grep -q "Uvicorn running on" benchmark_logs/serving.log; then
+    if grep -q "Uvicorn running on" benchmark_logs/${log_name}_serving.log; then
         break
     fi
     sleep 5s
@@ -53,16 +59,17 @@ done
 sleep 5s
 echo ${pid}
 
-num_prompts=300
-request_rate=1
+hl-smi -l > benchmark_logs/${log_name}_hlsmi.log &
+hl_pid=$(($!-1))
+
+
 start_time=$(date +%s)
 echo "Start to benchmark"
-python benchmarks/benchmark_serving.py --backend vllm --model ${model} --tokenizer ${tokenizer} --dataset-name sonnet --dataset-path benchmarks/sonnet.txt --request-rate ${request_rate} --num-prompts ${num_prompts} --port 8080 --sonnet-input-len ${in_len} --sonnet-output-len ${out_len} --sonnet-prefix-len 100 \
---save-result 2>&1 | tee benchmark_logs/static-online-gaudi3-0.9util-TPparallel${tp_parrallel}-multistep${multi_step}_nprompt${num_prompts}_rrate${request_rate}_bs${bs}_i${in_len}_o${out_len}_prepad.log
+python benchmarks/benchmark_serving.py --backend vllm --model ${model} --tokenizer ${tokenizer} --dataset-name sonnet --dataset-path benchmarks/sonnet.txt --request-rate ${request_rate} --num-prompts ${num_prompts} --port 8080 --sonnet-input-len ${in_len} --sonnet-output-len ${out_len} --sonnet-prefix-len 100 2>&1 | tee benchmark_logs/${log_name}_run1.log
 end_time=$(date +%s)
 echo "Time elapsed: $((end_time - start_time))s"
 
 sleep 10
 
 kill ${pid}
-#--backend openai-chat --endpoint "v1/chat/completions"
+kill ${hl_pid}

--- a/scripts/run_static-online_ep4.sh
+++ b/scripts/run_static-online_ep4.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 tp_parrallel=8
-bs=96
 in_len=1024
 out_len=1024
 multi_step=1
 total_len=$((in_len + out_len))
-VLLM_DECODE_BLOCK_BUCKET_MIN=$((in_len * bs / 128))
-VLLM_DECODE_BLOCK_BUCKET_MAX=$((total_len * bs / 128 + 128))
 ep_size=4
 moe_n_slice=1
 gpu_utils=0.8
+bs=96
+num_prompts=96
+request_rate=96
+log_name="static-online-gaudi3-${gpu_utils}util-TPparallel${tp_parrallel}-EP${ep_size}-loop${moe_n_slice}moegroups-multistep${multi_step}_nprompt${num_prompts}_rrate${request_rate}_bs${bs}_i${in_len}_o${out_len}"
 
+VLLM_DECODE_BLOCK_BUCKET_MIN=$((in_len * bs / 128))
+VLLM_DECODE_BLOCK_BUCKET_MAX=$((total_len * bs / 128 + 128))
 # model="/data/models/DeepSeek-R1/"
 # tokenizer="/data/models/DeepSeek-R1/"
 model="/data/models/DeepSeek-R1/"
@@ -22,8 +25,6 @@ VLLM_MOE_N_SLICE=${moe_n_slice} \
 VLLM_EP_SIZE=${ep_size} \
 VLLM_MLA_DISABLE_REQUANTIZATION=1 \
 PT_HPU_ENABLE_LAZY_COLLECTIVES="true" \
-VLLM_RAY_DISABLE_LOG_TO_DRIVER="1" \
-RAY_IGNORE_UNHANDLED_ERRORS="1" \
 PT_HPU_WEIGHT_SHARING=0 \
 VLLM_PROMPT_BS_BUCKET_MIN=1 \
 VLLM_PROMPT_BS_BUCKET_MAX=${bs} \
@@ -45,12 +46,12 @@ python -m vllm.entrypoints.openai.api_server \
     --max-model-len 2048 \
     --distributed_executor_backend mp \
     --gpu_memory_utilization ${gpu_utils} \
-    --trust_remote_code 2>&1 | tee benchmark_logs/serving.log &
+    --trust_remote_code 2>&1 | tee benchmark_logs/${log_name}_serving.log &
 pid=$(($!-1))
 
 until [[ "$n" -ge 100 ]] || [[ $ready == true ]]; do
     n=$((n+1))
-    if grep -q "Uvicorn running on" benchmark_logs/serving.log; then
+    if grep -q "Uvicorn running on" benchmark_logs/${log_name}_serving.log; then
         break
     fi
     sleep 5s
@@ -58,15 +59,18 @@ done
 sleep 10s
 echo ${pid}
 
-num_prompts=96
-request_rate=96
+hl-smi -l > benchmark_logs/${log_name}_smi.log &
+hl_pid=$(($!-1))
+
+
 start_time=$(date +%s)
 echo "Start to benchmark"
-python benchmarks/benchmark_serving.py --backend vllm --model ${model} --tokenizer ${tokenizer} --dataset-name sonnet --dataset-path benchmarks/sonnet.txt --request-rate ${request_rate} --num-prompts ${num_prompts} --port 8080 --sonnet-input-len ${in_len} --sonnet-output-len ${out_len} --sonnet-prefix-len 100 2>&1 | tee benchmark_logs/static-online-gaudi3-${gpu_utils}util-TPparallel${tp_parrallel}-EP${ep_size}-loop${moe_n_slice}moegroups-multistep${multi_step}_nprompt${num_prompts}_rrate${request_rate}_bs${bs}_i${in_len}_o${out_len}_2.log
+python benchmarks/benchmark_serving.py --backend vllm --model ${model} --tokenizer ${tokenizer} --dataset-name sonnet --dataset-path benchmarks/sonnet.txt --request-rate ${request_rate} --num-prompts ${num_prompts} --port 8080 --sonnet-input-len ${in_len} --sonnet-output-len ${out_len} --sonnet-prefix-len 100 2>&1 | tee benchmark_logs/${log_name}_run1.log
 end_time=$(date +%s)
 echo "Time elapsed: $((end_time - start_time))s"
 
 sleep 10
 
 kill ${pid}
+kill ${hl_pid}
 #--backend openai-chat --endpoint "v1/chat/completions"

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -75,7 +75,7 @@ class HPUMLAAttentionBackend(HPUAttentionBackend):
         num_kv_heads: int,
         head_size: int,
     ) -> Tuple[int, ...]:
-        return (num_blocks, block_size, head_size), (num_blocks, block_size, head_size//9*8)
+        return (num_blocks, block_size, head_size//9*1), (num_blocks, block_size, head_size//9*8)
     
     @staticmethod
     def get_impl_cls() -> Type["HPUAttentionImpl"]:
@@ -85,6 +85,39 @@ class HPUMLAAttentionBackend(HPUAttentionBackend):
     def get_name() -> str:
         return "HPU_MLA"
 
+def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping,
+            block_bias, block_scales, block_groups, scale, matmul_qk_op,
+            matmul_av_op, batch2block_matmul_op, block2batch_matmul_op,
+            keys_fetch_func, values_fetch_func):
+    batch_size = query.size(0)
+    q_heads = query.size(1)
+    kv_heads = key_cache.size(2)
+
+    query = ops.batch2block(scale * query, block_mapping, batch2block_matmul_op).unsqueeze(-2)
+    key = keys_fetch_func(key_cache, block_list).transpose(1, 2)
+    value = values_fetch_func(value_cache, block_list).transpose(1, 2)
+    # get concat key
+    key = torch.concat((value, key), dim=-1)
+    block_bias = block_bias.view(key.size(0), 1, 1, -1)
+    if kv_heads != q_heads:
+        block_bias = block_bias.unsqueeze(1)
+        query = query.unflatten(1, (kv_heads, -1))
+        key = key.unflatten(1, (kv_heads, 1))
+        value = value.unflatten(1, (kv_heads, 1))
+        key = key.transpose(3, 4)
+    else:
+        key = key.transpose(2, 3)
+
+    attn = matmul_qk_op(query, key)
+    attn = attn + block_bias
+    attn = ops.pipelined_pa(attn, value, block_groups, block_mapping, block_scales=block_scales,
+                        batch_size=batch_size, matmul_av_op=matmul_av_op,
+                        batch2block_matmul_op=batch2block_matmul_op, block2batch_matmul_op=block2batch_matmul_op)
+    attn = ops.block2batch(attn, block_mapping, block2batch_matmul_op)
+    attn = attn.squeeze(-2)
+    if kv_heads != q_heads:
+        attn = attn.flatten(1, 2)
+    return attn
 
 @dataclass
 class HPUAttentionMetadata(HPUPagedAttentionMetadata, AttentionMetadata):
@@ -206,10 +239,10 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata]):
                 (k_c_normed, k_pe.view(batch_size, -1, self.qk_rope_head_dim)), dim=-1)
         # assert layer._k_scale == 0, f"got _k_scale={layer._k_scale}"
         latent_vec_k = latent_vec_k.view(-1, self.qk_rope_head_dim + self.kv_lora_rank)
-        latent_vec_v = k_c_normed.view(-1, self.kv_lora_rank)
+        #latent_vec_v = k_c_normed.view(-1, self.kv_lora_rank)
         if is_prefill:
             latent_vec_k = latent_vec_k.unflatten(0, (block_indices.size(0), -1))
-            latent_vec_v = latent_vec_v.unflatten(0, (block_indices.size(0), -1))
+            #latent_vec_v = latent_vec_v.unflatten(0, (block_indices.size(0), -1))
         # print("latent_vec", latent_vec.shape)
 
 
@@ -219,7 +252,8 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata]):
             # print(f"v cache shape: {kv_cache[1].shape}")
             # print(f"latent vec k shape: {latent_vec_k.shape}")
             # print(f"latent vec v shape: {latent_vec_v.shape}")
-            
+            latent_vec_v = latent_vec_k[..., :self.kv_lora_rank]
+            latent_vec_k = latent_vec_k[..., self.kv_lora_rank:]
             k_cache = self.latent_cache_k(latent_vec_k, kv_cache[0], block_indices,
                                         block_offsets)
             v_cache = self.latent_cache_v(latent_vec_v, kv_cache[1], block_indices,
@@ -284,7 +318,7 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata]):
         kv_c_and_k_pe_cache = kv_cache[0].unsqueeze(2)
         kv_c_cache = kv_cache[1].unsqueeze(2)
 
-        output = HPUPagedAttention.forward_decode(
+        output = flat_pa_mla(
             query=q,
             key_cache=kv_c_and_k_pe_cache,
             value_cache=kv_c_cache,

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -112,8 +112,8 @@ class CacheEngine:
         key_cache_block = cache_config.block_size * num_heads * head_size
         # For MLA there is no value cache, since the latent vector
         # is joint keys and values.
-        # value_cache_block = key_cache_block if not model_config.use_mla else 0
-        value_cache_block = key_cache_block // 9 * 8
+        value_cache_block = key_cache_block if not model_config.use_mla else 0
+        #value_cache_block = key_cache_block // 9 * 8
         total = num_attention_layers * (key_cache_block + value_cache_block)
         if cache_config.cache_dtype == "auto":
             dtype = model_config.dtype

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1828,6 +1828,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         max_blocks = kv_caches[0][0].size(0)
         self.bucketing_ctx.generate_prompt_buckets()
         self.bucketing_ctx.generate_decode_buckets(max_blocks)
+        
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
             multiplier = 3 if os.getenv('VLLM_REGIONAL_COMPILATION',
                                         'true').lower() == 'true' else 1


### PR DESCRIPTION
Before, we can only allocate 1854 blocks with 29.2G, now we are able to allocate 3156 blocks
Performance wise, not visible regression and able to push to higher batch_size or longer context length


