### PR TITLE
Revert "Improve RMSNorm to support 2D inputs"

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -113,18 +113,11 @@ class RMSNorm(CustomOp):
             orig_shape = x.shape
             residual += x.view(residual.shape)
             # Note: HPUFusedRMSNorm requires 3D tensors as inputs
-            residual_shape = residual.shape
-            if len(residual_shape) == 2:
-                residual = residual.unsqueeze(0)
             x = HPUFusedRMSNorm.apply(residual, self.weight,
                                       self.variance_epsilon)
-            return x.view(orig_shape), residual.view(residual_shape)
+            return x.view(orig_shape), residual
 
-        orig_shape = x.shape
-        if len(orig_shape) == 2:
-            x = x.unsqueeze(0)
         x = HPUFusedRMSNorm.apply(x, self.weight, self.variance_epsilon)
-        x = x.view(orig_shape)
         return x
 
     def forward_xpu(


### PR DESCRIPTION
Reverts HabanaAI/vllm-fork#784 due to increased warmup time