### PR TITLE
[SW-221458] Synchronization between HPU and CPU for more precise TTFT measurement

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2465,6 +2465,9 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     logits = self.model.compute_logits(hidden_states,
                                                        sampling_metadata)
                 htorch.core.mark_step()
+                # Force synchronization between HPU and CPU for more precise TTFT measurement
+                torch.hpu.synchronize() 
+                
                 # Only perform sampling in the driver worker.
                 if not self.is_driver_worker:
                     continue


### PR DESCRIPTION
Now the TTFT is measured on the CPU side. It is not that accurate, due to asynchronous execution between the CPU and HPU, leading to an underestimation of actual HPU computation time. It can be seen from profiling file that when the first token time is set on the CPU, the calculation on the HPU has not yet been completed. 

Adding synchronization between HPU and CPU after compute_logits when first_token_time is set, ensuring more precise TTFT measurement.