### PR TITLE
[SW-224431] Fix fp8 measurement for mixtral

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -716,9 +716,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if current_platform.is_hpu():
             topk_ids = topk_ids.view(*x.shape[:-1], -1)
             topk_weights = topk_weights.view(*x.shape[:-1], -1)
-            return layer.moe_op(x,
-                                topk_ids=topk_ids.to(torch.int64),
-                                topk_weights=topk_weights.to(x.dtype))
+            return layer.moe_op(x, topk_ids.to(torch.int64),
+                                topk_weights.to(x.dtype))
 
         return fused_experts(
             x,


### PR DESCRIPTION
Previously it was only checking if it is using quant_config and choosing VllmMixtureOfExpertsOpFP8 as OP, which only difference is that when measuring scales it is assuming block quant. This will only happen when we are using Fp8MoEMethod as quant_method.
Kwargs in moe_op call had to be disabled, beacuse of different apis of FP8 and unquantized