### PR TITLE
Resolve Speculative Decode RTE

### DIFF
--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -201,7 +201,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
              target_hidden_states, non_spec_target_token_ids,
              non_spec_target_probs, non_spec_target_logprobs,
              non_spec_target_hidden_states) = self._split_scoring_output_hpu(
-                 target_sampler_output, num_scoring_tokens)
+                 target_sampler_output, num_scoring_tokens, non_spec_indices)
         else:
             (target_token_ids, target_probs, target_logprobs,
              target_hidden_states, non_spec_target_token_ids,
@@ -312,7 +312,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
                 _,
                 _,
             ) = self._split_scoring_output_hpu(target_sampler_output,
-                                               num_scoring_tokens)
+                                               num_scoring_tokens, [])
         else:
             (
                 target_sampler_output.sampled_token_ids,
@@ -464,7 +464,8 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
 
     @staticmethod
     def _split_scoring_output_hpu(
-        sampler_output: SamplerOutput, num_scoring_tokens: int
+        sampler_output: SamplerOutput, num_scoring_tokens: int,
+        non_spec_indices: List[int],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor,
                Optional[torch.Tensor], torch.Tensor, torch.Tensor,
                torch.Tensor, Optional[torch.Tensor]]:
@@ -479,22 +480,25 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
         #
         # First samples are from speculative scoring, latter samples are non-
         # speculative samples.
-        split_sizes = (num_scoring_tokens,
+        split_sizes = (len(non_spec_indices),
+                       num_scoring_tokens,
                        sampler_output.sampled_token_ids.numel() -
-                       num_scoring_tokens)
-        (spec_probs, non_spec_probs
+                       num_scoring_tokens - len(non_spec_indices))
+        (non_spec_probs, spec_probs, dummy_probs
          ) = sampler_output.sampled_token_probs.split(split_sizes)
-        (spec_sampled_tokens, non_spec_sampled_tokens
+        (non_spec_sampled_tokens, spec_sampled_tokens, dummy_sampled_tokens
          ) = sampler_output.sampled_token_ids.flatten().split(split_sizes)
         (
-            spec_logprobs,
             non_spec_logprobs,
+            spec_logprobs,
+            dummy_logprobs,
         ) = sampler_output.logprobs.split(split_sizes)
 
         if sampler_output.hidden_states is not None:
             (
-                spec_hidden_states,
                 non_spec_hidden_states,
+                spec_hidden_states,
+                dummy_hidden_states,
             ) = sampler_output.hidden_states.split(split_sizes)
         else:
             spec_hidden_states, non_spec_hidden_states = None, None


### PR DESCRIPTION
- Speculative decoding fails when batch size exceeds 1 due to incorrect handling of mixed speculative and non-speculative sequences in the batch.
- This PR corrects batch expansion ordering and accounts for padding sequences.

Below is a reference to the line where we combine speculative and non-speculative. The order is clearly non-speculative first followed by speculative.
https://github.com/HabanaAI/vllm-fork/blob/4d91f3bf48381073e51deb0c03c19457c1ee5137/vllm/spec_decode/batch_expansion.py#L135

Below is a reference to the line where we pad the batch with dummy sequences. These also must be accounted for.
https://github.com/HabanaAI/vllm-fork/blob/4d91f3bf48381073e51deb0c03c19457c1ee5137/vllm/worker/hpu_model_runner.py#L1270-L1275

Below is the error that is encountered without this fix.
![image](https://github.com/user-attachments/assets/f4f15d3b-288c-45fd-aa43-cc61ba451c7b)

With this fix significantly higher throughputs can be achieved and accuracy is unimpacted (examined bert F1 accuracy; tested llama-3.1-8B with n-gram speculative decoding).
