### PR TITLE
Align encoder decoder warmup to new input processors

### DIFF
--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -326,13 +326,11 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         if attn_metadata.is_prompt:
             batch_size = attn_metadata.num_prefills
             batched_tokens, _ = query.shape
-            if key is not None:
-                batched_kv_tokens, _, _ = key.shape
+            batched_kv_tokens, _, _ = key.shape
             assert batch_size > 0, (
                 "In prefill stage the num_prefills should be > 0")
             assert batched_tokens % batch_size == 0
-            if key is not None:
-                assert batched_kv_tokens % batch_size == 0
+            assert batched_kv_tokens % batch_size == 0
             seq_len = batched_tokens // batch_size
 
         query = query.view(-1, self.num_heads, self.head_size)
@@ -374,12 +372,6 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                                     device=query.device,
                                     dtype=torch.bool)
 
-            # NOTE(kzawora): mllama prefill fwd pass doesn't pass keys and
-            # values in profile_run. No idea why. This is a dirty workaround.
-            if key is None:
-                key = query
-            if value is None:
-                value = query
             out = ops.prompt_attention(
                 query.view(query_shape),
                 key.view(kv_shape),

--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -446,18 +446,24 @@ class HPUEncoderDecoderModelRunner(
         sampling_params = SamplingParams(temperature=temperature)
         num_blocks = math.ceil(seq_len / self.block_size)
         cross_block_table: Optional[List[int]] = None
-        encoder_dummy_data \
-            = self.input_registry.dummy_data_for_profiling(
-                self.model_config,
-                                        seq_len,
-                                        self.mm_registry,
-                                        is_encoder_data=True)
+        seq_len = max(seq_len, 1)
         mm_counts = self.mm_registry.get_mm_limits_per_prompt(
             self.model_config)
         num_images = mm_counts["image"]
         max_mm_tokens = self.mm_registry.get_max_multimodal_tokens(
             self.model_config) * num_images
-        seq_len = max(seq_len, 1)
+        decoder_dummy_data \
+            = self.input_registry.dummy_data_for_profiling(
+                self.model_config,
+                seq_len,
+                self.mm_registry,
+                is_encoder_data=False)
+        encoder_dummy_data \
+            = self.input_registry.dummy_data_for_profiling(
+                self.model_config,
+                max_mm_tokens,
+                self.mm_registry,
+                is_encoder_data=True)
         if is_prompt:
             input_len = seq_len
             output_len = 0
@@ -478,12 +484,13 @@ class HPUEncoderDecoderModelRunner(
         seq_data.output_token_ids = output_token_ids
         return SequenceGroupMetadata(
             request_id=str(group_id),
-            is_prompt=(output_len == 0),
+            is_prompt=is_prompt,
             seq_data={group_id: seq_data},
             sampling_params=sampling_params,
             block_tables=block_tables,
             encoder_seq_data=encoder_dummy_data.seq_data,
-            multi_modal_data=encoder_dummy_data.multi_modal_data,
+            multi_modal_data=decoder_dummy_data.multi_modal_data,
+            multi_modal_placeholders=decoder_dummy_data.multi_modal_placeholders,
             cross_block_table=cross_block_table)
 
     def trim_attn_metadata(self, metadata: AttentionMetadata) -> object:

--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -490,7 +490,8 @@ class HPUEncoderDecoderModelRunner(
             block_tables=block_tables,
             encoder_seq_data=encoder_dummy_data.seq_data,
             multi_modal_data=decoder_dummy_data.multi_modal_data,
-            multi_modal_placeholders=decoder_dummy_data.multi_modal_placeholders,
+            multi_modal_placeholders=decoder_dummy_data.
+            multi_modal_placeholders,
             cross_block_table=cross_block_table)
 
     def trim_attn_metadata(self, metadata: AttentionMetadata) -> object:


### PR DESCRIPTION
This PR removes WA for mllama error caused by new input processors after rebase: https://github.com/HabanaAI/vllm-fork/commit/0d3a5f5efe023de2d1853b3b14550734c6b5d6c8
It also aligns dummy sequence generation to match new input processors.
