### PR TITLE
[SW-212036] Change gc thr multiplier to 16

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -685,7 +685,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 os.environ.get(f'VLLM_GC_THR_GEN{i}', default_gc_thrs[i]))
         if requested_gc_thrs == default_gc_thrs:
             gc_thr_multiplier = int(os.environ.get('VLLM_GC_THR_MULTIPLIER',
-                                                   2))
+                                                   16))
             requested_gc_thrs = [
                 t * gc_thr_multiplier for t in default_gc_thrs
             ]


### PR DESCRIPTION
https://docs.python.org/3/library/gc.html#gc.set_threshold

We see every X calls a gap of 100-1s depending on the benchmark when garbage collector is called and increasing the default of this multiplier is fixing the issue. 
