### PR TITLE
Update deepseek modeling file for PatchedVLLMKVCache

### DIFF
--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -430,20 +430,20 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata], torch.nn.Module):
         # write the latent and rope to kv cache
         if kv_cache is not None and len(kv_cache) == 2:
             if not self.VLLM_USE_FP8_MATMUL:
-                k_cache = self.latent_cache_k(latent_vec_k, kv_cache[0],
-                                              block_indices, block_offsets)
+                self.latent_cache_k(latent_vec_k, kv_cache[0],
+                                    block_indices, block_offsets)
+                k_cache = kv_cache[0]
             else:
                 k_cache = self.latent_cache_k_nodeq(latent_vec_k, kv_cache[0],
                                                     block_indices,
                                                     block_offsets)
             v_cache = None
-            kv_cache = (k_cache, v_cache)
 
         if is_prefill:
             return self._forward_prefill(q, k_c_normed, k_pe, attn_metadata,
                                          batch_size)
         else:
-            return self._forward_decode(q_nope, q_pe, kv_cache, attn_metadata,
+            return self._forward_decode(q_nope, q_pe, (k_cache, v_cache), attn_metadata,
                                         batch_size)
 
     def _forward_prefill(self, q: torch.Tensor, k_c_normed: torch.Tensor,


### PR DESCRIPTION
Previously, when we use INC to convert deepseek FP8 model, we need this [commit ](https://github.com/intel/neural-compressor/commit/7c0a3e20f48e89707c7be0ec0e4719e6bbc55bac) to remove extra converts in KVCache but actually GC can remove them during graph optimization theoretically.
Furthermore, the change in commit is not aligned with the design of INC patched module, which wants to keep the returned tensor BF16 because we can't make sure users' next operation.
So, I update the modeling file to make GC can work for patched KVCache pattern of deepseek model.
Since next release is very close and GC currently can not work as expection during decode stage, it is still a workround. We will root cause and fix it from source in next relase.

This PR should work together with this PR: https://github.com/intel/neural-compressor/pull/2165
