### PR TITLE
add ScaleToHwAligned for loading fp8 vllm model

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@3e0fb39
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@145c63d

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@21e4718
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@c1843ce

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -86,7 +86,8 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
         # INPUT SCALE
         if self.is_static_input_scheme and hasattr(layer, 'input_scale'):
             input_scale = layer.input_scale.max()
-            input_scale = ConvertScaleToHwAligned().calc(input_scale)
+            if current_platform.is_hpu():
+                input_scale = ConvertScaleToHwAligned().calc(input_scale)
             layer.input_scale = Parameter(input_scale, requires_grad=False)
         else:
             layer.input_scale = None

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -5,7 +5,8 @@ from typing import Callable, List, Optional
 import torch
 from compressed_tensors.quantization import QuantizationStrategy
 from torch.nn import Parameter
-from vllm_hpu_extension.ops import get_hpu_gaudi2_scale_factor, is_hpu_gaudi2
+from vllm_hpu_extension.ops import (
+    get_hpu_gaudi2_scale_factor, is_hpu_gaudi2, is_hpu_gaudi3, ScaleToHwAligned)
 
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme)
@@ -85,9 +86,13 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
 
         # INPUT SCALE
         if self.is_static_input_scheme and hasattr(layer, 'input_scale'):
+            layer.input_scale = ScaleToHwAligned().calc(layer.input_scale)
             input_scale = layer.input_scale.max()
             if is_hpu_gaudi2():
                 input_scale = input_scale * get_hpu_gaudi2_scale_factor()
+                input_scale = ScaleToHwAligned("GAUDI2").calc(input_scale)
+            if is_hpu_gaudi3():
+                input_scale = ScaleToHwAligned("GAUDI3").calc(input_scale)
             layer.input_scale = Parameter(input_scale, requires_grad=False)
         else:
             layer.input_scale = None

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -86,7 +86,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
 
         # INPUT SCALE
         if self.is_static_input_scheme and hasattr(layer, 'input_scale'):
-            layer.input_scale = ScaleToHwAligned().calc(layer.input_scale)
             input_scale = layer.input_scale.max()
             if is_hpu_gaudi2():
                 input_scale = input_scale * get_hpu_gaudi2_scale_factor()

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -102,7 +102,8 @@ def requantize_with_max_scale(
         logical_widths: List[int]) -> Tuple[torch.Tensor, torch.Tensor]:
     # Max scale to be used for requanitzation.
     max_w_scale = weight_scale.max()
-    max_w_scale = ConvertScaleToHwAligned().calc(max_w_scale)
+    if current_platform.is_hpu():
+        max_w_scale = ConvertScaleToHwAligned().calc(max_w_scale)
     # QKV / MLP is fused in the on disk checkpoint if any of the
     # weight scales are still set to the default since we initialize
     # N weight scales for N shards but we only load 1 weight scale

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -3,8 +3,7 @@
 from typing import List, Optional, Tuple, Union
 
 import torch
-from vllm_hpu_extension.ops import (
-    get_hpu_gaudi2_scale_factor, is_hpu_gaudi2, is_hpu_gaudi3, ScaleToHwAligned)
+from vllm_hpu_extension.scales import ConvertScaleToHwAligned
 
 from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
@@ -103,11 +102,7 @@ def requantize_with_max_scale(
         logical_widths: List[int]) -> Tuple[torch.Tensor, torch.Tensor]:
     # Max scale to be used for requanitzation.
     max_w_scale = weight_scale.max()
-    if is_hpu_gaudi2():
-        max_w_scale = max_w_scale * get_hpu_gaudi2_scale_factor()
-        max_w_scale = ScaleToHwAligned("GAUDI2").calc(max_w_scale)
-    if is_hpu_gaudi3():
-        max_w_scale = ScaleToHwAligned("GAUDI3").calc(max_w_scale)
+    max_w_scale = ConvertScaleToHwAligned().calc(max_w_scale)
     # QKV / MLP is fused in the on disk checkpoint if any of the
     # weight scales are still set to the default since we initialize
     # N weight scales for N shards but we only load 1 weight scale

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -27,7 +27,7 @@ class HpuPlatform(Platform):
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
     supported_quantization: list[str] = [
         "compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu"
-        ]
+    ]
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -25,7 +25,9 @@ class HpuPlatform(Platform):
     dispatch_key: str = "HPU"
     ray_device_key: str = "HPU"
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
-    supported_quantization: list[str] = ["compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu"]
+    supported_quantization: list[str] = [
+        "compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu"
+        ]
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -25,7 +25,7 @@ class HpuPlatform(Platform):
     dispatch_key: str = "HPU"
     ray_device_key: str = "HPU"
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
-    supported_quantization: list[str] = ["fp8", "inc", "awq_hpu", "gptq_hpu"]
+    supported_quantization: list[str] = ["compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu"]
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,


### PR DESCRIPTION
https://jira.habana-labs.com/browse/SW-207506 the scales provided by neuralmagic fp8 model method are maxabs, it need do hw scale align to adapt hpu platform to get better accuracy and performance. I add the class `ConvertScaleHwAlign` in vllm-hpu-extension(https://github.com/HabanaAI/vllm-hpu-extension/pull/118) and call it in vllm-fork. the class also include the device check and make factor first if the device is G2.
it is used for loading the models in this link. https://huggingface.co/collections/neuralmagic/fp8-llms-for-vllm-666742ed2b78b7ac8df13127

