### PR TITLE
Optimize rope if head_size == rotary_dim

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -260,20 +260,26 @@ class RotaryEmbedding(CustomOp):
         sin = self.sin
         cos = self.cos
         query_shape = query.shape
-        query = query.view(num_tokens, -1, self.head_size)
-        query_rot = query[..., :self.rotary_dim]
-        query_pass = query[..., self.rotary_dim:]
-        query_rot = apply_rotary_pos_emb(query_rot, cos, sin, None, 0,
-                                         rope_mode)
-        query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
-
         key_shape = key.shape
+        query = query.view(num_tokens, -1, self.head_size)
         key = key.view(num_tokens, -1, self.head_size)
-        key_rot = key[..., :self.rotary_dim]
-        key_pass = key[..., self.rotary_dim:]
-        key_rot = apply_rotary_pos_emb(key_rot, cos, sin, None, 0, rope_mode)
-        key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
-        return query, key
+        if self.head_size == self.rotary_dim:
+            # Avoid unnecessary slicing and concatenation
+            query = apply_rotary_pos_emb(query, cos, sin, None, 0, rope_mode)
+            key = apply_rotary_pos_emb(key, cos, sin, None, 0, rope_mode)
+        else:
+            query_rot = query[..., :self.rotary_dim]
+            query_pass = query[..., self.rotary_dim:]
+            query_rot = apply_rotary_pos_emb(query_rot, cos, sin, None, 0,
+                                             rope_mode)
+            query = torch.cat((query_rot, query_pass), dim=-1)
+
+            key_rot = key[..., :self.rotary_dim]
+            key_pass = key[..., self.rotary_dim:]
+            key_rot = apply_rotary_pos_emb(key_rot, cos, sin, None, 0,
+                                           rope_mode)
+            key = torch.cat((key_rot, key_pass), dim=-1)
+        return query.reshape(query_shape), key.reshape(key_shape)
 
     def extra_repr(self) -> str:
         s = f"head_size={self.head_size}, rotary_dim={self.rotary_dim}"

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -263,23 +263,24 @@ class RotaryEmbedding(CustomOp):
         key_shape = key.shape
         query = query.view(num_tokens, -1, self.head_size)
         key = key.view(num_tokens, -1, self.head_size)
+
         if self.head_size == self.rotary_dim:
             # Avoid unnecessary slicing and concatenation
             query = apply_rotary_pos_emb(query, cos, sin, None, 0, rope_mode)
             key = apply_rotary_pos_emb(key, cos, sin, None, 0, rope_mode)
-        else:
-            query_rot = query[..., :self.rotary_dim]
-            query_pass = query[..., self.rotary_dim:]
-            query_rot = apply_rotary_pos_emb(query_rot, cos, sin, None, 0,
-                                             rope_mode)
-            query = torch.cat((query_rot, query_pass), dim=-1)
+            return query.reshape(query_shape), key.reshape(key_shape)
 
-            key_rot = key[..., :self.rotary_dim]
-            key_pass = key[..., self.rotary_dim:]
-            key_rot = apply_rotary_pos_emb(key_rot, cos, sin, None, 0,
-                                           rope_mode)
-            key = torch.cat((key_rot, key_pass), dim=-1)
-        return query.reshape(query_shape), key.reshape(key_shape)
+        query_rot = query[..., :self.rotary_dim]
+        query_pass = query[..., self.rotary_dim:]
+        query_rot = apply_rotary_pos_emb(query_rot, cos, sin, None, 0,
+                                         rope_mode)
+        query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+        key_rot = key[..., :self.rotary_dim]
+        key_pass = key[..., self.rotary_dim:]
+        key_rot = apply_rotary_pos_emb(key_rot, cos, sin, None, 0, rope_mode)
+        key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+        return query, key
 
     def extra_repr(self) -> str:
         s = f"head_size={self.head_size}, rotary_dim={self.rotary_dim}"


### PR DESCRIPTION
Avoid unnecessary slice and concat in rope if head_size is equal to rotary_dim. It allows us to better pipeline rope with QKV projection.
