### PR TITLE
[CI] Align t.compile and lazy test definitions

### DIFF
--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -4,109 +4,178 @@ stages:
     steps:
       - name: v0_gsm8k_small_g3_tp1_part1
         flavor: g3
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
       - name: v0_gsm8k_small_g3_tp1_part2
         flavor: g3
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small-2.txt -t 1
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small-2.txt -t 1
       - name: v0_gsm8k_small_g3_tp1_part3
         flavor: g3
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small-3.txt -t 1
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small-3.txt -t 1
       - name: v0_gsm8k_small_g3_tp2
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
       - name: v0_gsm8k_small_g2_tp1
         flavor: g2
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
       - name: v0_gsm8k_small_g2_tp2
         flavor: g2.s
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
       - name: v0_gsm8k_g2_deepseek-v2-lite_tp1
         flavor: g3
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-deepseek.txt -t 1
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-deepseek.txt -t 1
       #- name: v1_gsm8k_small_g3_tp1
       #  flavor: g3
-      #  command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+      #  command: >-
+      #    export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+      #    cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
       - name: v1_gsm8k_small_g3_tp2
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
       #- name: v1_gsm8k_small_g2_tp1
       #  flavor: g2
-      #  command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+      #  command: >-
+      #    export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+      #    cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
       - name: v1_gsm8k_small_g2_tp2
         flavor: g2.s
-        command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
   - name: test_gsm8k_small_models_apc
     steps:
       - name: gsm8k_small_g3_tp1_apc
         flavor: g3
-        command: export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
+        command: >-
+          export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
       - name: gsm8k_small_g2_tp1_apc
         flavor: g2
-        command: export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
+        command: >-
+          export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
   - name: test_gsm8k_large_models
     steps:
       - name: v0_gsm8k_large_g3_tp2_part1
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
       - name: v0_gsm8k_large_g3_tp2_part2
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-2.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-2.txt -t 2
       - name: v0_gsm8k_large_g2_tp4
         flavor: g2.m
-        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
       - name: v1_gsm8k_large_g3_tp2_part1
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
       - name: v1_gsm8k_large_g3_tp2_part2
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-2.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-2.txt -t 2
       - name: v1_gsm8k_large_g2_tp4
         flavor: g2.m
-        command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
+        command: >-
+          export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
   - name: test_gsm8k_fp8
     steps:
       - name: gsm8k_small_g3_tp1_fp8
         flavor: g3
-        command: cd .jenkins/lm-eval-harness && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-fp8-g3-tp1.txt -t 1
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-fp8-g3-tp1.txt -t 1
       - name: gsm8k_small_g3_tp2_fp8
         flavor: g3.s
-        command: cd .jenkins/lm-eval-harness && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-fp8.txt -t 2
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-fp8.txt -t 2
   - name: test_gsm8k_mss
     steps:
       - name: gsm8k_small_g3_tp1_mss
         flavor: g3
-        command: cd .jenkins/lm-eval-harness && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-mss.txt -t 1
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-mss.txt -t 1
       - name: gsm8k_small_g2_tp1_mss
         flavor: g2
-        command: cd .jenkins/lm-eval-harness && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-mss.txt -t 1
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-mss.txt -t 1
       - name: gsm8k_small_g3_tp2_mss
         flavor: g3.s
-        command: cd .jenkins/lm-eval-harness && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-mss.txt -t 2
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-mss.txt -t 2
       - name: gsm8k_small_g2_tp2_mss
         flavor: g2.s
-        command: cd .jenkins/lm-eval-harness && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-mss.txt -t 2
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-mss.txt -t 2
       - name: gsm8k_small_g2_tp1_spec_decode
         flavor: g2
-        command: cd .jenkins/lm-eval-harness && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-mss.txt -t 1
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-mss.txt -t 1
   - name: test_gsm8k_spec_decode
     steps:
       - name: gsm8k_small_g2_tp1_mlp_spec_decode
         flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True pytest -v tests/spec_decode/e2e/test_mlp_correctness.py::test_mlp_e2e_greedy_correctness 
+        command: >-
+          PT_HPU_LAZY_MODE=1 TORCH_COMPILE_DISABLE=true VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
+          pytest -v tests/spec_decode/e2e/test_mlp_correctness.py::test_mlp_e2e_greedy_correctness 
       - name: gsm8k_small_g2_tp1_medusa_spec_decode
         flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True pytest -v tests/spec_decode/e2e/test_medusa_correctness.py::test_medusa_e2e_greedy_correctness
+        command: >-
+          PT_HPU_LAZY_MODE=1 TORCH_COMPILE_DISABLE=true VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
+          pytest -v tests/spec_decode/e2e/test_medusa_correctness.py::test_medusa_e2e_greedy_correctness
       - name: gsm8k_small_g2_tp1_eagle_spec_decode
         flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True pytest -v tests/spec_decode/e2e/test_eagle_correctness.py::test_eagle_e2e_greedy_correctness
+        command: >-
+          PT_HPU_LAZY_MODE=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
+          pytest -v tests/spec_decode/e2e/test_eagle_correctness.py::test_eagle_e2e_greedy_correctness
   - name: tests_lora
     steps:
       - name: test_llama_lora
         flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_llama_hpu.py::test_llama_lora_1x
+        command: >-
+          PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true 
+          pytest -v tests/lora/test_llama_hpu.py::test_llama_lora_1x
       - name: test_multilora
         flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_multilora_hpu.py::test_llama_multilora_1x
+        command: >-
+          PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true 
+          pytest -v tests/lora/test_multilora_hpu.py::test_llama_multilora_1x
       # - name: test_long_context
       #   flavor: g2
       #   command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_long_context_hpu.py::test_quality
@@ -117,26 +186,42 @@ stages:
         command: cd .jenkins/vision && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-small.txt -t 1
       - name: multimodal_small_g3_tp2
         flavor: g3.s
-        command: cd .jenkins/vision && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          cd .jenkins/vision &&
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-small.txt -t 2
       - name: multimodal_small_g3_tp1_mss
         flavor: g3
-        command: cd .jenkins/vision && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-mss.txt -t 1
+        command: >-
+          cd .jenkins/vision &&
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-mss.txt -t 1
       - name: multimodal_small_g3_tp2_mss
         flavor: g3.s
-        command: cd .jenkins/vision && PT_HPU_LAZY_MODE=1 bash run-tests.sh -c configs/models-mss.txt -t 2
+        command: >-
+          cd .jenkins/vision &&
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-mss.txt -t 2
   - name: tests_int4_quantization
     steps:
       - name: test_awq
         flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/quantization/test_awq.py::test_awq
+        command: >-
+          PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true 
+          pytest -v tests/quantization/test_awq.py::test_awq
       - name: test_gptq
         flavor: g2
-        command: PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true pytest -v tests/quantization/test_gptq.py::test_gptq
+        command: >-
+          PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true 
+          pytest -v tests/quantization/test_gptq.py::test_gptq
   - name: tests_guided_decode
     steps:
     - name: test_lazy_outlines
       flavor: g2
-      command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && PT_HPU_LAZY_MODE=1 pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO 
+      command: >-
+        pip install -e tests/vllm_test_utils &&
+        export VLLM_SKIP_WARMUP=true && PT_HPU_LAZY_MODE=1 
+        pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO 
     #- name: test_guided_generate
     #  flavor: g2
     #  command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && PT_HPU_LAZY_MODE=1 pytest -v tests/entrypoints/llm/test_guided_generate.py -s -vvv --log-cli-level=INFO
@@ -144,8 +229,16 @@ stages:
     steps:
     - name: test_v1_core_engine_worker_g2
       flavor: g2
-      command:  export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && pytest -v -s -vvv --log-cli-level=INFO tests/v1/core -k "not kv_connector" && pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker 
+      command: >-
+        export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/core -k "not kv_connector" && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker 
     - name: test_v1_core_engine_worker_g3
       flavor: g3
-      command: export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && pytest -v -s -vvv --log-cli-level=INFO tests/v1/core -k "not kv_connector" && pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker 
+      command: >-
+        export PT_HPU_LAZY_MODE=1 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/core -k "not kv_connector" && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker 
     

--- a/.jenkins/test_config_t_compile.yaml
+++ b/.jenkins/test_config_t_compile.yaml
@@ -2,63 +2,116 @@
 stages:
   - name: test_gsm8k_small_models
     steps:
-      - name: v0_gsm8k_small_g3_tp1
+      - name: v0_gsm8k_small_g3_tp1_part1
         flavor: g3
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+      - name: v0_gsm8k_small_g3_tp1_part2
+        flavor: g3
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small-2.txt -t 1
+      - name: v0_gsm8k_small_g3_tp1_part3
+        flavor: g3
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small-3.txt -t 1
       - name: v0_gsm8k_small_g3_tp2
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
       - name: v0_gsm8k_small_g2_tp1
         flavor: g2
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
       - name: v0_gsm8k_small_g2_tp2
         flavor: g2.s
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+      - name: v0_gsm8k_g2_deepseek-v2-lite_tp1
+        flavor: g3
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-deepseek.txt -t 1
       #- name: v1_gsm8k_small_g3_tp1
       #  flavor: g3
-      #  command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+      #  command: >-
+      #    export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+      #    cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
       - name: v1_gsm8k_small_g3_tp2
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
       #- name: v1_gsm8k_small_g2_tp1
       #  flavor: g2
-      #  command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
+      #  command: >-
+      #    export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+      #    cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1
       - name: v1_gsm8k_small_g2_tp2
         flavor: g2.s
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 2
   - name: test_gsm8k_small_models_apc
     steps:
       - name: gsm8k_small_g3_tp1_apc
         flavor: g3
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
       - name: gsm8k_small_g2_tp1_apc
         flavor: g2
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-small.txt -t 1 -a
   - name: test_gsm8k_large_models
     steps:
-      - name: v0_gsm8k_large_g3_tp2
+      - name: v0_gsm8k_large_g3_tp2_part1
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
+      - name: v0_gsm8k_large_g3_tp2_part2
+        flavor: g3.s
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-2.txt -t 2
       - name: v0_gsm8k_large_g2_tp4
         flavor: g2.m
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
-      - name: v1_gsm8k_large_g3_tp2
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
+      - name: v1_gsm8k_large_g3_tp2_part1
         flavor: g3.s
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 2
+      - name: v1_gsm8k_large_g3_tp2_part2
+        flavor: g3.s
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-2.txt -t 2
       - name: v1_gsm8k_large_g2_tp4
         flavor: g2.m
-        command: export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
+        command: >-
+          export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True && export VLLM_USE_V1=1 && export VLLM_CONTIGUOUS_PA=false && 
+          cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4
   - name: test_gsm8k_fp8
     steps:
       - name: gsm8k_small_g3_tp1_fp8
         flavor: g3
-        command: >
+        command: >-
           cd .jenkins/lm-eval-harness && 
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
-          bash run-tests.sh -c configs/models-fp8.txt -t 1
+          bash run-tests.sh -c configs/models-fp8-g3-tp1.txt -t 1
       - name: gsm8k_small_g3_tp2_fp8
         flavor: g3.s
-        command: >
+        command: >-
           cd .jenkins/lm-eval-harness && 
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-fp8.txt -t 2
@@ -66,31 +119,31 @@ stages:
     steps:
       - name: gsm8k_small_g3_tp1_mss
         flavor: g3
-        command: >
+        command: >-
           cd .jenkins/lm-eval-harness && 
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-mss.txt -t 1
       - name: gsm8k_small_g2_tp1_mss
         flavor: g2
-        command: >
+        command: >-
           cd .jenkins/lm-eval-harness && 
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-mss.txt -t 1
       - name: gsm8k_small_g3_tp2_mss
         flavor: g3.s
-        command: >
+        command: >-
           cd .jenkins/lm-eval-harness && 
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-mss.txt -t 2
       - name: gsm8k_small_g2_tp2_mss
         flavor: g2.s
-        command: >
+        command: >-
           cd .jenkins/lm-eval-harness && 
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-mss.txt -t 2
       - name: gsm8k_small_g2_tp1_spec_decode
         flavor: g2
-        command: >
+        command: >-
           cd .jenkins/lm-eval-harness && 
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-mss.txt -t 1
@@ -98,12 +151,12 @@ stages:
     steps:
       - name: gsm8k_small_g2_tp1_mlp_spec_decode
         flavor: g2
-        command: > 
+        command: >-
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 TORCH_COMPILE_DISABLE=true VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
           pytest -v tests/spec_decode/e2e/test_mlp_correctness.py::test_mlp_e2e_greedy_correctness 
       - name: gsm8k_small_g2_tp1_medusa_spec_decode
         flavor: g2
-        command: >
+        command: >-
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 TORCH_COMPILE_DISABLE=true VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
           pytest -v tests/spec_decode/e2e/test_medusa_correctness.py::test_medusa_e2e_greedy_correctness
       - name: gsm8k_small_g2_tp1_eagle_spec_decode
@@ -120,77 +173,88 @@ stages:
           pytest -v tests/lora/test_llama_hpu.py::test_llama_lora_1x
       - name: test_multilora
         flavor: g2
-        command: >
+        command: >-
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true 
           pytest -v tests/lora/test_multilora_hpu.py::test_llama_multilora_1x
       # - name: test_long_context
       #   flavor: g2
-      #   command:  VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true pytest -v tests/lora/test_long_context_hpu.py::test_quality
+      #   command: >-
+      #     VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true 
+      #     pytest -v tests/lora/test_long_context_hpu.py::test_quality
   - name: tests_multimodal
     steps:
       - name: multimodal_small_g3_tp1
         flavor: g3
-        command: >
-          cd .jenkins/vision &&
+        command: >-
+          cd .jenkins/vision && 
           VLLM_T_COMPILE_FULLGRAPH=False PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-small.txt -t 1
       - name: multimodal_small_g3_tp2
         flavor: g3.s
-        command: >
-          cd .jenkins/vision && 
+        command: >-
+          cd .jenkins/vision &&
           VLLM_T_COMPILE_FULLGRAPH=False PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-small.txt -t 2
       - name: multimodal_small_g3_tp1_mss
         flavor: g3
-        command: >
-          cd .jenkins/vision && VLLM_T_COMPILE_FULLGRAPH=False PT_HPU_LAZY_MODE=0 
+        command: >-
+          cd .jenkins/vision &&
+          VLLM_T_COMPILE_FULLGRAPH=False PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-mss.txt -t 1
       - name: multimodal_small_g3_tp2_mss
         flavor: g3.s
-        command: >
-          cd .jenkins/vision && 
+        command: >-
+          cd .jenkins/vision &&
           VLLM_T_COMPILE_FULLGRAPH=False PT_HPU_LAZY_MODE=0 
           bash run-tests.sh -c configs/models-mss.txt -t 2
   - name: tests_int4_quantization
     steps:
       - name: test_awq
         flavor: g2
-        command: >
+        command: >-
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true 
           pytest -v tests/quantization/test_awq.py::test_awq
       - name: test_gptq
         flavor: g2
-        command: >
+        command: >-
           VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 VLLM_SKIP_WARMUP=true 
           pytest -v tests/quantization/test_gptq.py::test_gptq
   - name: tests_guided_decode
     steps:
     - name: test_lazy_outlines
       flavor: g2
-      command: >
-        export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && 
-        VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
+      command: >-
+        pip install -e tests/vllm_test_utils &&
+        VLLM_SKIP_WARMUP=true  VLLM_T_COMPILE_FULLGRAPH=True PT_HPU_LAZY_MODE=0 
         pytest -v tests/entrypoints/llm/test_lazy_outlines.py -s -vvv --log-cli-level=INFO 
-    - name: test_guided_generate
-      flavor: g2
-      command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && PT_HPU_LAZY_MODE=0 pytest -v tests/entrypoints/llm/test_guided_generate.py -s -vvv --log-cli-level=INFO
+    #- name: test_guided_generate
+    #  flavor: g2
+    #  command: export VLLM_SKIP_WARMUP=true && pip install -e tests/vllm_test_utils && PT_HPU_LAZY_MODE=0 pytest -v tests/entrypoints/llm/test_guided_generate.py -s -vvv --log-cli-level=INFO
   - name: test_v1_basic_uts
     steps:
-    - name: test_v1_core_engine_worker_entrypoints_g2
+    - name: test_v1_core_engine_worker_g2
       flavor: g2
-      command:  export PT_HPU_LAZY_MODE=0 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && pytest -v -s -vvv --log-cli-level=INFO tests/v1/core && pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker && pytest -v -s -vvv --log-cli-level=INFO tests/v1/entrypoints 
-    - name: test_v1_core_engine_worker_entrypoints_g3
+      command: >-
+        export PT_HPU_LAZY_MODE=0 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/core && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker 
+    - name: test_v1_core_engine_worker_g3
       flavor: g3
-      command: export PT_HPU_LAZY_MODE=0 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && pytest -v -s -vvv --log-cli-level=INFO tests/v1/core && pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker && pytest -v -s -vvv --log-cli-level=INFO tests/v1/entrypoints        
+      command: >-
+        export PT_HPU_LAZY_MODE=0 && export VLLM_USE_V1=1 && export VLLM_SKIP_WARMUP=true && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/core && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/engine && 
+        pytest -v -s -vvv --log-cli-level=INFO tests/v1/worker 
   - name: benchmarks
     steps:
     - name: benchmark_llama_3_1_8b_bf16
       flavor: g3
-      command: >
+      command: >-
         export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True &&
         bash .jenkins/benchmark/run-benchmark.sh 
     - name: benchmark_llama_3_1_8b_fp8
       flavor: g3
-      command: >
+      command: >-
         export PT_HPU_LAZY_MODE=0 && export VLLM_T_COMPILE_FULLGRAPH=True &&
         bash .jenkins/benchmark/run-benchmark.sh -fp8


### PR DESCRIPTION
It aligns tests run for lazy and t.compile.
It also separates lines with environment settings to make it easier to combine lazy and t.compile tests.
