### PR TITLE
Enable torchrun on Gaudi

### DIFF
--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -63,8 +63,6 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         self.rank = rank
         self.distributed_init_method = distributed_init_method
         self.is_driver_worker = is_driver_worker
-        if self.is_driver_worker:
-            assert self.rank == 0, "The driver worker must have rank 0."
 
         if self.model_config.trust_remote_code:
             # note: lazy import to avoid importing torch before initializing


### PR DESCRIPTION
How to run it:
VLLM_SKIP_WARMUP=true torchrun --nproc-per-node 2 examples/offline_inference/torchrun_example.py