### PR TITLE
Fix guided decoding crashes

### DIFF
--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -91,3 +91,8 @@ stages:
       - name: test_gptq
         flavor: g2
         command: VLLM_SKIP_WARMUP=true pytest -v tests/quantization/test_gptq.py::test_gptq
+  - name: tests_guided_decode
+    steps:
+    - name: test_lazy_outlines
+      flavor: g2
+      command: pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_lazy_outlines.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,13 +47,6 @@ repos:
     types: [python]
     additional_dependencies: &mypy_deps [mypy==1.11.1, types-setuptools, types-PyYAML, types-requests]
     stages: [pre-commit] # Don't run in CI
-  - id: mypy-3.9 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
-    name: Run mypy for Python 3.9
-    entry: tools/mypy.sh 1 "3.9"
-    language: python
-    types: [python]
-    additional_dependencies: *mypy_deps
-    stages: [manual] # Only run in CI
   - id: mypy-3.10 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
     name: Run mypy for Python 3.10
     entry: tools/mypy.sh 1 "3.10"


### PR DESCRIPTION
This PR mostly ports https://github.com/vllm-project/vllm/pull/11389 to the design introduced by https://github.com/HabanaAI/vllm-fork/pull/358 and makes the custom caching code a little bit more robust.
Currently there are two problems with guided decode:
- `mask[list(allowed_tokens)] = 0` is causing crashes due to allowed_tokens containing tensors. Pretty easy fix.
- The value type of `self._fsm_state` was changed from `int` to union of `int` and `outlines.state.CFGState`, which may cause `self._cached_get_mask_tensor(state_id, scores.size(-1), scores.device)` to crash, as `outlines.state.CFGState` is not hashable. This PR changes the caching mechanism so that if function arguments are not hashable, their id is taken as key. This might cause some cache misses, but that's better than crashing, as it does right now.
None of the above is problem on upstream, as this stems from code introduced in https://github.com/HabanaAI/vllm-fork/pull/358.
I've also added guided decode tests to CI suite.