### PR TITLE
workaround cpu fallback when calling max on a bool tensor

### DIFF
--- a/vllm/model_executor/layers/spec_decode_base_sampler.py
+++ b/vllm/model_executor/layers/spec_decode_base_sampler.py
@@ -83,7 +83,7 @@ class SpecDecodeBaseSampler(nn.Module):
         batch_size, k = substitute_token_ids.shape
         bonus_token_ids = bonus_token_ids.squeeze(-1)
         # Determine the index of the first False value for each row.
-        limits = (accepted == 0).max(1).indices
+        limits = (accepted == 0).to(torch.int32).max(1).indices
         limits[~(accepted == 0).any(1)] = k
 
         # Create masks using the indices.


### PR DESCRIPTION
workaround cpu fallback when calling max on a bool tensor

FIX [SW-214823](https://jira.habana-labs.com/browse/SW-214823)
