### PR TITLE
Fix a typo in dtype conversion log

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2358,7 +2358,7 @@ def _get_and_verify_dtype(
 
             if current_platform.is_hpu() and config_dtype == torch.float16:
                 logger.info(
-                    "For HPU, we cast models to bfloat16 instead of"
+                    "For HPU, we cast models to bfloat16 instead of "
                     "using float16 by default. Please specify `dtype` if you "
                     "want to use float16.")
                 torch_dtype = torch.bfloat16


### PR DESCRIPTION
Fix missing space in the log info for model type casting
