### PR TITLE
fix server crash when the client use random seed sampling

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1559,6 +1559,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     def prepare_input_tensors(
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
+        finished_requests_ids: Optional[List[str]] = None
     ) -> Tuple[TModelInputForHPU, SamplingMetadata]:
         if len(seq_group_metadata_list) == 0:
             return self._model_input_cls(), None
@@ -1616,9 +1617,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         ) = self._prepare_decode(decode_reqs)
 
         if not self.is_pooler:
+            generators = self.get_generators(finished_requests_ids)
             sampling_metadata = SamplingMetadata.prepare(
-                seq_group_metadata_list, seq_lens, query_lens, self.device,
-                self.pin_memory)
+                seq_group_metadata_list,
+                seq_lens,
+                query_lens,
+                self.device,
+                self.pin_memory,
+                generators=generators)
 
         if not self.scheduler_config.chunked_prefill_enabled:
             assert (len(prefill_reqs) and len(decode_reqs)) == 0
@@ -2355,7 +2361,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 self.profiler_counter_helper.capture_seq_group_metadata_stats(
                     seq_group_metadata_list=seq_group_metadata_list)
             model_input, sampling_metadata = self.prepare_input_tensors(
-                seq_group_metadata_list)
+                seq_group_metadata_list, finished_requests_ids)
             assert model_input.attn_metadata is not None
             is_prompt = model_input.attn_metadata.is_prompt
 


### PR DESCRIPTION
Start a server with the current code (commit: a2c1ece9acc79a6d310c52b02f4694838f8ca67d) :
``` bash
VLLM_SKIP_WARMUP=true vllm serve /models/Llama-2-7b-chat-hf
```
Send a request with given `seed`:
``` bash
curl http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "/models/Llama-2-7b-chat-hf",
  "messages": [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Please generate a random number."}
  ],
  "seed": 10
}'
```
Will cause a server crash with the following trace:
``` log
ERROR 03-18 03:55:59 engine.py:139] AssertionError()
ERROR 03-18 03:55:59 engine.py:139] Traceback (most recent call last):
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/engine/multiprocessing/engine.py", line 137, in start
ERROR 03-18 03:55:59 engine.py:139]     self.run_engine_loop()
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/engine/multiprocessing/engine.py", line 200, in run_engine_loop
ERROR 03-18 03:55:59 engine.py:139]     request_outputs = self.engine_step()
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/engine/multiprocessing/engine.py", line 218, in engine_step
ERROR 03-18 03:55:59 engine.py:139]     raise e
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/engine/multiprocessing/engine.py", line 209, in engine_step
ERROR 03-18 03:55:59 engine.py:139]     return self.engine.step()
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/engine/llm_engine.py", line 1386, in step
ERROR 03-18 03:55:59 engine.py:139]     outputs = self.model_executor.execute_model(
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/executor/executor_base.py", line 138, in execute_model
ERROR 03-18 03:55:59 engine.py:139]     output = self.collective_rpc("execute_model",
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/executor/uniproc_executor.py", line 58, in collective_rpc
ERROR 03-18 03:55:59 engine.py:139]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/utils.py", line 2293, in run_method
ERROR 03-18 03:55:59 engine.py:139]     return func(*args, **kwargs)
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/worker/hpu_worker.py", line 293, in execute_model
ERROR 03-18 03:55:59 engine.py:139]     output = LocalOrDistributedWorkerBase.execute_model(
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/worker/worker_base.py", line 418, in execute_model
ERROR 03-18 03:55:59 engine.py:139]     output = self.model_runner.execute_model(
ERROR 03-18 03:55:59 engine.py:139]   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 03-18 03:55:59 engine.py:139]     return func(*args, **kwargs)
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/worker/hpu_model_runner.py", line 2548, in execute_model
ERROR 03-18 03:55:59 engine.py:139]     output = self.model.sample(
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/worker/hpu_model_runner.py", line 458, in sample
ERROR 03-18 03:55:59 engine.py:139]     return self.model.sample(*args, **kwargs)
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/model_executor/models/llama.py", line 570, in sample
ERROR 03-18 03:55:59 engine.py:139]     next_tokens = self.sampler(logits, sampling_metadata)
ERROR 03-18 03:55:59 engine.py:139]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1742, in _wrapped_call_impl
ERROR 03-18 03:55:59 engine.py:139]     return self._call_impl(*args, **kwargs)
ERROR 03-18 03:55:59 engine.py:139]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1848, in _call_impl
ERROR 03-18 03:55:59 engine.py:139]     return inner()
ERROR 03-18 03:55:59 engine.py:139]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1796, in inner
ERROR 03-18 03:55:59 engine.py:139]     result = forward_call(*args, **kwargs)
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/model_executor/layers/sampler.py", line 300, in forward
ERROR 03-18 03:55:59 engine.py:139]     maybe_deferred_sample_results, maybe_sampled_tokens_tensor = _sample(
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/model_executor/layers/sampler.py", line 1017, in _sample
ERROR 03-18 03:55:59 engine.py:139]     return _sample_with_torch(
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/model_executor/layers/sampler.py", line 957, in _sample_with_torch
ERROR 03-18 03:55:59 engine.py:139]     multinomial_samples[sampling_type] = _multinomial(
ERROR 03-18 03:55:59 engine.py:139]   File "/workspace/vllm-fork/vllm/model_executor/layers/sampler.py", line 765, in _multinomial
ERROR 03-18 03:55:59 engine.py:139]     assert seq_group.generator is not None
ERROR 03-18 03:55:59 engine.py:139] AssertionError
```
And the response is normal after this PR:
``` json
{
  "id": "chatcmpl-b91a7a18b2e340a49eb2eb21c4e5c4ee",
  "object": "chat.completion",
  "created": 1742270263,
  "model": "/models/Llama-2-7b-chat-hf",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "reasoning_content": null,
        "content": "  Of course! I'd be happy to help. Here is a random number for you: 854.",
        "tool_calls": []
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": null
    }
  ],
  "usage": {
    "prompt_tokens": 33,
    "total_tokens": 59,
    "completion_tokens": 26,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null
}
```