### PR TITLE
[CI] Fix test_lazy_outlines.py performance, add more guided decode tests

### DIFF
--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -95,4 +95,8 @@ stages:
     steps:
     - name: test_lazy_outlines
       flavor: g2
-      command: pip install -e tests/vllm_test_utils && VLLM_SKIP_WARMUP=true pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO
+      command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils &&pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO 
+    - name: 
+      flavor: g2
+      command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_guided_generate.py -s -vvv --log-cli-level=INFO
+    

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -96,7 +96,7 @@ stages:
     - name: test_lazy_outlines
       flavor: g2
       command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils &&pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO 
-    - name: 
+    - name: test_guided_generate
       flavor: g2
       command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_guided_generate.py -s -vvv --log-cli-level=INFO
     

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -95,7 +95,7 @@ stages:
     steps:
     - name: test_lazy_outlines
       flavor: g2
-      command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils &&pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO 
+      command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO 
     - name: test_guided_generate
       flavor: g2
       command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_guided_generate.py -s -vvv --log-cli-level=INFO

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -95,4 +95,4 @@ stages:
     steps:
     - name: test_lazy_outlines
       flavor: g2
-      command: pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO
+      command: pip install -e tests/vllm_test_utils && VLLM_SKIP_WARMUP=true pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -95,4 +95,4 @@ stages:
     steps:
     - name: test_lazy_outlines
       flavor: g2
-      command: pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_lazy_outlines.py
+      command: pip install -e tests/vllm_test_utils && pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO

--- a/tests/entrypoints/llm/test_guided_generate.py
+++ b/tests/entrypoints/llm/test_guided_generate.py
@@ -10,7 +10,7 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import GuidedDecodingParams, SamplingParams
 
-MODEL_NAME = "Qwen/Qwen2.5-7B-Instruct"
+MODEL_NAME = "/mnt/weka/data/pytorch/Qwen/Qwen2-7b-Instruct"
 GUIDED_DECODING_BACKENDS = ["outlines", "lm-format-enforcer", "xgrammar"]
 
 

--- a/tests/entrypoints/llm/test_lazy_outlines.py
+++ b/tests/entrypoints/llm/test_lazy_outlines.py
@@ -17,8 +17,7 @@ def run_normal():
     sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
 
     # Create an LLM without guided decoding as a baseline.
-    llm = LLM(model="facebook/opt-125m",
-              enforce_eager=True,
+    llm = LLM(model="/mnt/weka/data/pytorch/llama3.2/Meta-Llama-3.2-1B",
               gpu_memory_utilization=0.3)
     outputs = llm.generate(prompts, sampling_params)
     for output in outputs:
@@ -33,8 +32,7 @@ def run_normal():
 
 def run_lmfe(sample_regex):
     # Create an LLM with guided decoding enabled.
-    llm = LLM(model="facebook/opt-125m",
-              enforce_eager=True,
+    llm = LLM(model="/mnt/weka/data/pytorch/llama3.2/Meta-Llama-3.2-1B",
               guided_decoding_backend="lm-format-enforcer",
               gpu_memory_utilization=0.3)
     sampling_params = SamplingParams(temperature=0.8, top_p=0.95)


### PR DESCRIPTION
This PR fixes the abnormally long execution time for test_lazy_outlines.py (>20 min down to <1min) and adds larger test suite for guided decoding with Qwen2-7b-Instruct (~4 minutes) 