### PR TITLE
[SW-218309][CI] Added always conditions to summarize job

### DIFF
--- a/.github/workflows/trigger_jenkins.yml
+++ b/.github/workflows/trigger_jenkins.yml
@@ -291,7 +291,7 @@ jobs:
       name: Summarize Test Results
       runs-on: generic-runner
       needs: [TestRun,read_codeowners]
-      if: needs.TestRun.result != 'skipped' && needs.read_codeowners.result != 'skipped'
+      if: always() && needs.TestRun.result != 'skipped' && needs.read_codeowners.result != 'skipped'
       steps:
         - name: Checkout Repository
           uses: actions/checkout@v4


### PR DESCRIPTION
Adding a condition so the summarize job will run even in tests failure but not when tests were skipped due to commenter which is not part of code owners
I'm adding to avoid summarize job runs for nothing  
