### PR TITLE
[SW-224484] - Update to latest vllm-hpu-extension for index_reduce

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@3e0fb39
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@0a3e71f


### PR DESCRIPTION
In grouped_max unnecessary casts are removed as index_reduce is supported in fp16 now