### PR TITLE
Fix fsdpa usage inside enc_dec attention forward

### DIFF
--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -386,7 +386,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                 matmul_qk_op=self.matmul_qk,
                 softmax_op=self.softmax,
                 matmul_av_op=self.matmul_av,
-                fsdpa_op=self.fused_scaled_dot_product_attention,
+                fsdpa_op=self.fused_scaled_dot_product_attention
+                if self.prefill_use_fusedsdpa else None,
             )
             output = out.reshape(batch_size, seq_len, hidden_size)
         else:


### PR DESCRIPTION
Similar to https://github.com/HabanaAI/vllm-fork/blob/7c55e6662c54c96928f836a779257a786c0b67cd/vllm/attention/backends/hpu_attn.py#L266
