### PR TITLE
Fix "Configuration was not warmed up" logs for uns without APC

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -919,6 +919,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     def _check_config(self, batch_size, seq_len, attn_metadata, warmup_mode):
         is_prefix_caching = self.vllm_config.cache_config.enable_prefix_caching
+        cfg = None
         if is_prefix_caching:
             phase = self._phase(attn_metadata)
             num_blocks = self._num_blocks(attn_metadata)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -919,7 +919,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     def _check_config(self, batch_size, seq_len, attn_metadata, warmup_mode):
         is_prefix_caching = self.vllm_config.cache_config.enable_prefix_caching
-        cfg = None
+        cfg : Optional[tuple] = None
+        assert cfg == None, "Configs changed between 2D and 3D"
         if is_prefix_caching:
             phase = self._phase(attn_metadata)
             num_blocks = self._num_blocks(attn_metadata)
@@ -931,9 +932,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         seen = cfg in self.seen_configs
         self.seen_configs.add(cfg)
         if not seen and not warmup_mode:
-            logger.warning("Configuration: (%s, %s, %s%s) was not warmed-up!",
-                           phase, batch_size, seq_len,
-                           f", {num_blocks}" if is_prefix_caching else "")
+            logger.warning(f"Configuration: ({cfg}) was not warmed-up!")
 
     def _prepare_prompt(
         self,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -919,8 +919,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     def _check_config(self, batch_size, seq_len, attn_metadata, warmup_mode):
         is_prefix_caching = self.vllm_config.cache_config.enable_prefix_caching
-        cfg : Optional[tuple] = None
-        assert cfg == None, "Configs changed between 2D and 3D"
+        cfg: Optional[tuple] = None
+        assert cfg is None, "Configs changed between 2D and 3D"
         if is_prefix_caching:
             phase = self._phase(attn_metadata)
             num_blocks = self._num_blocks(attn_metadata)
@@ -932,7 +932,10 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         seen = cfg in self.seen_configs
         self.seen_configs.add(cfg)
         if not seen and not warmup_mode:
-            logger.warning(f"Configuration: ({cfg}) was not warmed-up!")
+            logger.warning("Configuration: %s was not warmed-up!",
+                           (phase.value, batch_size, seq_len,
+                            num_blocks) if is_prefix_caching else
+                           (phase, batch_size, seq_len))
 
     def _prepare_prompt(
         self,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -923,17 +923,16 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             phase = self._phase(attn_metadata)
             num_blocks = self._num_blocks(attn_metadata)
             cfg = (batch_size, seq_len, num_blocks, phase)
+            phase = phase.value
         else:
             phase = 'prompt' if attn_metadata.is_prompt else 'decode'
             cfg = (batch_size, seq_len, phase)
         seen = cfg in self.seen_configs
         self.seen_configs.add(cfg)
         if not seen and not warmup_mode:
-            cfg_log = (phase.value, batch_size, seq_len,
-                       num_blocks) if is_prefix_caching else (phase,
-                                                              batch_size,
-                                                              seq_len)
-            logger.warning("Configuration: %s was not warmed-up!", cfg_log)
+            logger.warning("Configuration: (%s, %s, %s%s) was not warmed-up!",
+                           phase, batch_size, seq_len,
+                           f", {num_blocks}" if is_prefix_caching else "")
 
     def _prepare_prompt(
         self,


### PR DESCRIPTION
After [882](https://github.com/HabanaAI/vllm-fork/pull/882) there is "Configuration X, X, X, 0 was not warmed up" for every run, even without APC enabled. It suggested that some buckets were not warmed up even if they were (therefore 0 at the end for num blocks as we do not have 3D warmup). 

For runs with APC logs will look like that:
`Configuration: ('prefill', 1, 2048, 0) was not warmed-up!`
And without:
`Configuration: ('prompt', 1, 2048) was not warmed-up!`