### PR TITLE
[SW-219324] Add block-size 256 to args list

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -458,7 +458,7 @@ class EngineArgs:
         parser.add_argument('--block-size',
                             type=int,
                             default=EngineArgs.block_size,
-                            choices=[8, 16, 32, 64, 128],
+                            choices=[8, 16, 32, 64, 128, 256],
                             help='Token block size for contiguous chunks of '
                             'tokens. This is ignored on neuron devices and '
                             'set to ``--max-model-len``. On CUDA devices, '


### PR DESCRIPTION
vLLM Llama3.1-70B FP8 2K/2K throughput measurements shows good improvement with blocksize 256 , hence adding this as an option to the argument list