### PR TITLE
vLLM-Base: Full enabling of ALiBi

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/tvoas/vllm-hpu-extension.git@473f7ff
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@2bcd7f8

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@260cc03
+vllm-hpu-extension @ git+https://github.com/tvoas/vllm-hpu-extension.git@473f7ff

--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -21,6 +21,7 @@ class HPUPagedAttentionMetadata:
     block_mapping: Optional[torch.Tensor]
     block_usage: Optional[torch.Tensor]
     block_groups: Optional[torch.Tensor]
+    alibi_blocks: Optional[torch.Tensor]
 
 
 class HPUPagedAttention:

--- a/vllm/v1/attention/backends/hpu_attn.py
+++ b/vllm/v1/attention/backends/hpu_attn.py
@@ -48,6 +48,7 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    block_mapping=None,
                    block_usage=None,
                    block_groups=None,
+                   alibi_blocks=None,
                    attn_bias=None,
                    num_decode_tokens=0,
                    context_lens_tensor=None,
@@ -70,6 +71,7 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    block_mapping=None,
                    block_usage=None,
                    block_groups=None,
+                   alibi_blocks=None,
                    attn_bias=None,
                    num_decode_tokens=0,
                    context_lens_tensor=context_lens_tensor,
@@ -88,6 +90,7 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                              block_size):
         return cls(is_prompt=False,
                    block_mapping=None,
+                   alibi_blocks=None,
                    attn_bias=None,
                    seq_lens_tensor=None,
                    context_lens_tensor=None,


### PR DESCRIPTION
Resolves a regression in ALiBi-based models.

This is a fixed version ofhttps://github.com/HabanaAI/vllm-fork/pull/503 which was reverted by https://github.com/HabanaAI/vllm-fork/pull/907.

This depends on the vllm-hpu-extension PR: https://github.com/HabanaAI/vllm-hpu-extension/pull/141

All pre-commit checks are passed locally.