### PR TITLE
[deepseek_r1] add torch profiler for the LLM engine

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -2,6 +2,7 @@
 
 import itertools
 import warnings
+import os
 from contextlib import contextmanager
 from typing import (Any, Callable, ClassVar, Dict, List, Optional, Sequence,
                     Tuple, Type, Union, cast, overload)
@@ -34,6 +35,7 @@ from vllm.model_executor.guided_decoding.guided_fields import (
 from vllm.outputs import (ClassificationRequestOutput, EmbeddingRequestOutput,
                           PoolingRequestOutput, RequestOutput,
                           ScoringRequestOutput)
+from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import (BeamSearchParams, GuidedDecodingParams,
@@ -243,6 +245,39 @@ class LLM:
             engine_args, usage_context=UsageContext.LLM_CLASS)
 
         self.request_counter = Counter()
+
+        self.profiler = self._setup_profiler()
+    
+    def _setup_profiler(self):
+        enable_profile = os.getenv("VLLM_ENGINE_PROFILER_ENABLED",
+                                   "false").lower() in ["true", "1"]
+        if not enable_profile:
+            return None
+        warmup = int(os.getenv("VLLM_ENGINE_PROFILER_WARMUP_STEPS", "0"))
+        steps = int(os.getenv("VLLM_ENGINE_PROFILER_STEPS", "1"))
+        repeat = int(os.getenv("VLLM_ENGINE_PROFILER_REPEAT", "1"))
+        schedule = torch.profiler.schedule(wait=0,
+                                           warmup=warmup,
+                                           active=steps,
+                                           repeat=repeat)
+        activities = [ torch.profiler.ProfilerActivity.CPU ]
+        if current_platform.is_cuda():
+            activities.append(torch.profiler.ProfilerActivity.CUDA)
+        elif current_platform.is_hpu():
+            activities.append(torch.profiler.ProfilerActivity.HPU)
+            # from habana_frameworks.torch.activity_profiler import DebugActivity
+            # debug_activities=[DebugActivity.BRIDGE_FUNCTION_CALLS]
+        profiler = torch.profiler.profile(
+            schedule=schedule,
+            activities=activities,
+            # debug_activities=debug_activities,
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(
+                '.', use_gzip=True),
+            record_shapes=False,
+            with_modules=False,
+            profile_memory=False,
+            with_stack=True)
+        return profiler
 
     @staticmethod
     def get_engine_class() -> Type[LLMEngine]:
@@ -1393,6 +1428,8 @@ class LLM:
         outputs: List[Union[RequestOutput, PoolingRequestOutput]] = []
         total_in_toks = 0
         total_out_toks = 0
+        if self.profiler:
+            self.profiler.start()
         while self.llm_engine.has_unfinished_requests():
             step_outputs = self.llm_engine.step()
             for output in step_outputs:
@@ -1412,9 +1449,15 @@ class LLM:
                                 f"est. speed input: {in_spd:.2f} toks/s, "
                                 f"output: {out_spd:.2f} toks/s")
                         pbar.update(1)
+            if self.profiler:
+                self.profiler.step()
 
         if use_tqdm:
             pbar.close()
+
+        if self.profiler:
+            torch.hpu.synchronize()
+            self.profiler.stop()
 
         # Make sure that all workers are finished.
         self.llm_engine.stop_remote_worker_execution_loop()


### PR DESCRIPTION
This PR enabled a profiler for each step of the LLMEngine. The following 4 ENVs are used to control the profiler:

- VLLM_ENGINE_PROFILER_ENABLED, set to true to enable device profiler.
- VLLM_ENGINE_PROFILER_WARMUP_STEPS, number of steps to ignore for profiling.
- VLLM_ENGINE_PROFILER_STEPS, number of steps to capture for profiling.
- VLLM_ENGINE_PROFILER_REPEAT, number of cycles for (warmup + profile).

> Please refer to [torch.profiler.schedule](https://pytorch.org/docs/stable/profiler.html#torch.profiler.schedule) for more details about the profiler schedule arguments.

> The step in profiling means a step of the LLM engine and **exclude** the profile and warmup run in HabanaModelRunner.

Please use `export VLLM_PROFILER_ENABLED=True` to enable the high-level vLLM profiler and use the result to choose the steps for detailed LLMEngine profiling.