### PR TITLE
[DeepSeek R1] Skip profile run on decode server

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1840,6 +1840,10 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                      lora_request=lora_request)
 
     def profile_run(self) -> None:
+        if self.vllm_config.kv_transfer_config is not None and\
+            self.vllm_config.kv_transfer_config.is_kv_consumer:
+            return
+
         num_layers = self.model_config.get_num_layers(self.parallel_config)
         kv_caches = [None] * num_layers
         bind_kv_cache(


### PR DESCRIPTION
In PD disaggregation scenario, it doesn't make sense to profile run with the largest prefill bucket on the decode instances. However, it can not run with decode batch because the number of hpu blocks is unknown at this stage. The PR skip the profile run on decode instances and it is expected to use VLLM_GPU_MEMORY_UTILIZATION to reserve enough memory.

