### PR TITLE
Fixes delayed sampling for sequential requests

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2781,10 +2781,10 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         model_input = self.cached_step_inputs.pop(0)
         delayed_output = self.cached_step_outputs.pop(0).cpu().squeeze(-1).tolist()
         ctx = model_input.async_callback.keywords["ctx"]
-        assert len(ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
-        output_data = ctx.output_queue[0]
-        #assert len(output_data.outputs) == 1
-        if len(output_data.outputs) > 0:
+        #assert len(ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
+        if len(ctx.output_queue) > 0:
+            output_data = ctx.output_queue[0]
+            assert len(output_data.outputs) == 1
             for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
                 fake_out.samples[0].output_token = real_out
             for sg, real_out in zip(output_data.seq_group_metadata_list, delayed_output):

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2783,13 +2783,14 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         ctx = model_input.async_callback.keywords["ctx"]
         assert len(ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
         output_data = ctx.output_queue[0]
-        assert len(output_data.outputs) == 1
-        for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
-            fake_out.samples[0].output_token = real_out
-        for sg, real_out in zip(output_data.seq_group_metadata_list, delayed_output):
-            assert len(sg.seq_data) == 1
-            seq_data = list(sg.seq_data.values())[0]
-            # This is a hack. Assigning output_token_ids triggers
-            # a cache recomputation and we only need to update the last token
-            seq_data.output_token_ids_array[-1] = real_out
-            seq_data._cached_all_token_ids[-1] = real_out
+        #assert len(output_data.outputs) == 1
+        if len(output_data.outputs) > 0:
+            for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
+                fake_out.samples[0].output_token = real_out
+            for sg, real_out in zip(output_data.seq_group_metadata_list, delayed_output):
+                assert len(sg.seq_data) == 1
+                seq_data = list(sg.seq_data.values())[0]
+                # This is a hack. Assigning output_token_ids triggers
+                # a cache recomputation and we only need to update the last token
+                seq_data.output_token_ids_array[-1] = real_out
+                seq_data._cached_all_token_ids[-1] = real_out

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2781,19 +2781,20 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         model_input = self.cached_step_inputs.pop(0)
         delayed_output = self.cached_step_outputs.pop(0).cpu().squeeze(-1).tolist()
         ctx = model_input.async_callback.keywords["ctx"]
-        if len(ctx.output_queue) == 0:
-            self.cached_step_inputs.pop(0)
-        elif len(ctx.output_queue) == 1:
-            output_data = ctx.output_queue[0]
-            assert len(output_data.outputs) == 1
-            for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
-                fake_out.samples[0].output_token = real_out
-            for sg, real_out in zip(output_data.seq_group_metadata_list, delayed_output):
-                assert len(sg.seq_data) == 1
-                seq_data = list(sg.seq_data.values())[0]
-                # This is a hack. Assigning output_token_ids triggers
-                # a cache recomputation and we only need to update the last token
-                seq_data.output_token_ids_array[-1] = real_out
-                seq_data._cached_all_token_ids[-1] = real_out
-        else:
-            assert len(ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
+        # If there's no output to patch with,
+        # which is usually the case when we're starting a new request after all in-flight requests are completed,
+        # We return (Note that we have now cleared the cached_step_inputs/outputs as required).
+        if len(ctx.output_queue) == 0: 
+            return
+        assert len(ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
+        output_data = ctx.output_queue[0]
+        assert len(output_data.outputs) == 1
+        for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
+            fake_out.samples[0].output_token = real_out
+        for sg, real_out in zip(output_data.seq_group_metadata_list, delayed_output):
+            assert len(sg.seq_data) == 1
+            seq_data = list(sg.seq_data.values())[0]
+            # This is a hack. Assigning output_token_ids triggers
+            # a cache recomputation and we only need to update the last token
+            seq_data.output_token_ids_array[-1] = real_out
+            seq_data._cached_all_token_ids[-1] = real_out

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2781,8 +2781,9 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         model_input = self.cached_step_inputs.pop(0)
         delayed_output = self.cached_step_outputs.pop(0).cpu().squeeze(-1).tolist()
         ctx = model_input.async_callback.keywords["ctx"]
-        #assert len(ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
-        if len(ctx.output_queue) > 0:
+        if len(ctx.output_queue) == 0:
+            self.cached_step_inputs.pop(0)
+        elif len(ctx.output_queue) == 1:
             output_data = ctx.output_queue[0]
             assert len(output_data.outputs) == 1
             for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
@@ -2794,3 +2795,5 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 # a cache recomputation and we only need to update the last token
                 seq_data.output_token_ids_array[-1] = real_out
                 seq_data._cached_all_token_ids[-1] = real_out
+        else:
+            assert len(ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'


### PR DESCRIPTION
- Previously LLM.generate() could not be called multiple times with delayed sampling enabled.
- This also was the case with step() calls
- Issue occurs when after the last (batch) request is finished, and we're starting a new request, but `cached_step_inputs` and `cached_step_outputs` still contain elements saved from the last served (batch) request. This shouldn't be the case.
- The cleanest solution would be to skip appending to [`cached_step_inputs/outputs`](https://github.com/HabanaAI/vllm-fork/blob/50b28af6491ed6eb75794d4968fe1c679e65ea92/vllm/worker/hpu_model_runner.py#L2610-L2611) if the recently generated [`output`](https://github.com/HabanaAI/vllm-fork/blob/50b28af6491ed6eb75794d4968fe1c679e65ea92/vllm/worker/hpu_model_runner.py#L2608) is the final token generated for the current batch request. But couldn't find a cleaner way to check for this in the model runner.
- So we instead check (in [`_patch_prev_output`](https://github.com/HabanaAI/vllm-fork/blob/50b28af6491ed6eb75794d4968fe1c679e65ea92/vllm/worker/hpu_model_runner.py#L2776)) for when the scheduler context has empty output_queue, which means no pending outputs to patch.

Tests here: https://github.com/habana-internal/mlperf_inference/pull/158
