### PR TITLE
Update `_maybe_wrap_in_hpu_graph` function

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -902,8 +902,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         return seq_group_metadata_list, real_batch_size, batch_size_padded
 
     def _maybe_wrap_in_hpu_graph(self, *args, **kwargs):
-        disable_cache = os.environ.get('PT_HPUGRAPH_DISABLE_TENSOR_CACHE', 'true')
-        disable_cache = disable_cache.lower() in ('true', '1')
+        disable_cache_var = os.environ.get('PT_HPUGRAPH_DISABLE_TENSOR_CACHE', 'true')
+        disable_cache: bool = disable_cache_var.lower() in ('true', '1')
         return htorch.hpu.wrap_in_hpu_graph(
             HpuModelAdapter(*args, **kwargs),
             disable_tensor_cache=disable_cache,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -161,11 +161,6 @@ def get_target_layer_suffix_list(model_type) -> list[str]:
     ]
 
 
-def get_hpu_disable_tensor_cache():
-    env_var = os.environ.get('HPU_DISABLE_TENSOR_CACHE', 'true')
-    return env_var.lower() == 'true'
-
-
 def modify_model_layers(module: torch.nn.Module,
                         suffix_list: list[str],
                         n=1,
@@ -907,14 +902,11 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         return seq_group_metadata_list, real_batch_size, batch_size_padded
 
     def _maybe_wrap_in_hpu_graph(self, *args, **kwargs):
-        disable_tensor_cache = get_hpu_disable_tensor_cache()
-        if self.model_is_mrope:
-            logger.warning(
-                "Setting HPU_DISABLE_TENSOR_CACHE to False for this model")
-            disable_tensor_cache = False
+        disable_cache = os.environ.get('PT_HPUGRAPH_DISABLE_TENSOR_CACHE', 'true')
+        disable_cache = disable_cache.lower() in ('true', '1')
         return htorch.hpu.wrap_in_hpu_graph(
             HpuModelAdapter(*args, **kwargs),
-            disable_tensor_cache=True,
+            disable_tensor_cache=disable_cache,
         ) if htorch.utils.internal.is_lazy() else HpuModelAdapter(
             *args, **kwargs)
 


### PR DESCRIPTION
# What does this PR do?

- Removed the `get_hpu_disable_tensor_cache` function.
- Updated `_maybe_wrap_in_hpu_graph` to directly read the environment variable `PT_HPUGRAPH_DISABLE_TENSOR_CACHE`.
- Fix the logic to determine `disable_tensor_cache` by checking if the environment variable is set to 'true' or '1' and prevent mismatch issues.