### PR TITLE
Added the logic to fix the warmup phase for spec decoding when enforce_eager is not used

### DIFF
--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -388,7 +388,8 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         """
         num_gpu_blocks, num_cpu_blocks = (
             self.scorer_worker.determine_num_available_blocks())
-
+        # Calling determine_num_available_blocks for draft model as well
+        self.proposer_worker.determine_num_available_blocks()
         scorer_cache_block_size_bytes = (
             self.scorer_worker.get_cache_block_size_bytes())
         proposer_cache_block_size_bytes = (

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1801,7 +1801,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         logger.info(msg)
 
     @torch.inference_mode()
-    def warmup_model(self, kv_caches: List[torch.Tensor]) -> None:
+    def warmup_model(self, kv_caches: List[torch.Tensor], mem_margin_val: Optional[float] = None) -> None:
         if profile := os.environ.get('VLLM_PT_PROFILE', None):
             phase, bs, seq_len, graph = profile.split('_')
             is_prompt = phase == 'prompt'
@@ -1855,6 +1855,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                     kv_caches)
 
             if not self.enforce_eager and htorch.utils.internal.is_lazy():
+                if self.mem_margin is None:
+                   self.mem_margin = mem_margin_val
                 assert self.mem_margin is not None, \
                     ("HabanaWorker.determine_num_available_blocks needs "
                     "to be called before warming up the model.")

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -389,7 +389,7 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         # NOTE(kzawora): We should use virtual engine index here
         # for pipeline parallelism. Using 0 for now.
         assert self.hpu_cache is not None
-        self.model_runner.warmup_model(self.hpu_cache[0])
+        self.model_runner.warmup_model(self.hpu_cache[0], self.model_runner.mem_margin)
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)


### PR DESCRIPTION
Added the logic to fix the warmup phase for spec decoding when enforce_eager is not used


Issue - HS-4898

<!--- pyml disable-next-line no-emphasis-as-heading -->
