### PR TITLE
Added the logic to fix the warmup phase for spec decoding when enforce_eager is not used

### DIFF
--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -394,7 +394,12 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         """Calling the determine_num_available_blocks for
         draft model to calculate mem_margin
         """
-        self.proposer_worker.determine_num_available_blocks()
+        try:
+            self.proposer_worker.determine_num_available_blocks()
+        except NotImplementedError as e:
+            logger.info(
+                "determine_num_available_blocks method is not implemented : ",
+                type(self.proposer_worker))
         scorer_cache_block_size_bytes = (
             self.scorer_worker.get_cache_block_size_bytes())
         proposer_cache_block_size_bytes = (

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -396,7 +396,7 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         """
         try:
             self.proposer_worker.determine_num_available_blocks()
-        except NotImplementedError as e:
+        except NotImplementedError:
             logger.info(
                 "determine_num_available_blocks method is not implemented : ",
                 type(self.proposer_worker))

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -391,7 +391,10 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         """
         num_gpu_blocks, num_cpu_blocks = (
             self.scorer_worker.determine_num_available_blocks())
-
+        """Calling the determine_num_available_blocks for
+        draft model to calculate mem_margin
+        """
+        self.proposer_worker.determine_num_available_blocks()
         scorer_cache_block_size_bytes = (
             self.scorer_worker.get_cache_block_size_bytes())
         proposer_cache_block_size_bytes = (

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -258,3 +258,14 @@ class ModelRunnerWrapperBase:
 
     def __getattr__(self, attr):
         return getattr(self.model_runner, attr)
+
+    def __setattr__(self, name, value):
+        """
+        Ensure that setting the 'model_runner' attribute
+        does not delegate to model_runner
+        """
+
+        if name == "model_runner":
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self.model_runner, name, value)


### PR DESCRIPTION
HS-Ticket - https://habana.atlassian.net/browse/HS-4898 

Getting the below issue in offline/online mode when speculative_decoding is being used with warmup enabled.


return func(*args, **kwargs)
[rank0]:   File "/root/vllm-fork/vllm/worker/hpu_model_runner.py", line 1861, in warmup_model
[rank0]:     assert self.mem_margin is not None, \
[rank0]: AssertionError: HabanaWorker.determine_num_available_blocks needs to be called before warming up the model.

after checking further, profiling is being called on Target Model runner instance and the warmup is being called on HPUModelRunner instance, which is causing few of the variables not set correctly.
INFO 02-24 21:29:20 hpu_model_runner.py:711] Pre-loading model weights on hpu:0 took 238.9 MiB of device memory (12.64 GiB/94.62 GiB used) and 243.4 MiB of host memory (19.88 GiB/108.1 GiB used)
INFO 02-24 21:29:21 hpu_model_runner.py:789] Wrapping in HPU Graph took 0 B of device memory (12.64 GiB/94.62 GiB used) and 0 B of host memory (19.88 GiB/108.1 GiB used)
INFO 02-24 21:29:21 hpu_model_runner.py:793] Loading model weights took in total 238.9 MiB of device memory (12.64 GiB/94.62 GiB used) and 243.4 MiB of host memory (19.88 GiB/108.1 GiB used)
INFO 02-24 21:29:21 spec_decode_worker.py:339] [Speculative Decoding] Use batch expansion for scoring proposals.
In spec decode determine blocks:  <vllm.worker.hpu_worker.HPUWorker object at 0x7f870af030a0>
In spec decode determine blocks:  <vllm.spec_decode.multi_step_worker.MultiStepWorker object at 0x7f86f791b1f0>
In determine num available blocks - hpu_worker:  <vllm.spec_decode.target_model_runner.TargetModelRunner object at 0x7f8708c5df00>
INFO 02-24 21:29:22 hpu_worker.py:315] Model profiling run took 140 MiB of device memory (12.78 GiB/94.62 GiB used) and 49.74 MiB of host memory (19.93 GiB/108.1 GiB used)
In determine hpu_worker:  <vllm.spec_decode.target_model_runner.TargetModelRunner object at 0x7f8708c5df00>
In determine hpu_worker mem_margin:  8788168755.199999
INFO 02-24 21:29:22 hpu_worker.py:341] Free device memory: 81.85 GiB, 73.66 GiB usable (gpu_memory_utilization=0.9), 7.366 GiB reserved for HPUGraphs (VLLM_GRAPH_RESERVED_MEM=0.1), 66.3 GiB reserved for KV cache
In spec decoding, determine blocks is over
INFO 02-24 21:29:22 executor_base.py:96] # HPU blocks: 990, # CPU blocks: 64
INFO 02-24 21:29:22 executor_base.py:101] Maximum concurrency for 2048 tokens per request: 61.88x
INFO 02-24 21:29:23 hpu_worker.py:374] Initializing cache engine took 61.88 GiB of device memory (74.65 GiB/94.62 GiB used) and 136 KiB of host memory (19.93 GiB/108.1 GiB used)
In hpu worker _warm-up_model  <vllm.spec_decode.target_model_runner.TargetModelRunner object at 0x7f8708c5df00>
In warmup beginning:  <vllm.worker.hpu_model_runner.HPUModelRunner object at 0x7f870af03100>
Generated 5 prompt buckets [bs, seq]: [(1, 128), (2, 128), (4, 128), (8, 128), (16, 128)]
Omitted 1 prompt buckets due to exceeded token budget (max_num_batched_tokens=2048)
Omitted prompt buckets: [(32, 128)]
Generated 6 decode buckets [bs, total_blocks]: [(1, 128), (2, 128), (4, 128), (8, 128), (16, 128), (32, 128)]
In warm up 2:  <vllm.worker.hpu_model_runner.HPUModelRunner object at 0x7f870af03100>
INFO 02-24 21:29:23 hpu_model_runner.py:1730] [Warmup][Prompt][1/5] batch_size:16 seq_len:128 free_mem:19.97 GiB
INFO 02-24 21:29:23 hpu_model_runner.py:1730] [Warmup][Prompt][2/5] batch_size:8 seq_len:128 free_mem:19.96 GiB
INFO 02-24 21:29:24 hpu_model_runner.py:1730] [Warmup][Prompt][3/5] batch_size:4 seq_len:128 free_mem:19.96 GiB
INFO 02-24 21:29:25 hpu_model_runner.py:1730] [Warmup][Prompt][4/5] batch_size:2 seq_len:128 free_mem:19.96 GiB
INFO 02-24 21:29:25 hpu_model_runner.py:1730] [Warmup][Prompt][5/5] batch_size:1 seq_len:128 free_mem:19.96 GiB
INFO 02-24 21:29:26 hpu_model_runner.py:1730] [Warmup][Decode][1/6] batch_size:32 num_blocks:128 free_mem:19.96 GiB
INFO 02-24 21:29:27 hpu_model_runner.py:1730] [Warmup][Decode][2/6] batch_size:16 num_blocks:128 free_mem:19.96 GiB
INFO 02-24 21:29:28 hpu_model_runner.py:1730] [Warmup][Decode][3/6] batch_size:8 num_blocks:128 free_mem:19.96 GiB
INFO 02-24 21:29:28 hpu_model_runner.py:1730] [Warmup][Decode][4/6] batch_size:4 num_blocks:128 free_mem:19.96 GiB
INFO 02-24 21:29:29 hpu_model_runner.py:1730] [Warmup][Decode][5/6] batch_size:2 num_blocks:128 free_mem:19.96 GiB
INFO 02-24 21:29:30 hpu_model_runner.py:1730] [Warmup][Decode][6/6] batch_size:1 num_blocks:128 free_mem:19.96 GiB
In hpu_model_runner - not eager mode,  <vllm.worker.hpu_model_runner.HPUModelRunner object at 0x7f870af03100>
[rank0]: Traceback (most recent call last):
[rank0]:   File "/root/vllm-fork/test_spec.py", line 8, in <module>
[rank0]:     llm = LLM(
[rank0]:   File "/root/vllm-fork/vllm/utils.py", line 1110, in inner
[rank0]:     return fn(*args, **kwargs)
[rank0]:   File "/root/vllm-fork/vllm/entrypoints/llm.py", line 236, in __init__
[rank0]:     self.llm_engine = self.engine_class.from_engine_args(
[rank0]:   File "/root/vllm-fork/vllm/engine/llm_engine.py", line 482, in from_engine_args
[rank0]:     engine = cls(
[rank0]:   File "/root/vllm-fork/vllm/engine/llm_engine.py", line 274, in __init__
[rank0]:     self._initialize_kv_caches()
[rank0]:   File "/root/vllm-fork/vllm/engine/llm_engine.py", line 427, in _initialize_kv_caches
[rank0]:     self.model_executor.initialize_cache(num_gpu_blocks, num_cpu_blocks)
[rank0]:   File "/root/vllm-fork/vllm/executor/executor_base.py", line 107, in initialize_cache
[rank0]:     self.collective_rpc("initialize_cache",
[rank0]:   File "/root/vllm-fork/vllm/executor/uniproc_executor.py", line 51, in collective_rpc
[rank0]:     answer = run_method(self.driver_worker, method, args, kwargs)
[rank0]:   File "/root/vllm-fork/vllm/utils.py", line 2288, in run_method
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/root/vllm-fork/vllm/spec_decode/spec_decode_worker.py", line 409, in initialize_cache
[rank0]:     self.scorer_worker.initialize_cache(num_gpu_blocks=num_gpu_blocks,
[rank0]:   File "/root/vllm-fork/vllm/worker/hpu_worker.py", line 375, in initialize_cache
[rank0]:     self._warm_up_model()
[rank0]:   File "/root/vllm-fork/vllm/worker/hpu_worker.py", line 396, in _warm_up_model
[rank0]:     self.model_runner.warmup_model(self.hpu_cache[0])
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/root/vllm-fork/vllm/worker/hpu_model_runner.py", line 1861, in warmup_model
[rank0]:     assert self.mem_margin is not None, \
[rank0]: AssertionError: HabanaWorker.determine_num_available_blocks needs to be called before warming up the model.