### PR TITLE
Fixing (1) tensor size mismatch and (2) missing prepare_cos_sin issues for Phi-3.5

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -539,8 +539,6 @@ class Phi3LongRoPEScaledRotaryEmbedding(CustomOp):
         long_mscale: Optional[float] = None,
     ):
         super().__init__()
-        self.head_size = head_size
-        self.rotary_dim = rotary_dim
 
         if is_neox_style is False:
             raise ValueError(

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -26,7 +26,6 @@ import math
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
-import torch.nn as nn
 from transformers import PretrainedConfig
 
 from vllm.model_executor.custom_op import CustomOp

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -612,8 +612,8 @@ class Phi3LongRoPEScaledRotaryEmbedding(CustomOp):
             positions = positions + offsets
         positions = positions.flatten()
         num_tokens = positions.shape[0]
-        cos_sin = self.long_short_cos_sin_cache.index_select(0, positions).view(
-            num_tokens, 1, -1)
+        cos_sin = self.long_short_cos_sin_cache.index_select(
+            0, positions).view(num_tokens, 1, -1)
         cos, sin = cos_sin.chunk(2, dim=-1)
         cos = torch.cat((cos, cos), dim=-1)
         sin = torch.cat((sin, sin), dim=-1)


### PR DESCRIPTION
Solving the two issues reported in: https://jira.habana-labs.com/browse/SW-221986

1) vLLM both offline and online inferencing of the "microsoft/Phi-3.5-mini-instruct" model firstly complained about a missing 'prepare_cos_sin' method, that is necessary for the rotational position embeddings (RoPE):

```
ERROR 03-11 10:04:32 engine.py:389]   File "/home/vllm-fork/vllm/worker/hpu_model_runner.py", line 424, in _prepare_cos_sin
ERROR 03-11 10:04:32 engine.py:389]     raise AttributeError(
ERROR 03-11 10:04:32 engine.py:389] AttributeError: The module at the end of the path does not have a 'prepare_cos_sin' method.
```

2) Model fails due the a size mismatch:

```
File "/home/vllm-fork/vllm/model_executor/layers/rotary_embedding.py", line 641, in forward
    query_rot = query_rot * cos + _rotate_neox(query_rot) * sin
RuntimeError: The size of tensor a (96) must match the size of tensor b (1024) at non-singleton dimension 3 
```
