### PR TITLE
Update requirements-hpu; set vllm-hpu-extension to support multi-node fp8 calibration

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@d4f37bb
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@42a9583

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@42a9583
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@d4b0d38


### PR DESCRIPTION
Related vllm-hpu-extension:
- branch: https://github.com/HabanaAI/vllm-hpu-extension/tree/v1.20.0
- commit: https://github.com/HabanaAI/vllm-hpu-extension/commit/d4b0d387842601c29cc2e4712935356a9dae9505