### PR TITLE
Moved set_indices_and_offsets into prepare_prompt and prepare_decode

### DIFF
--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -509,7 +509,6 @@ class HPUEncoderDecoderModelRunner(
             'block_list',
             'block_mapping',
             'block_usage',
-            'slot_mapping',
             'is_prompt',
             'block_indices',
             'block_offsets',

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1196,12 +1196,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             for modality, placeholder_map in
             multi_modal_placeholder_maps.items()
         }
-        # calculate indices using CPU and locate them on HPU
-        slot_mapping_flat = slot_mapping.flatten()  # type: ignore
-        indices = torch.div(slot_mapping_flat,
-                            self.block_size,
-                            rounding_mode="floor")
-        indices = indices.unflatten(0, (-1, self.block_size))[:, 0]
 
         # calculate indices using CPU and locate them on HPU
         slot_mapping_flat = slot_mapping.flatten()  # type: ignore

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -380,6 +380,7 @@ class HpuModelAdapter:
                                      attn_bias=attn_bias)
         return metadata
 
+
     def _update_metadata(self, attn_metadata, batch_size, seq_len, device,
                          dtype):
 
@@ -1207,8 +1208,12 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         input_positions = input_positions.to(  # type: ignore
             self.device, non_blocking=True)
         slot_mapping_HPU = slot_mapping.to(  # type: ignore
+<<<<<<< HEAD
             self.device,  # type: ignore
             non_blocking=True)  # type: ignore
+=======
+            self.device, non_blocking=True)
+>>>>>>> a6f715447 (- linter fixes)
         seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
         context_lens_tensor = context_lens_tensor.to(self.device,
                                                      non_blocking=True)
@@ -1533,8 +1538,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                             self.block_size,
                             rounding_mode="floor")
         offsets = torch.fmod(slot_mapping, self.block_size)
+<<<<<<< HEAD
         attn_metadata.block_offsets = offsets.to(self.device,
                                                  non_blocking=True)
+=======
+        attn_metadata.block_offsets = offsets.to(
+            self.device,  # type: ignore
+            non_blocking=True)
+>>>>>>> a6f715447 (- linter fixes)
         attn_metadata.block_indices = indices.to(  # type: ignore
             self.device,  # type: ignore
             non_blocking=True)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1206,11 +1206,12 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             self.device, non_blocking=True)
         input_positions = input_positions.to(  # type: ignore
             self.device, non_blocking=True)
-        slot_mapping_HPU = slot_mapping.to(self.device, non_blocking=True)
+        slot_mapping_HPU = slot_mapping.to(  # type: ignore
+            self.device,  # type: ignore
+            non_blocking=True)  # type: ignore
         seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
         context_lens_tensor = context_lens_tensor.to(self.device,
                                                      non_blocking=True)
-
 
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=True,
@@ -1232,10 +1233,13 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             enable_kv_scales_calculation=False,
         )
         # calculate indices using CPU and locate them on HPU
-        slot_mapping = slot_mapping.flatten()
-        indices = torch.div(slot_mapping, self.block_size, rounding_mode="floor")
+        slot_mapping = slot_mapping.flatten()  # type: ignore
+        indices = torch.div(slot_mapping,
+                            self.block_size,
+                            rounding_mode="floor")
         indices = indices.unflatten(0, (-1, self.block_size))[:, 0]
-        attn_metadata.block_indices=indices.to(self.device, non_blocking=True)
+        attn_metadata.block_indices = indices.to(self.device,
+                                                 non_blocking=True)
 
         multi_modal_kwargs = MultiModalKwargs.batch(multi_modal_kwargs_list)
         for t in multi_modal_kwargs:
@@ -1475,8 +1479,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                    dtype=self.model_config.dtype,
                                    device='cpu')
         slot_mapping_CPU = torch.tensor(slot_mapping,
-                                    dtype=torch.long,
-                                    device='cpu')
+                                        dtype=torch.long,
+                                        device='cpu')
 
         input_tokens = input_tokens.to(  # type: ignore
             self.device, non_blocking=True)
@@ -1525,10 +1529,15 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         )
         # calculate indices and offsets using CPU and locate them on HPU
         slot_mapping = slot_mapping_CPU.flatten()
-        indices = torch.div(slot_mapping, self.block_size, rounding_mode="floor")
+        indices = torch.div(slot_mapping,
+                            self.block_size,
+                            rounding_mode="floor")
         offsets = torch.fmod(slot_mapping, self.block_size)
-        attn_metadata.block_offsets=offsets.to(self.device, non_blocking=True)
-        attn_metadata.block_indices=indices.to(self.device, non_blocking=True)
+        attn_metadata.block_offsets = offsets.to(self.device,
+                                                 non_blocking=True)
+        attn_metadata.block_indices = indices.to(  # type: ignore
+            self.device,  # type: ignore
+            non_blocking=True)
 
         return PrepareDecodeMetadata(input_tokens=input_tokens,
                                      input_positions=input_positions,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -380,7 +380,6 @@ class HpuModelAdapter:
                                      attn_bias=attn_bias)
         return metadata
 
-
     def _update_metadata(self, attn_metadata, batch_size, seq_len, device,
                          dtype):
 
@@ -1214,9 +1213,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             self.device, non_blocking=True)
         input_positions = input_positions.to(  # type: ignore
             self.device, non_blocking=True)
-        slot_mapping_HPU = slot_mapping.to(  # type: ignore
-            self.device,  # type: ignore
-            non_blocking=True)  # type: ignore
         seq_lens_tensor = seq_lens_tensor.to(self.device, non_blocking=True)
         context_lens_tensor = context_lens_tensor.to(self.device,
                                                      non_blocking=True)


### PR DESCRIPTION
This PR is moving execution of set_indices_and_offsets into CPU device. It is a preliminary step into making HPUModelAdapter torch compiled as set_indices_and_offsets did not (based on observations) benefited from torch compilation and even neglected some performance gain from other optimizations.