### PR TITLE
Add helm chart demonstrating multi model serving using k8s

### DIFF
--- a/scripts/vllm-multi-model-chart/.helmignore
+++ b/scripts/vllm-multi-model-chart/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.venv/
+.vscode/

--- a/scripts/vllm-multi-model-chart/Chart.yaml
+++ b/scripts/vllm-multi-model-chart/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: vllm-multi-model-chart
+description: Serves multiple models using vLLM using a single Intel Gaudi HPU
+
+# Compatible Kubernetes versions
+kubeVersion: 1.27 - 1.29
+
+# Chart type
+type: application
+
+# Chart version
+version: 0.1.0

--- a/scripts/vllm-multi-model-chart/README.md
+++ b/scripts/vllm-multi-model-chart/README.md
@@ -1,0 +1,110 @@
+# Deploy vLLM with Multiple Models using Intel® Gaudi® AI accelerators with Kubernetes
+
+This example demonstrates using vLLM to serve multiple models with a single Intel Gaudi HPU from a Kubernetes cluster.
+
+## Prerequisites
+
+To run this example you will need:
+* Docker to build and push the docker image
+* A Kubernetes cluster with Intel® Gaudi® Al accelerators (see the
+  [Kubernetes Installation](https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/Kubernetes_Installation/index.html)
+  instructions for Intel Gaudi or the [Intel Kubernetes Service Guide](https://console.cloud.intel.com/docs/guides/k8s_guide.html)
+  for using a Kubernetes cluster from Intel® Tiber™ AI Cloud)
+* [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
+* [Helm](https://helm.sh/docs/intro/quickstart/) installed and configured
+
+## Docker Image
+
+Before deploying vLLM to Kubernetes, you will first need to build and push a vLLM docker image for HPU. To do this,
+clone the `multi_model` branch from the [HabanaAI fork of vLLM](https://github.com/HabanaAI/vllm-fork/tree/multi_model),
+and build the image using the `Dockerfile.hpu` file. Push the image to a registry that will be accessible by your
+Kubernetes cluster nodes.
+
+```
+# Clone the multi_model branch of the HabanaAI fork of vLLM
+git clone https://github.com/HabanaAI/vllm-fork.git --branch multi_model --single-branch --depth 1
+cd vllm-fork
+
+# Build the docker image
+$ docker build -f Dockerfile.hpu -t vllm-hpu-env .
+
+# Tag and push the image to a container registry
+docker tag vllm-hpu-env <registry/image:tag>
+docker push <registry/image:tag>
+```
+
+### Deploy vLLM using Kubernetes
+
+After the docker image has been built and pushed, use the [Helm](https://helm.sh) chart to deploy vLLM to your cluster.
+
+The Helm chart includes:
+* Secret used for storing a [Hugging Face token](https://huggingface.co/docs/hub/en/security-tokens)
+* [Persistent volume claim (PVC)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for the [Hugging Face Hub model cache](https://huggingface.co/docs/huggingface_hub/en/guides/manage-cache) directory
+* Deployment to run the vLLM model server
+* Service to expose the deployment
+
+1. Before installing the Helm chart, update the [`values.yaml` file](values.yaml) to configure your job. Important
+   values that you will need to set are:
+   * Set `image.repository` and `image.tag` based on the docker image that you have built and pushed.
+   * Set`secret.hfToken` with your Hugging Face token, if you are using gated models.
+   * The `args` section has the command used launch vLLM. In those args, specify the name of the models to serve.
+   * Set your Kubernetes storage class name in the `storage.storageClassName` field.
+   * The `resources` section defines the resource limits and requests for the deployment.
+
+2. After configuring the [`values.yaml`](values.yaml) file, the Helm chart can be deployed to the cluster:
+   ```
+   cd scripts/vllm-multi-model-chart
+   helm install -f values.yaml gaudi-multi-model .
+   ```
+3. Monitor the job by check the pod status, and viewing the logs. It will take a few minutes for the model weights to
+   download. Note that if the same PVC is reused, subsequent runs can use cached models files.
+   ```
+   kubectl get pods
+
+   kubectl logs <gaudi-multi-model-deployment pod name> -f
+   ```
+   When it's ready you will see a message about Uvicorn running on port 8000.
+4. If you don't have an external IP for the node running the vLLM deployment, port forward in order to access the
+   vLLM service from your local machine. In a separate terminal port forward:
+   ```
+   kubectl port-forward svc/gaudi-multi-model-service 8000:80
+   ```
+5. Now that the service is up and running, you can use cURL commands to test the deployment. For example:
+   * List the running models:
+     ```
+     curl http://localhost:8000/v1/models
+     ```
+
+   * Query the served models with prompt inputs (change the `model`, depending on the names of the models that you
+     served - by default, the values file uses `meta-llama/Llama-3.1-8B-Instruct` and `mistralai/Mistral-7B-Instruct-v0.3`):
+     ```
+     curl http://localhost:8000/v1/completions \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "prompt": "San Francisco is a",
+            "max_tokens": 20,
+            "temperature": 0
+            }'
+     ```
+
+   * Swap out the models being served:
+     ```
+     curl http://localhost:8000/v1/update_models \
+        -H "Content-Type: application/json" \
+        -d '{"models": [{"id":"mistralai/Mistral-7B-Instruct-v0.3"},{"id":"Qwen/Qwen2.5-7B-Instruct"}]}'
+     ```
+
+We have demonstrated serving multiple models using a single HPU from a Kubernetes cluster using vLLM. When you are done,
+the vLLM deployment and service can be shut down to free resources using:
+```
+kubectl delete deployment gaudi-multi-model-deployment
+kubectl delete service gaudi-multi-model-service
+```
+This leaves the PVC and secret resources for use with future deployments
+(using `helm upgrade -f values.yaml gaudi-multi-model .`).
+
+If you would like to delete all Helm chart resources, uninstall the chart:
+```
+helm uninstall gaudi-multi-model
+```

--- a/scripts/vllm-multi-model-chart/templates/deployment.yaml
+++ b/scripts/vllm-multi-model-chart/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-deployment
+  labels:
+    app: vllm-hpu-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-hpu-app
+  template:
+    metadata:
+      labels:
+        app: vllm-hpu-app
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Release.Name }}-container
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        image:  "{{ required "Required value 'image.repository' must be defined in your values.yaml file" .Values.image.repository }}:{{ required "Required value 'image.tag' must be defined in your values.yaml file" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.command }}
+        command:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.args }}
+        args:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        env:
+        {{- if .Values.secret.hfToken}}
+        - name: HUGGING_FACE_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-hf-token-secret
+              key: token
+        {{- end }}
+        {{- toYaml .Values.env | nindent 8 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        volumeMounts:
+        - name: cache-volume 
+          mountPath: {{ .Values.storage.pvcMountPath }}
+        - name: shm
+          mountPath: /dev/shm
+        {{- with .Values.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      volumes:
+      - name: cache-volume
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-pvc
+      # vLLM needs to access the host's shared memory for tensor parallel inference.
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: "2Gi"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/scripts/vllm-multi-model-chart/templates/pvc.yaml
+++ b/scripts/vllm-multi-model-chart/templates/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-pvc
+spec:
+  storageClassName: {{ .Values.storage.storageClassName }}
+  {{- with .Values.storage.accessModes }}
+  accessModes:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.storage.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/scripts/vllm-multi-model-chart/templates/secret.yaml
+++ b/scripts/vllm-multi-model-chart/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.secret.hfToken}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-hf-token-secret
+type: Opaque
+data:
+  token: {{ .Values.secret.hfToken | b64enc }}
+{{- end }}

--- a/scripts/vllm-multi-model-chart/templates/service.yaml
+++ b/scripts/vllm-multi-model-chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-service
+spec:
+  ports:
+  - name: {{ .Release.Name }}-http
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.service.targetPort }}
+  # The label selector should match the deployment labels
+  selector:
+    app: vllm-hpu-app
+  sessionAffinity: None
+  type: ClusterIP

--- a/scripts/vllm-multi-model-chart/values.yaml
+++ b/scripts/vllm-multi-model-chart/values.yaml
@@ -1,0 +1,131 @@
+# Default values for vllm-multi-model-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Repository and name of the docker image
+  repository: 
+  # -- Tag of the docker image
+  tag: 
+  # -- Determines when the kubelet will pull the image to the worker nodes. Choose from: `IfNotPresent`, `Always`, or `Never`. If updates to the image have been made, use `Always` to ensure the newest image is used.
+  pullPolicy: IfNotPresent
+
+secret:
+  # -- Hugging Face token
+  hfToken: 
+
+# -- Optional [image pull secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) to pull from a private registry
+imagePullSecrets: []
+
+# -- Entrypoint to run bash commands defined in the args 
+command: ["bash", "-c"]
+
+# -- Entrypoint script to define the models to serve, calculate the memory allocation based on the number of models being served, and start the vLLM server
+args:
+  - >-
+    set -x
+
+    models=("mistralai/Mistral-7B-Instruct-v0.3" "meta-llama/Llama-3.1-8B-Instruct")
+    mem_ratio=$(awk -v n1=$(expr 9 / ${#models[@]}) 'BEGIN {printf "%.2f", n1 / 10}')
+
+    python3 -m vllm.entrypoints.openai.mm_api_server \
+      --models ${models[@]} \
+      --port 8000 \
+      --device hpu \
+      --dtype bfloat16 \
+      --gpu-memory-utilization=$mem_ratio \
+      --use-v2-block-manager \
+      --max-model-len 4096
+
+# -- Pod [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to attach metadata to the job
+podAnnotations: {}
+
+# -- Specify a pod security context to run as a non-root user
+podSecurityContext: {}
+  # runAsUser: 1000
+  # runAsGroup: 3000
+  # fsGroup: 2000
+
+# -- Optionally specify [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) settings
+securityContext:
+  capabilities:
+    add: ["SYS_NICE"]
+
+# -- Optionally define a config map's data as container environment variables
+envFrom: []
+
+# -- Define environment variables to set in the container
+env:
+- name: VLLM_CONTIGUOUS_PA
+  value: "false"
+- name: VLLM_SKIP_WARMUP
+  value: "true"
+- name: OMPI_MCA_btl_vader_single_copy_mechanism
+  value: "none"
+
+service:
+  # -- Expose the model inference endpoint on the specified port
+  port: 80
+  # -- Port where vLLM is running within the pod
+  targetPort: 8000
+
+# -- Specify resource limits and requests for the deployment
+resources:
+  limits:
+    cpu: "20"
+    memory: 128G
+    habana.ai/gaudi: 1
+    hugepages-2Mi: 4000Mi
+  requests:
+    cpu: "20"
+    memory: 128G
+    habana.ai/gaudi: 1
+    hugepages-2Mi: 4000Mi
+
+storage:
+  # -- Name of the storage class to use for the persistent volume claim. To list the available storage classes use: `kubectl get storageclass`.
+  storageClassName: default
+  # -- [Access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for the persistent volume.
+  accessModes:
+  - "ReadWriteOnce"
+  # -- Storage [resources](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resources)
+  resources:
+    requests:
+      storage: 60Gi
+  # -- Locaton where the PVC will be mounted in the deployment pod
+  pvcMountPath: /root/.cache/huggingface
+
+# -- Endpoint to verify health of the container and determine if it should be restarted
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 24
+
+# -- Probe to determine when the deployment is ready
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+# -- Probe to determine if the application has started
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 120
+
+# -- Optionally use the [nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) to target nodes with a specified label 
+nodeSelector: {}
+
+# -- Optionally specify [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) to run on tainted nodes
+tolerations: []
+
+# -- Optionally specify an [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) to contrain deployment pod to nodes with specific labels
+affinity: {}


### PR DESCRIPTION
This PR adds an example of a Kubernetes helm chart that is used to deploy the vLLM server with multiple models using a single Gaudi card. The templates in the helm chart follow the same type of deployment described in the [vLLM Kubernetes documentation](https://docs.vllm.ai/en/latest/deployment/k8s.html) where it uses a secret for the HF token, PVC for the HF hub cache, and a deployment/service for the vLLM server. The helm chart `values.yaml` file deploys the vLLM server using `mistralai/Mistral-7B-Instruct-v0.3` and `meta-llama/Llama-3.1-8B-Instruct` by default. These can be modified as needed.