### PR TITLE
Revert to old way of calling fused_scaled_dot_product_attention

### DIFF
--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -11,7 +11,8 @@ import torch
 import vllm_hpu_extension.kernels as kernels
 import vllm_hpu_extension.ops as ops
 from vllm_hpu_extension.flags import enabled_flags
-from vllm_hpu_extension.utils import Matmul, Softmax, VLLMKVCache
+from vllm_hpu_extension.utils import (Matmul, ModuleFusedSDPA, Softmax,
+                                      VLLMKVCache)
 
 import vllm.envs as envs
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
@@ -133,7 +134,9 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         self.block2batch_matmul = Matmul()
         self.k_cache = VLLMKVCache()
         self.v_cache = VLLMKVCache()
-        self.fused_scaled_dot_product_attention = kernels.fsdpa()
+        HPUFusedSDPA = kernels.fsdpa()
+        self.fused_scaled_dot_product_attention = None if HPUFusedSDPA is None \
+            else ModuleFusedSDPA(HPUFusedSDPA)
 
         self.prefill_impl = 'naive'
         if "flex_attention" in enabled_flags():
@@ -272,7 +275,7 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                               block_list=None,
                               key_cache=None,
                               value_cache=None):
-        fsdpa_op = self.fused_scaled_dot_product_attention.apply \
+        fsdpa_op = self.fused_scaled_dot_product_attention \
             if self.fused_scaled_dot_product_attention is not None else None
 
         return {


### PR DESCRIPTION
The current way of calling the op directly prevents neural-compressor from patching the fp8 module correctly, as it relies on ModuleFusedSDPA being present: https://github.com/intel/neural-compressor/blob/master/neural_compressor/torch/algorithms/fp8_quant/utils/patched_module_restore_registry.py#L128
