### PR TITLE
Split qkv and gate_up for llama; TP overlap with mlp

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1019,6 +1019,8 @@ class CacheConfig:
             prefix caching enabled.
         enable_prefix_caching: Whether to enable prefix caching.
         cpu_offload_gb: Size of the CPU offload buffer in GiB.
+        split_qk_v: Whether to split qk and v calculations.
+        split_gate_up: Whether to split gate and up calculations.
     """
 
     def compute_hash(self) -> str:
@@ -1050,6 +1052,8 @@ class CacheConfig:
         sliding_window: Optional[int] = None,
         enable_prefix_caching: bool = False,
         cpu_offload_gb: float = 0,
+        split_qk_v: bool = False,
+        split_gate_up: bool = False,
         calculate_kv_scales: Optional[bool] = None,
     ) -> None:
         self.block_size = block_size
@@ -1061,6 +1065,8 @@ class CacheConfig:
         self.sliding_window = sliding_window
         self.enable_prefix_caching = enable_prefix_caching
         self.cpu_offload_gb = cpu_offload_gb
+        self.split_qk_v = split_qk_v
+        self.split_gate_up = split_gate_up
         self.calculate_kv_scales = calculate_kv_scales
         self._verify_args()
         self._verify_cache_dtype()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -541,6 +541,14 @@ class EngineArgs:
             default=None,
             help='If specified, ignore GPU profiling result and use this number'
             ' of GPU blocks. Used for testing preemption.')
+        parser.add_argument('--split-qk-v',
+                            action='store_true',
+                            default=EngineArgs.split_qk_v,
+                            help='Whether to separate qk and v calculations.')
+        parser.add_argument('--split-gate-up',
+                            action='store_true',
+                            default=EngineArgs.split_gate_up,
+                            help='Whether to separate gate and up calculations.')
         parser.add_argument('--max-num-batched-tokens',
                             type=int,
                             default=EngineArgs.max_num_batched_tokens,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -122,6 +122,8 @@ class EngineArgs:
     swap_space: float = 4  # GiB
     cpu_offload_gb: float = 0  # GiB
     gpu_memory_utilization: float = 0.90
+    split_qk_v: bool = False
+    split_gate_up: bool = False
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: Optional[int] = None
     max_num_prefill_seqs: Optional[int] = None
@@ -1151,6 +1153,8 @@ class EngineArgs:
             cache_dtype=self.kv_cache_dtype,
             is_attention_free=model_config.is_attention_free,
             num_gpu_blocks_override=self.num_gpu_blocks_override,
+            split_qk_v=self.split_qk_v,
+            split_gate_up=self.split_gate_up,
             sliding_window=model_config.get_sliding_window(),
             enable_prefix_caching=self.enable_prefix_caching,
             cpu_offload_gb=self.cpu_offload_gb,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -310,6 +310,10 @@ class LLMEngine:
                     self.model_config.enforce_eager,
                     "disable_custom_all_reduce":
                     self.parallel_config.disable_custom_all_reduce,
+                    "split_qk_v":
+                    self.cache_config.split_qk_v,
+                    "split_gate_up":
+                    self.cache_config.split_gate_up,
                 })
 
         if self.tokenizer:

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Inference-only LLaMA model compatible with HuggingFace weights."""
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
+import os
 
 import torch
 from torch import nn
@@ -37,6 +38,7 @@ from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (MergedColumnParallelLinear,
                                                QKVParallelLinear,
+                                               ColumnParallelLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -57,7 +59,22 @@ from .utils import (AutoWeightsLoader, PPMissingLayer, extract_layer_index,
                     maybe_prefix)
 
 is_hpu = current_platform.is_hpu()
+if is_hpu:
+    import habana_frameworks.torch as htorch
 
+# split_size>128: fixed-length splits (each slice is split_size)
+# split_size<128: fixed-num splits (split_size num of slices)
+def get_split_size(seq_len, batch_size, orig_split_size):
+    if orig_split_size<128:
+        split_size = max((seq_len*batch_size)//orig_split_size, 1)
+    else:
+        split_size = orig_split_size
+    return split_size
+
+# Use the first override whenever possible
+VLLM_MLP_SIZE_OVERRIDE = int(os.environ.get("VLLM_MLP_SIZE_OVERRIDE", "512"))
+# Use the second override 
+VLLM_MLP_SIZE_OVERRIDE_2 = int(os.environ.get("VLLM_MLP_SIZE_OVERRIDE_2", "384"))
 
 class LlamaMLP(nn.Module):
 
@@ -69,15 +86,36 @@ class LlamaMLP(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         bias: bool = False,
         prefix: str = "",
+        do_split: bool = False,
+        split_size: int = 2,
+        split_gate_up: bool = False
     ) -> None:
         super().__init__()
-        self.gate_up_proj = MergedColumnParallelLinear(
-            input_size=hidden_size,
-            output_sizes=[intermediate_size] * 2,
-            bias=bias,
-            quant_config=quant_config,
-            prefix=f"{prefix}.gate_up_proj",
-        )
+        self.split_gate_up = split_gate_up
+        self.hidden_size = hidden_size
+        if self.split_gate_up:
+            self.gate_proj = ColumnParallelLinear(
+                input_size=hidden_size,
+                output_size=intermediate_size,
+                bias=bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.gate_proj",
+            )
+            self.up_proj = ColumnParallelLinear(
+                input_size=hidden_size,
+                output_size=intermediate_size,
+                bias=bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.up_proj"
+            )
+        else:
+            self.gate_up_proj = MergedColumnParallelLinear(
+                input_size=hidden_size,
+                output_sizes=[intermediate_size] * 2,
+                bias=bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.gate_up_proj",
+            )
         self.down_proj = RowParallelLinear(
             input_size=intermediate_size,
             output_size=hidden_size,
@@ -91,9 +129,23 @@ class LlamaMLP(nn.Module):
         self.act_fn = SiluAndMul()
 
     def forward(self, x):
-        x, _ = self.gate_up_proj(x)
-        x = self.act_fn(x)
+        batch_size = x.size(0)
+        seq_len = x.size(1)
+        if (seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE==0:
+            x = x.view(-1,VLLM_MLP_SIZE_OVERRIDE,self.hidden_size)
+        elif (seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE_2==0:
+            x = x.view(-1,VLLM_MLP_SIZE_OVERRIDE_2,self.hidden_size)
+        if self.split_gate_up:
+            x = nn.functional.silu(self.gate_proj(x)[0]) * self.up_proj(x)[0]
+        else:
+            x, _ = self.gate_up_proj(x)
+            x = self.act_fn(x)
+
+        # Separate split for down is not implemented yet
         x, _ = self.down_proj(x)
+
+        if ((seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE==0) or ((seq_len*batch_size)%VLLM_MLP_SIZE_OVERRIDE_2==0):
+            x = x.view(batch_size,seq_len,self.hidden_size)
         return x
 
 
@@ -111,7 +163,10 @@ class LlamaAttention(nn.Module):
                  bias: bool = False,
                  bias_o_proj: bool = False,
                  cache_config: Optional[CacheConfig] = None,
-                 prefix: str = "") -> None:
+                 prefix: str = "",
+                 do_split: bool = False,
+                 split_size: int = 2,
+                 output_slice: bool = False) -> None:
         super().__init__()
         layer_idx = extract_layer_index(prefix)
         self.hidden_size = hidden_size
@@ -140,16 +195,46 @@ class LlamaAttention(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
+        self.split_qk_v = cache_config.split_qk_v
+        self.do_split = do_split
+        self.split_size = split_size
+        self.output_slice = output_slice
 
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size=hidden_size,
-            head_size=self.head_dim,
-            total_num_heads=self.total_num_heads,
-            total_num_kv_heads=self.total_num_kv_heads,
-            bias=bias,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkv_proj",
-        )
+        if self.split_qk_v:
+            self.q_proj = ColumnParallelLinear(input_size=self.hidden_size,
+                                               output_size=self.hidden_size,
+                                               bias=bias,
+                                               gather_output=False,
+                                               skip_bias_add=False,
+                                               params_dtype=None,
+                                               quant_config=quant_config,
+                                               prefix=f"{prefix}.q_proj")
+            self.k_proj = ColumnParallelLinear(input_size=self.hidden_size,
+                                               output_size=self.kv_size * tp_size,
+                                               bias=bias,
+                                               gather_output=False,
+                                               skip_bias_add=False,
+                                               params_dtype=None,
+                                               quant_config=quant_config,
+                                               prefix=f"{prefix}.k_proj")
+            self.v_proj = ColumnParallelLinear(input_size=self.hidden_size,
+                                               output_size=self.kv_size * tp_size,
+                                               bias=bias,
+                                               gather_output=False,
+                                               skip_bias_add=False,
+                                               params_dtype=None,
+                                               quant_config=quant_config,
+                                               prefix=f"{prefix}.v_proj")
+        else:
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size=hidden_size,
+                head_size=self.head_dim,
+                total_num_heads=self.total_num_heads,
+                total_num_kv_heads=self.total_num_kv_heads,
+                bias=bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj"
+            )
 
         self.o_proj = RowParallelLinear(
             input_size=self.total_num_heads * self.head_dim,
@@ -197,6 +282,53 @@ class LlamaAttention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
+    def forward_qkv(
+        self,
+        hidden_states: torch.Tensor,
+    ):
+        if self.split_qk_v:
+            q, _ = self.q_proj(hidden_states)
+            k, _ = self.k_proj(hidden_states)
+            v, _ = self.v_proj(hidden_states)
+        else:
+            qkv, _ = self.qkv_proj(hidden_states)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
+                                dim=-1)
+        
+        return q,k,v
+    
+    def forward_attnpost(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        positions: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
+        batch_size = attn_output.size(0)
+        seq_len = attn_output.size(1)
+        split_size = get_split_size(seq_len, batch_size, self.split_size)
+        do_split = self.do_split and attn_metadata.is_prompt
+        if ((seq_len*batch_size)//split_size>=2) and do_split:
+            attn_output = attn_output.view(1, -1, self.q_size)
+            attn_list = torch.split(attn_output, split_size, 1)
+            output_list = []
+            for attn_slice in attn_list:
+                output_slice = self.o_proj(attn_slice)[0]
+                output_list.append(output_slice)
+            if self.output_slice:
+                return output_list
+            else:
+                output = torch.cat(output_list)
+                output = output.view(batch_size, seq_len, self.hidden_size)
+                return output
+        else:
+            output, _ = self.o_proj(attn_output)
+            return output
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -204,12 +336,37 @@ class LlamaAttention(nn.Module):
         kv_cache: torch.Tensor,
         attn_metadata: AttentionMetadata,
     ) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        batch_size = hidden_states.size(0)
+        seq_len = hidden_states.size(1)
+        split_size = get_split_size(seq_len, batch_size, self.split_size)
+        do_split = self.do_split and attn_metadata.is_prompt
+        if self.split_qk_v:
+            # q, k, v, _ = self.qkv_proj(hidden_states)
+            q, _ = self.q_proj(hidden_states)
+            k, _ = self.k_proj(hidden_states)
+            v, _ = self.v_proj(hidden_states)
+        else:
+            qkv, _ = self.qkv_proj(hidden_states)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
+                                dim=-1)
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
-        output, _ = self.o_proj(attn_output)
-        return output
+        if ((seq_len*batch_size)//split_size>=2) and do_split:
+            attn_output = attn_output.view(1, -1, self.q_size)
+            attn_list = torch.split(attn_output, split_size, 1)
+            output_list = []
+            for attn_slice in attn_list:
+                output_slice = self.o_proj(attn_slice)[0]
+                output_list.append(output_slice)
+            if self.output_slice:
+                return output_list
+            else:
+                output = torch.cat(output_list)
+                output = output.view(batch_size, seq_len, self.hidden_size)
+                return output
+        else:
+            output, _ = self.o_proj(attn_output)
+            return output
 
 
 class LlamaDecoderLayer(nn.Module):
@@ -240,6 +397,12 @@ class LlamaDecoderLayer(nn.Module):
         if hasattr(config, 'qkv_bias'):
             attention_bias = config.qkv_bias
 
+        split_size = int(os.environ.get('VLLM_TP_SPLIT_SIZE_BY_SEQ', '1'))
+        output_slice = int(os.environ.get('VLLM_TP_OUTPUT_SLICE', '1')) == 1
+        do_split = split_size > 1
+        self.split_size = split_size
+        self.do_split = do_split
+        self.output_slice = output_slice and do_split
         self.self_attn = LlamaAttention(
             config=config,
             hidden_size=self.hidden_size,
@@ -254,6 +417,9 @@ class LlamaDecoderLayer(nn.Module):
             bias_o_proj=bias_o_proj,
             cache_config=cache_config,
             prefix=f"{prefix}.self_attn",
+            do_split=do_split,
+            split_size=split_size,
+            output_slice=output_slice
         )
         self.mlp = LlamaMLP(
             hidden_size=self.hidden_size,
@@ -262,6 +428,9 @@ class LlamaDecoderLayer(nn.Module):
             quant_config=quant_config,
             bias=getattr(config, "mlp_bias", False),
             prefix=f"{prefix}.mlp",
+            do_split=do_split,
+            split_size=split_size,
+            split_gate_up=cache_config.split_gate_up,
         )
         self.input_layernorm = RMSNorm(config.hidden_size,
                                        eps=config.rms_norm_eps)
@@ -276,24 +445,88 @@ class LlamaDecoderLayer(nn.Module):
         attn_metadata: AttentionMetadata,
         residual: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # Self Attention
-        if residual is None:
-            residual = hidden_states
-            hidden_states = self.input_layernorm(hidden_states)
+        # Get prompt bs from attn_metadata. The one from hidden_states may be inaccurate due to slicing
+        if attn_metadata.is_prompt:
+            batch_size = attn_metadata.seq_lens_tensor.size(0)
         else:
-            hidden_states, residual = self.input_layernorm(
+            batch_size = 1
+        # Self Attention
+        if (residual is not None) and type(hidden_states)==list:
+            # TP parallel slice cross layers
+            residual_list_output = []
+            q_list = []
+            k_list = []
+            v_list = []
+            for hidden_states_ind, residual_ind in zip(hidden_states, residual):
+                hidden_states_ind, residual_ind = self.input_layernorm(hidden_states_ind, residual_ind)
+                
+                q,k,v = self.self_attn.forward_qkv(hidden_states_ind)
+                residual_list_output.append(residual_ind)
+                q_list.append(q)
+                k_list.append(k)
+                v_list.append(v)
+                # Prevent qkv from getting merged by GC
+                htorch.core.mark_step()
+            q = torch.cat(q_list, dim=1)
+            k = torch.cat(k_list, dim=1)
+            v = torch.cat(v_list, dim=1)
+            residual = torch.cat(residual_list_output, dim=1)
+            hidden_states_shape = residual.shape
+            batch_size_fake, seq_len_fake, hidden_size = hidden_states_shape
+            hidden_states = self.self_attn.forward_attnpost(
+                q=q,
+                k=k,
+                v=v,
+                positions=positions,
+                kv_cache=kv_cache,
+                attn_metadata=attn_metadata
+            )
+        else:
+            if residual is None:
+                residual = hidden_states
+                hidden_states = self.input_layernorm(hidden_states)
+            else:
+                hidden_states, residual = self.input_layernorm(
+                    hidden_states, residual)
+            hidden_states_shape = hidden_states.shape
+            batch_size_fake, seq_len_fake, hidden_size = hidden_states_shape
+            
+            hidden_states = self.self_attn(positions=positions,
+                                        hidden_states=hidden_states,
+                                        kv_cache=kv_cache,
+                                        attn_metadata=attn_metadata)
+        
+        # Calculate real seq_len from product of inaccurate batch_size and seq_len
+        seq_len = (batch_size_fake*seq_len_fake)//batch_size
+        split_size = get_split_size(seq_len, batch_size, self.split_size)
+        # only split for prefill
+        do_split = self.do_split and attn_metadata.is_prompt
+
+        # self_attn output a list of tensors to be processed sequential at layernorm and mlp
+        if do_split and (seq_len*batch_size)//split_size>=2 and self.output_slice:
+            # Slice residual
+            residual = residual.view(1, -1, hidden_size)
+            residual_list = torch.split(residual, split_size, 1)
+
+            residual_list_output = []
+            output_list = []
+            # Sequentially process slices
+            for hidden_state, residual in zip(hidden_states, residual_list):
+                hidden_state, residual = self.post_attention_layernorm(hidden_state, residual)
+                hidden_state = self.mlp(hidden_state)
+                residual_list_output.append(residual)
+                output_list.append(hidden_state)
+
+            residual = residual_list_output
+            hidden_states = output_list
+
+        else:
+            # Fully Connected
+            hidden_states, residual = self.post_attention_layernorm(
                 hidden_states, residual)
-        hidden_states = self.self_attn(positions=positions,
-                                       hidden_states=hidden_states,
-                                       kv_cache=kv_cache,
-                                       attn_metadata=attn_metadata)
+            hidden_states = self.mlp(hidden_states)
 
-        # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(
-            hidden_states, residual)
-        hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
-
 
 @support_torch_compile
 class LlamaModel(nn.Module):
@@ -344,6 +577,9 @@ class LlamaModel(nn.Module):
             make_empty_intermediate_tensors_factory(
                 ["hidden_states", "residual"], config.hidden_size))
 
+        self.split_qk_v = cache_config.split_qk_v
+        self.split_gate_up = cache_config.split_gate_up
+
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -368,7 +604,6 @@ class LlamaModel(nn.Module):
             residual = intermediate_tensors["residual"]
 
         if is_hpu:
-            import habana_frameworks.torch as htorch
             htorch.core.mark_step()
 
         for i in range(self.start_layer, self.end_layer):
@@ -376,6 +611,9 @@ class LlamaModel(nn.Module):
             hidden_states, residual = layer(positions, hidden_states,
                                             kv_caches[i - self.start_layer],
                                             attn_metadata, residual)
+        if type(hidden_states)==list:
+            hidden_states = torch.cat(hidden_states, dim=1)
+            residual = torch.cat(residual, dim=1)
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({
                 "hidden_states": hidden_states,
@@ -389,12 +627,16 @@ class LlamaModel(nn.Module):
                                                    torch.Tensor]]) -> Set[str]:
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
-            (".qkv_proj", ".q_proj", "q"),
-            (".qkv_proj", ".k_proj", "k"),
-            (".qkv_proj", ".v_proj", "v"),
-            (".gate_up_proj", ".gate_proj", 0),
-            (".gate_up_proj", ".up_proj", 1),
         ]
+        if not self.split_qk_v:
+            stacked_params_mapping.append((".qkv_proj", ".q_proj", "q"))
+            stacked_params_mapping.append((".qkv_proj", ".k_proj", "k"))
+            stacked_params_mapping.append((".qkv_proj", ".v_proj", "v"))
+
+        if not self.split_gate_up:
+            stacked_params_mapping.append((".gate_up_proj", ".gate_proj", 0))
+            stacked_params_mapping.append((".gate_up_proj", ".up_proj", 1))
+        
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
@@ -614,7 +856,7 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
 
             combined_item = (f"{item}.{next_item}"
                              if next_item is not None else None)
-
+            
             if combined_item in mapping:
                 name = name.replace(combined_item, mapping[combined_item])
             elif item in mapping and mapping[item] not in name:


### PR DESCRIPTION
Related tickets: 
1. https://jira.habana-labs.com/browse/SW-222304
2. https://jira.habana-labs.com/browse/SW-222307

TP overlap changes are merged with split qkv and gate_up changes as the code is mixed together at the moment. If really needed I can separate the two. mlp override is removed for now.
Split qkv is a potential replicate of https://github.com/HabanaAI/vllm-fork/pull/914
Tested here: https://github.com/habana-internal/mlperf_inference/pull/205
