### PR TITLE
[DO NOT MERGE] Return first token from the first step

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1408,9 +1408,10 @@ class LLMEngine:
                     scheduler_outputs.scheduled_seq_groups)
 
                 # Return the first token from the first step
-                for seq_group in seq_group_metadata_list:
-                    if seq_group.is_prompt and len(ctx.output_queue) > 0:
-                        self._process_model_outputs(ctx=ctx)
+                if envs.VLLM_STEP0_FIRST_TOKEN:
+                    for seq_group in seq_group_metadata_list:
+                        if seq_group.is_prompt and len(ctx.output_queue) > 0:
+                            self._process_model_outputs(ctx=ctx)
 
             # Check if need to run the usual non-async path
             if not allow_async_output_proc:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1407,6 +1407,11 @@ class LLMEngine:
                     outputs[0], seq_group_metadata_list,
                     scheduler_outputs.scheduled_seq_groups)
 
+                # Return the first token from the first step
+                for seq_group in seq_group_metadata_list:
+                    if seq_group.is_prompt and len(ctx.output_queue) > 0:
+                        self._process_model_outputs(ctx=ctx)
+
             # Check if need to run the usual non-async path
             if not allow_async_output_proc:
                 self._process_model_outputs(ctx=ctx)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
+    VLLM_STEP0_FIRST_TOKEN: bool = False
 
 
 def get_default_cache_root():
@@ -467,6 +468,10 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
+
+    # If set, return first token as soon as generated
+    "VLLM_STEP0_FIRST_TOKEN":
+    lambda: bool(int(os.getenv("VLLM_STEP0_FIRST_TOKEN", "0"))),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
First token is returned after the second step when there is no other prefill scheduled.
When TTFT is important, the second step is not desired.
Changes in this PR ensures that the first token is returned after the first step. 