### PR TITLE
Flat KV cache layout

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@89030c
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@dev/kdamaszke/flat_kv_cache

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@dev/kdamaszke/flat_kv_cache
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@987d9d2

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -461,7 +461,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
 
         key = key.view(-1, self.num_kv_heads, self.head_size)
         value = value.view(-1, self.num_kv_heads, self.head_size)
-        slot_mapping = attn_metadata.slot_mapping.flatten()
+        slot_mapping = attn_metadata.slot_mapping.flatten(
+        ) if attn_metadata.slot_mapping is not None else None
         key_cache = None
         value_cache = None
         if kv_cache is not None and isinstance(kv_cache, tuple):
@@ -579,7 +580,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         else:
             assert value is None
 
-        cross_slot_mapping = attn_metadata.cross_slot_mapping.flatten()
+        cross_slot_mapping = attn_metadata.cross_slot_mapping.flatten(
+        ) if attn_metadata.cross_slot_mapping is not None else None
         if kv_cache is not None and isinstance(kv_cache, tuple):
             key_cache, value_cache = HPUPagedAttention.split_kv_cache(
                 kv_cache, self.num_kv_heads, self.head_size)

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -511,7 +511,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                 attn_bias=attn_bias,
                 valid_seq_lengths=attn_metadata.seq_lens_tensor,
                 **self.common_attention_args(block_list, key_cache,
-                                             value_cache))
+                                             value_cache,
+                                             attn_metadata.block_size))
             output = out.reshape(batch_size, seq_len, hidden_size)
         else:
             # Decoding run.
@@ -520,16 +521,17 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                 block_mapping=attn_metadata.block_mapping,
                 block_bias=attn_metadata.attn_bias,
                 block_groups=attn_metadata.block_groups,
-                block_size=attn_metadata.block_size,
                 **self.common_attention_args(attn_metadata.block_list,
-                                             key_cache, value_cache))
+                                             key_cache, value_cache,
+                                             attn_metadata.block_size))
         # Reshape the output tensor.
         return output.view(batch_size, seq_len, hidden_size)
 
     def common_attention_args(self,
                               block_list=None,
                               key_cache=None,
-                              value_cache=None):
+                              value_cache=None,
+                              block_size=None):
         return {
             'scale': self.scale,
             'matmul_qk_op': self.matmul_qk,
@@ -543,6 +545,7 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             'block_list': block_list,
             'key_cache': key_cache,
             'value_cache': value_cache,
+            'block_size': block_size,
         }
 
     def forward_encoder_decoder(

--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -20,8 +20,7 @@ class HPUPagedAttentionMetadata:
     block_list: Optional[torch.Tensor]
     block_mapping: Optional[torch.Tensor]
     block_usage: Optional[torch.Tensor]
-    block_indices: Optional[torch.Tensor]
-    block_offsets: Optional[torch.Tensor]
+    block_indices_and_offsets: Optional[torch.Tensor]
     block_groups: Optional[torch.Tensor]
 
 
@@ -38,7 +37,7 @@ class HPUPagedAttention:
         num_kv_heads: int,
         head_size: int,
     ) -> Tuple[int, ...]:
-        return (num_blocks, block_size, num_kv_heads, head_size)
+        return (num_blocks * block_size, num_kv_heads, head_size)
 
     @staticmethod
     def split_kv_cache(

--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -20,7 +20,7 @@ class HPUPagedAttentionMetadata:
     block_list: Optional[torch.Tensor]
     block_mapping: Optional[torch.Tensor]
     block_usage: Optional[torch.Tensor]
-    block_indices_and_offsets: Optional[torch.Tensor]
+    block_indices_with_offsets: Optional[torch.Tensor]
     block_groups: Optional[torch.Tensor]
 
 

--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -20,7 +20,6 @@ class HPUPagedAttentionMetadata:
     block_list: Optional[torch.Tensor]
     block_mapping: Optional[torch.Tensor]
     block_usage: Optional[torch.Tensor]
-    block_indices_with_offsets: Optional[torch.Tensor]
     block_groups: Optional[torch.Tensor]
 
 

--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -1071,14 +1071,14 @@ class MllamaTextCrossAttention(CustomOp):
                     kv_cache, self.num_local_key_value_heads, self.head_dim)
                 cached_k = torch.cat([k[s:e] for s, e in kv_range_for_decode])
                 cached_v = torch.cat([v[s:e] for s, e in kv_range_for_decode])
-                block_indices_with_offsets = torch.cat([
-                    attn_metadata.cross_block_indices_with_offsets[s:e]
+                slot_mapping = torch.cat([
+                    attn_metadata.slot_mapping[s:e]
                     for s, e in kv_range_for_decode
                 ])
                 key_cache = self.attn.impl.k_cache(cached_k, key_cache,
-                                                   block_indices_with_offsets)
-                value_cache = self.attn.impl.v_cache(
-                    cached_v, value_cache, block_indices_with_offsets)
+                                                   slot_mapping)
+                value_cache = self.attn.impl.v_cache(cached_v, value_cache,
+                                                     slot_mapping)
 
         q_len = q.shape[0]
         kv_len = k.shape[0]

--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -1071,20 +1071,14 @@ class MllamaTextCrossAttention(CustomOp):
                     kv_cache, self.num_local_key_value_heads, self.head_dim)
                 cached_k = torch.cat([k[s:e] for s, e in kv_range_for_decode])
                 cached_v = torch.cat([v[s:e] for s, e in kv_range_for_decode])
-                block_indices = torch.cat([
-                    attn_metadata.cross_block_indices[s:e]
-                    for s, e in kv_range_for_decode
-                ])
-                block_offsets = torch.cat([
-                    attn_metadata.cross_block_offsets[s:e]
+                block_indices_with_offsets = torch.cat([
+                    attn_metadata.cross_block_indices_with_offsets[s:e]
                     for s, e in kv_range_for_decode
                 ])
                 key_cache = self.attn.impl.k_cache(cached_k, key_cache,
-                                                   block_indices,
-                                                   block_offsets)
-                value_cache = self.attn.impl.v_cache(cached_v, value_cache,
-                                                     block_indices,
-                                                     block_offsets)
+                                                   block_indices_with_offsets)
+                value_cache = self.attn.impl.v_cache(
+                    cached_v, value_cache, block_indices_with_offsets)
 
         q_len = q.shape[0]
         kv_len = k.shape[0]

--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -1072,7 +1072,7 @@ class MllamaTextCrossAttention(CustomOp):
                 cached_k = torch.cat([k[s:e] for s, e in kv_range_for_decode])
                 cached_v = torch.cat([v[s:e] for s, e in kv_range_for_decode])
                 slot_mapping = torch.cat([
-                    attn_metadata.slot_mapping[s:e]
+                    attn_metadata.cross_slot_mapping[s:e]
                     for s, e in kv_range_for_decode
                 ])
                 key_cache = self.attn.impl.k_cache(cached_k, key_cache,

--- a/vllm/v1/attention/backends/hpu_attn.py
+++ b/vllm/v1/attention/backends/hpu_attn.py
@@ -42,13 +42,12 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
     @classmethod
     def make_prefill_metadata(cls, seq_lens_tensor, num_prefills,
                               input_positions, num_prefill_tokens,
-                              slot_mapping):
+                              slot_mapping, block_size):
         return cls(is_prompt=True,
                    block_list=None,
                    block_mapping=None,
                    block_usage=None,
-                   block_indices=None,
-                   block_offsets=None,
+                   block_indices_with_offsets=None,
                    block_groups=None,
                    attn_bias=None,
                    num_decode_tokens=0,
@@ -59,19 +58,19 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    input_positions=input_positions,
                    num_prefill_tokens=num_prefill_tokens,
                    slot_mapping=slot_mapping,
-                   enable_kv_scales_calculation=False)
+                   enable_kv_scales_calculation=False,
+                   block_size=block_size)
 
     @classmethod
     def make_cached_prefill_metadata(cls, seq_lens_tensor, context_lens_tensor,
                                      num_prefills, num_prefill_tokens,
                                      input_positions, slot_mapping,
-                                     block_list):
+                                     block_list, block_size):
         return cls(is_prompt=True,
                    block_list=block_list,
                    block_mapping=None,
                    block_usage=None,
-                   block_indices=None,
-                   block_offsets=None,
+                   block_indices_with_offsets=None,
                    block_groups=None,
                    attn_bias=None,
                    num_decode_tokens=0,
@@ -82,15 +81,15 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    num_prefill_tokens=num_prefill_tokens,
                    input_positions=input_positions,
                    slot_mapping=slot_mapping,
-                   enable_kv_scales_calculation=False)
+                   enable_kv_scales_calculation=False,
+                   block_size=block_size)
 
     @classmethod
     def make_decode_metadata(cls, block_list, block_usage, block_groups,
-                             input_positions, num_decode_tokens, slot_mapping):
+                             input_positions, num_decode_tokens, slot_mapping, block_size):
         return cls(is_prompt=False,
                    block_mapping=None,
-                   block_indices=None,
-                   block_offsets=None,
+                   block_indices_with_offsets=None,
                    attn_bias=None,
                    seq_lens_tensor=None,
                    context_lens_tensor=None,
@@ -103,4 +102,5 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    input_positions=input_positions,
                    num_decode_tokens=num_decode_tokens,
                    slot_mapping=slot_mapping,
-                   enable_kv_scales_calculation=False)
+                   enable_kv_scales_calculation=False,
+                   block_size=block_size)

--- a/vllm/v1/attention/backends/hpu_attn.py
+++ b/vllm/v1/attention/backends/hpu_attn.py
@@ -47,7 +47,6 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    block_list=None,
                    block_mapping=None,
                    block_usage=None,
-                   block_indices_with_offsets=None,
                    block_groups=None,
                    attn_bias=None,
                    num_decode_tokens=0,
@@ -70,7 +69,6 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                    block_list=block_list,
                    block_mapping=None,
                    block_usage=None,
-                   block_indices_with_offsets=None,
                    block_groups=None,
                    attn_bias=None,
                    num_decode_tokens=0,
@@ -90,7 +88,6 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
                              block_size):
         return cls(is_prompt=False,
                    block_mapping=None,
-                   block_indices_with_offsets=None,
                    attn_bias=None,
                    seq_lens_tensor=None,
                    context_lens_tensor=None,

--- a/vllm/v1/attention/backends/hpu_attn.py
+++ b/vllm/v1/attention/backends/hpu_attn.py
@@ -64,8 +64,8 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
     @classmethod
     def make_cached_prefill_metadata(cls, seq_lens_tensor, context_lens_tensor,
                                      num_prefills, num_prefill_tokens,
-                                     input_positions, slot_mapping,
-                                     block_list, block_size):
+                                     input_positions, slot_mapping, block_list,
+                                     block_size):
         return cls(is_prompt=True,
                    block_list=block_list,
                    block_mapping=None,
@@ -86,7 +86,8 @@ class HPUAttentionMetadataV1(HPUAttentionMetadata):
 
     @classmethod
     def make_decode_metadata(cls, block_list, block_usage, block_groups,
-                             input_positions, num_decode_tokens, slot_mapping, block_size):
+                             input_positions, num_decode_tokens, slot_mapping,
+                             block_size):
         return cls(is_prompt=False,
                    block_mapping=None,
                    block_indices_with_offsets=None,

--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -81,10 +81,10 @@ class HpuModelAdapterEncoderDecoder(HpuModelAdapter):
                                      cross_attn_bias=cross_attn_bias)
         return metadata
 
-    def _set_cross_indices_and_offsets(self, metadata):
+    def _set_cross_indices_with_offsets(self, metadata):
         cross_slot_mapping = metadata.cross_slot_mapping.flatten()
         metadata = metadata._replace(
-            cross_block_indices_and_offsets=cross_slot_mapping)
+            cross_block_indices_with_offsets=cross_slot_mapping)
         return metadata
 
     def _update_seq_lens(self, attn_metadata, batch_size, seq_len, device):
@@ -103,7 +103,7 @@ class HpuModelAdapterEncoderDecoder(HpuModelAdapter):
         if max(attn_metadata.encoder_seq_lens) == 0:
             return attn_metadata
         if attn_metadata.is_prompt:
-            attn_metadata = self._set_cross_indices_and_offsets(attn_metadata)
+            attn_metadata = self._set_cross_indices_with_offsets(attn_metadata)
             attn_metadata = self._update_seq_lens(attn_metadata, batch_size,
                                                   seq_len, device)
         else:
@@ -510,7 +510,7 @@ class HPUEncoderDecoderModelRunner(
             'slot_mapping',
             'is_prompt',
             'block_size',
-            'block_indices_and_offsets',
+            'block_indices_with_offsets',
             'block_groups',
             'num_prefill_tokens',
             'num_decode_tokens',
@@ -518,7 +518,7 @@ class HPUEncoderDecoderModelRunner(
             'seq_lens',
             'encoder_seq_lens',
             'encoder_seq_lens_tensor',
-            'cross_block_indices_and_offsets',
+            'cross_block_indices_with_offsets',
             'cross_block_list',
             'cross_slot_mapping',
             'cross_block_mapping',

--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -81,14 +81,10 @@ class HpuModelAdapterEncoderDecoder(HpuModelAdapter):
                                      cross_attn_bias=cross_attn_bias)
         return metadata
 
-    def _set_cross_indices_and_offsets(self, metadata, block_size):
+    def _set_cross_indices_and_offsets(self, metadata):
         cross_slot_mapping = metadata.cross_slot_mapping.flatten()
-        indices = torch.div(cross_slot_mapping,
-                            block_size,
-                            rounding_mode="floor")
-        offsets = torch.fmod(cross_slot_mapping, block_size)
-        metadata = metadata._replace(cross_block_offsets=offsets,
-                                     cross_block_indices=indices)
+        metadata = metadata._replace(
+            cross_block_indices_and_offsets=cross_slot_mapping)
         return metadata
 
     def _update_seq_lens(self, attn_metadata, batch_size, seq_len, device):
@@ -107,8 +103,7 @@ class HpuModelAdapterEncoderDecoder(HpuModelAdapter):
         if max(attn_metadata.encoder_seq_lens) == 0:
             return attn_metadata
         if attn_metadata.is_prompt:
-            attn_metadata = self._set_cross_indices_and_offsets(
-                attn_metadata, self.block_size)
+            attn_metadata = self._set_cross_indices_and_offsets(attn_metadata)
             attn_metadata = self._update_seq_lens(attn_metadata, batch_size,
                                                   seq_len, device)
         else:
@@ -514,8 +509,8 @@ class HPUEncoderDecoderModelRunner(
             'block_usage',
             'slot_mapping',
             'is_prompt',
-            'block_indices',
-            'block_offsets',
+            'block_size',
+            'block_indices_and_offsets',
             'block_groups',
             'num_prefill_tokens',
             'num_decode_tokens',
@@ -523,8 +518,7 @@ class HPUEncoderDecoderModelRunner(
             'seq_lens',
             'encoder_seq_lens',
             'encoder_seq_lens_tensor',
-            'cross_block_indices',
-            'cross_block_offsets',
+            'cross_block_indices_and_offsets',
             'cross_block_list',
             'cross_slot_mapping',
             'cross_block_mapping',

--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -81,12 +81,6 @@ class HpuModelAdapterEncoderDecoder(HpuModelAdapter):
                                      cross_attn_bias=cross_attn_bias)
         return metadata
 
-    def _set_cross_indices_with_offsets(self, metadata):
-        cross_slot_mapping = metadata.cross_slot_mapping.flatten()
-        metadata = metadata._replace(
-            cross_block_indices_with_offsets=cross_slot_mapping)
-        return metadata
-
     def _update_seq_lens(self, attn_metadata, batch_size, seq_len, device):
         # Set the seq_lens to after-padding sequence lengths to prevent
         # graph recapturing.
@@ -103,7 +97,6 @@ class HpuModelAdapterEncoderDecoder(HpuModelAdapter):
         if max(attn_metadata.encoder_seq_lens) == 0:
             return attn_metadata
         if attn_metadata.is_prompt:
-            attn_metadata = self._set_cross_indices_with_offsets(attn_metadata)
             attn_metadata = self._update_seq_lens(attn_metadata, batch_size,
                                                   seq_len, device)
         else:
@@ -510,7 +503,6 @@ class HPUEncoderDecoderModelRunner(
             'slot_mapping',
             'is_prompt',
             'block_size',
-            'block_indices_with_offsets',
             'block_groups',
             'num_prefill_tokens',
             'num_decode_tokens',
@@ -518,7 +510,6 @@ class HPUEncoderDecoderModelRunner(
             'seq_lens',
             'encoder_seq_lens',
             'encoder_seq_lens_tensor',
-            'cross_block_indices_with_offsets',
             'cross_block_list',
             'cross_slot_mapping',
             'cross_block_mapping',

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -379,22 +379,6 @@ class HpuModelAdapter(torch.nn.Module):
         metadata = TrimmedAttentionMetadata(**metadata_dict)  # type: ignore
         return metadata
 
-    def _set_indices_with_offsets(self, metadata, block_size, is_prompt):
-        indices_with_offsets = metadata.slot_mapping.flatten()
-        if is_prompt and not self.use_merged_prefill:
-            indices = torch.div(indices_with_offsets,
-                                block_size,
-                                rounding_mode="floor")
-            indices = indices.unflatten(0, (-1, block_size))[:, 0]
-            indices = indices.unsqueeze(1) * block_size
-            offsets = torch.arange(block_size,
-                                   device=indices.device).unsqueeze(0)
-            indices_with_offsets = (indices + offsets).flatten()
-
-        metadata = metadata._replace(
-            block_indices_with_offsets=indices_with_offsets)
-        return metadata
-
     def _update_metadata(self, attn_metadata, batch_size, seq_len, device,
                          dtype):
 
@@ -404,9 +388,6 @@ class HpuModelAdapter(torch.nn.Module):
         else:
             attn_metadata = self._set_block_mapping(attn_metadata, batch_size,
                                                     device, dtype)
-        attn_metadata = self._set_indices_with_offsets(attn_metadata,
-                                                       self.block_size,
-                                                       attn_metadata.is_prompt)
         return attn_metadata
 
     def _prepare_cos_sin(self, positions):
@@ -1390,7 +1371,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             block_list=prefix_block_list_tensor,
             block_mapping=None,
             block_usage=None,
-            block_indices_with_offsets=None,
             block_groups=None,
             attn_bias=attn_bias,
             seq_lens=seq_lens,
@@ -1674,7 +1654,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             block_list=block_list,
             block_mapping=None,
             block_usage=block_usage,
-            block_indices_with_offsets=None,
             block_groups=block_groups,
             attn_bias=None,
             seq_lens_tensor=None,
@@ -2001,7 +1980,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             'slot_mapping',
             'is_prompt',
             'block_size',
-            'block_indices_with_offsets',
             'block_groups',
             'input_positions',
         ])


### PR DESCRIPTION
Change KV cache layout to (num_blocks * block_size, num_kv_heads, head_size). This will improve the performance as update will be done on 1D indices which will remove unnecessary transpose and memcopies due to low FCD.
Corresponding change: https://github.com/HabanaAI/vllm-hpu-extension/pull/152

The influence of this feature could be observed on the below profilings, where `Transpose` is no longer observed and `index_copy` kernels replaced the slower ones `scatters`:

- default
<img width="337" alt="image" src="https://github.com/user-attachments/assets/5d5d3828-18f3-40a5-bbfd-e6a28ca5450e" />

- this PR
<img width="307" alt="image" src="https://github.com/user-attachments/assets/a409ec61-2d53-4061-b4ae-7b121251cdf2" />

The gain from this feature is even better if we will use `split_qkv`, as whole `index_copy` is hidden under MME activity:
<img width="260" alt="image" src="https://github.com/user-attachments/assets/3cf2c0cd-a66a-418a-a8fc-f20f84854d75" />

