### PR TITLE
Add t.compile fp8 performance test to jenkins

### DIFF
--- a/.jenkins/benchmark/run-benchmark.sh
+++ b/.jenkins/benchmark/run-benchmark.sh
@@ -70,8 +70,6 @@ script_dir=$(dirname "$(readlink -f "$0")")
 
 start=`date +%s`
 
-export TQDM_DISABLE=True
-
 fp8_args=""
 if [[ $__fp8 == "yes" ]]; then
     export QUANT_CONFIG=/software/data/vllm-benchmarks/inc/maxabs_quant_unit.json

--- a/.jenkins/benchmark/run-benchmark.sh
+++ b/.jenkins/benchmark/run-benchmark.sh
@@ -92,7 +92,7 @@ python  $script_dir/../../benchmarks/benchmark_throughput.py \
     --max-num-batched-tokens 8192 \
     --max-num-seqs 128 \
     --use-padding-aware-scheduling \
-    $extra_args 2> >(tee -a $error_log_file) | tee -a $log_file
+    $fp8_args 2> >(tee -a $error_log_file) | tee -a $log_file
 
 # store exit status of the first command in the pipe (python script) only
 runtime_error=${PIPESTATUS[0]}

--- a/.jenkins/benchmark/run-benchmark.sh
+++ b/.jenkins/benchmark/run-benchmark.sh
@@ -74,7 +74,7 @@ export TQDM_DISABLE=True
 
 fp8_args=""
 if [[ $__fp8 == "yes" ]]; then
-    export QUANT_CONFIG=/software/users/kpietkun/configs/llama3.1_quant_cofnig.json
+    export QUANT_CONFIG=/software/data/vllm-benchmarks/inc/maxabs_quant_unit.json
     fp8_args="--quantization=inc \
         --kv-cache-dtype=fp8_inc \
         --weights-load_device=cpu "

--- a/.jenkins/benchmark/run-benchmark.sh
+++ b/.jenkins/benchmark/run-benchmark.sh
@@ -1,43 +1,110 @@
 #!/bin/bash
 
+__fp8="no"
+
+while [ -n "$1" ];
+    do
+        case $1 in
+        -fp8 )
+            __fp8="yes"
+            ;;
+        esac
+        shift
+    done
+
 model=/mnt/weka/data/pytorch/llama3.1/Meta-Llama-3.1-8B
 model_short=$(basename $model)
 #replace all '.' with '-'
 model_short=${model_short//./-}
-log_file=$(mktemp /tmp/_benchmark_${model_short}_XXXXXXX.log)
+tmp_file_name=$(mktemp /tmp/_benchmark_${model_short}_XXXXXXX)
+error_log_file="${tmp_file_name}_error.log"
+log_file="${tmp_file_name}.log"
+
+scenario=fp8
+if [[ $__fp8 == "no" ]]; then
+    scenario=bf16
+fi
 
 # Generate an empty result file.
 # This way in case of any crash it will be treated by jenkins as failure
 if [[ -n "$TEST_RESULTS_DIR" ]]; then
     mkdir -p ${TEST_RESULTS_DIR}
-    LOG_PATH=$(mktemp ${TEST_RESULTS_DIR}/benchmark_${model_short}_XXXXXX.xml)
+    LOG_PATH=$(mktemp ${TEST_RESULTS_DIR}/benchmark_${model_short}_${scenario}_XXXXXX.xml)
 fi
 
-throughput_threshold=999999 
-if [[ "${PERF_THRESHOLD}" ]]; then
-    throughput_threshold=${PERF_THRESHOLD}
-fi
-warmup_threshold=1 
-if [[ "${WARMUP_THRESHOLD}" ]]; then
-    warmup_threshold=${WARMUP_THRESHOLD}
-fi
+
+# Get threshold values according to the scenario and env variables
+throughput_threshold=999999
+
+IFS=',' read -ra pairs <<< "$PERF_THRESHOLD"
+for pair in "${pairs[@]}"; do
+    IFS='=' read -ra kv <<< "$pair"
+    key="${kv[0]}"
+    value="${kv[1]}"
+
+    if [[ $key == $scenario ]]; then
+        throughput_threshold=$value
+    fi
+done
+
+warmup_threshold=1
+
+IFS=',' read -ra pairs <<< "$WARMUP_THRESHOLD"
+for pair in "${pairs[@]}"; do
+    IFS='=' read -ra kv <<< "$pair"
+    key="${kv[0]}"
+    value="${kv[1]}"
+
+    if [[ $key == $scenario ]]; then
+        warmup_threshold=$value
+    fi
+done
 
 # Get the directory of the current script
 script_dir=$(dirname "$(readlink -f "$0")")
 
 start=`date +%s`
-python  $script_dir/../../benchmarks/benchmark_throughput.py \
-    --model $model \
-    --device hpu \
-    --seed 2024 \
-    --backend vllm \
-    --dataset /mnt/weka/data/pytorch/llama2/ShareGPT_V3_unfiltered_cleaned_split.json \
-    --num-prompts 1000 \
-    --dtype bfloat16 \
-    --max-model-len 4096 \
-    --max-num-batched-tokens 8192 \
-    --max-num-seqs 128 \
-    --use-padding-aware-scheduling |& tee $log_file
+
+export TQDM_DISABLE=True
+
+if [[ $__fp8 == "yes" ]]; then
+    export QUANT_CONFIG=/software/users/kpietkun/configs/llama3.1_quant_cofnig.json
+    python  $script_dir/../../benchmarks/benchmark_throughput.py \
+        --model $model \
+        --device hpu \
+        --seed 2024 \
+        --backend vllm \
+        --dataset /mnt/weka/data/pytorch/llama2/ShareGPT_V3_unfiltered_cleaned_split.json \
+        --num-prompts 1000 \
+        --dtype bfloat16 \
+        --max-model-len 4096 \
+        --max-num-batched-tokens 8192 \
+        --max-num-seqs 128 \
+        --quantization=inc \
+        --kv-cache-dtype=fp8_inc \
+        --weights-load_device=cpu \
+        --use-padding-aware-scheduling 2> >(tee -a $error_log_file) | tee -a $log_file
+
+else
+
+    python  $script_dir/../../benchmarks/benchmark_throughput.py \
+        --model $model \
+        --device hpu \
+        --seed 2024 \
+        --backend vllm \
+        --dataset /mnt/weka/data/pytorch/llama2/ShareGPT_V3_unfiltered_cleaned_split.json \
+        --num-prompts 1000 \
+        --dtype bfloat16 \
+        --max-model-len 4096 \
+        --max-num-batched-tokens 8192 \
+        --max-num-seqs 128 \
+        --use-padding-aware-scheduling 2> >(tee -a $error_log_file) | tee -a $log_file
+
+fi
+
+# store exit status of the first command in the pipe (python script) only
+runtime_error=${PIPESTATUS[0]}
+
 end=`date +%s`
 runtime=$((end-start))
 printf " -------------- \nBenchmark took: %2d:%02d\n\n" $((runtime/60)) $((runtime%60)) 
@@ -72,29 +139,33 @@ if [[ -n "$TEST_RESULTS_DIR" ]]; then
     # Report results for jenkins
     cat <<EOF > ${LOG_PATH}
 <?xml version="1.0" encoding="utf-8"?>
-<testsuites><testsuite name="benchmark" errors="0" failures="$((throughput_fail + warmup_fail))" skipped="0" tests="2" time="$runtime">
-<testcase classname=".jenkins.benchmark.${model_short}-bf16" name="${model_short}-bf16-throughput" time="$runtime">
+<testsuites><testsuite name="benchmark" errors="$runtime_error" failures="$((throughput_fail + warmup_fail))" skipped="0" tests="2" time="$runtime">
+<testcase classname=".jenkins.benchmark.${model_short}-${scenario}" name="${model_short}-${scenario}-throughput" time="$runtime">
 <properties>
 <property name="throughput" value="$throughput"/>
 <property name="throughput threshold" value="$throughput_threshold"/>
 </properties>
 EOF
-    if [[ "$throughput_fail" -eq 1 ]]; then
+    if [ "$throughput_fail" -eq 1 ] || [ "$runtime_error" -eq 1 ]; then
         cat <<EOF >> ${LOG_PATH}
-<failure message="Throughput did not meet the threshold  ($throughput &lt; $throughput_threshold)"></failure>
+<failure message="Throughput did not meet the threshold  ($throughput &lt; $throughput_threshold)">
+$(cat "$error_log_file" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g")
+</failure>
 EOF
     fi
  cat <<EOF >> ${LOG_PATH}
 </testcase>
-<testcase classname=".jenkins.benchmark.${model_short}-bf16" name="${model_short}-bf16-warmup" time="$warmup">
+<testcase classname=".jenkins.benchmark.${model_short}-${scenario}" name="${model_short}-${scenario}-warmup" time="$warmup">
 <properties>
 <property name="warmup time" value="$warmup"/>
 <property name="warmup threshold" value="$warmup_threshold"/>
 </properties>
 EOF
-    if [[ "$warmup_fail" -eq 1 ]]; then
+    if [ "$warmup_fail" -eq 1 ] || [ "$runtime_error" -eq 1 ]; then
         cat <<EOF >> ${LOG_PATH}
-<failure message="Warmup did not meet the threshold ($warmup &gt; $warmup_threshold)"></failure>
+<failure message="Warmup did not meet the threshold ($warmup &gt; $warmup_threshold)">
+$(cat "$error_log_file" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g")
+</failure>
 EOF
     fi
     cat <<EOF >> ${LOG_PATH}

--- a/.jenkins/benchmark/run-benchmark.sh
+++ b/.jenkins/benchmark/run-benchmark.sh
@@ -75,7 +75,7 @@ export TQDM_DISABLE=True
 fp8_args=""
 if [[ $__fp8 == "yes" ]]; then
     export QUANT_CONFIG=/software/users/kpietkun/configs/llama3.1_quant_cofnig.json
-    extra_args="--quantization=inc \
+    fp8_args="--quantization=inc \
         --kv-cache-dtype=fp8_inc \
         --weights-load_device=cpu "
 fi

--- a/.jenkins/benchmark/run-benchmark.sh
+++ b/.jenkins/benchmark/run-benchmark.sh
@@ -72,7 +72,7 @@ start=`date +%s`
 
 export TQDM_DISABLE=True
 
-extra_args=""
+fp8_args=""
 if [[ $__fp8 == "yes" ]]; then
     export QUANT_CONFIG=/software/users/kpietkun/configs/llama3.1_quant_cofnig.json
     extra_args="--quantization=inc \

--- a/.jenkins/test_config_t_compile.yaml
+++ b/.jenkins/test_config_t_compile.yaml
@@ -182,8 +182,13 @@ stages:
       command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_SKIP_WARMUP=true && pytest -v tests/v1/entrypoints  -s -vvv --log-cli-level=INFO 
   - name: benchmarks
     steps:
-    - name: benchmark_llama_3_1_8b
+    - name: benchmark_llama_3_1_8b_bf16
       flavor: g3
       command: >
         export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True &&
         bash .jenkins/benchmark/run-benchmark.sh 
+    - name: benchmark_llama_3_1_8b_fp8
+      flavor: g3
+      command: >
+        export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True &&
+        bash .jenkins/benchmark/run-benchmark.sh -fp8


### PR DESCRIPTION
This PR adds t.compile fp8 performance test to jenkins. This is a follow-up of @anko-intel's effort to early detect t.compile regressions in the CI pipeline.