### PR TITLE
Perform KV cache update on flat layout

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@21e4718
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@dev/kdamaszke/flat_kv_cache_update

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -229,9 +229,9 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             # Reshape the input keys and values and store them in the cache.
             # If kv_cache is not provided, the new key and value tensors are
             # not cached. This happens during the initial memory profiling run.
-            key_cache = self.k_cache(key_cache, key, block_indices,
+            key_cache = self.k_cache(key, key_cache, block_indices,
                                      flat_indices_with_offsets)
-            value_cache = self.v_cache(value_cache, value, block_indices,
+            value_cache = self.v_cache(value, value_cache, block_indices,
                                        flat_indices_with_offsets)
 
         if attn_metadata.is_prompt:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -912,7 +912,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     def _maybe_wrap_in_hpu_graph(self, *args, **kwargs):
         return htorch.hpu.wrap_in_hpu_graph(
             HpuModelAdapter(*args, **kwargs),
-            disable_tensor_cache=False,
+            disable_tensor_cache=True,
         ) if htorch.utils.internal.is_lazy() else HpuModelAdapter(
             *args, **kwargs)
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -893,7 +893,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     def _maybe_wrap_in_hpu_graph(self, *args, **kwargs):
         return htorch.hpu.wrap_in_hpu_graph(
             HpuModelAdapter(*args, **kwargs),
-            disable_tensor_cache=True,
+            disable_tensor_cache=False,
         ) if htorch.utils.internal.is_lazy() else HpuModelAdapter(
             *args, **kwargs)
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2560,6 +2560,11 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             if htorch.utils.internal.is_lazy():
                 execute_model_kwargs.update(
                     {"bypass_hpu_graphs": not use_graphs})
+                if use_graphs:
+                    # As we have disable_tensor_cache enabled,
+                    # we need to inform HPU graphs to not free KV cache tensors
+                    execute_model_kwargs.update(
+                        {"cache_tensors_list": kv_caches})
 
             htorch.core.mark_step()
             if self.is_driver_worker:


### PR DESCRIPTION
Doing KV cache update on flat layout is faster, because it allows us to avoid redundant memcopies due to small FCD in some cases.