### PR TITLE
Disable lora long-context test

### DIFF
--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -66,9 +66,9 @@ stages:
       - name: test_multilora
         flavor: g2
         command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_multilora_hpu.py::test_llama_multilora_1x
-      - name: test_long_context
-        flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_long_context_hpu.py::test_quality
+      # - name: test_long_context
+      #   flavor: g2
+      #   command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_long_context_hpu.py::test_quality
   - name: tests_multimodal
     steps:
       - name: multimodal_small_g3_tp1

--- a/.jenkins/test_config_t_compile.yaml
+++ b/.jenkins/test_config_t_compile.yaml
@@ -66,9 +66,9 @@ stages:
       - name: test_multilora
         flavor: g2
         command: PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_multilora_hpu.py::test_llama_multilora_1x
-      - name: test_long_context
-        flavor: g2
-        command: PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_long_context_hpu.py::test_quality
+      # - name: test_long_context
+      #   flavor: g2
+      #   command: PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_long_context_hpu.py::test_quality
   - name: tests_multimodal
     steps:
       - name: multimodal_small_g3_tp1


### PR DESCRIPTION
Once we switched CI to 1.20.0 release the **test_long_context** (command: `VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_long_context_hpu.py::test_quality`) test raises some response quality issues with lazy and compile modes. We decided to disable test until the fix will be provided.