### PR TITLE
Fix gemma3 workload execution failure

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -30,7 +30,6 @@ from vllm.multimodal.processing import (BaseMultiModalProcessor,
 # yapf: enable
 from vllm.multimodal.profiling import BaseDummyInputsBuilder
 from vllm.sequence import IntermediateTensors
-
 from vllm.platforms import current_platform
 
 from .interfaces import (MultiModalEmbeddings, SupportsLoRA,

--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -31,6 +31,8 @@ from vllm.multimodal.processing import (BaseMultiModalProcessor,
 from vllm.multimodal.profiling import BaseDummyInputsBuilder
 from vllm.sequence import IntermediateTensors
 
+from vllm.platforms import current_platform
+
 from .interfaces import (MultiModalEmbeddings, SupportsLoRA,
                          SupportsMultiModal, SupportsPP)
 from .siglip import SiglipVisionModel
@@ -639,6 +641,11 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
         **kwargs,
     ):
         kwargs["has_images"] = True
+
+        if current_platform.is_hpu():
+            input_ids = input_ids.flatten()
+            positions = positions.flatten()
+
         # NOTE(woosuk): Here, we distinguish the sequences by the position id 0.
         # This is a HACK. Fix this.
         start_idices = (positions == 0).cpu().nonzero()


### PR DESCRIPTION
Fixed gemma3 workload execution failures.
Tested with gemma3 4b it model.
For your testing, you might need to use cache for model, and need to set no_proxy for client connection.

* With 1.21.0
Server command:
```
VLLM_PROMPT_BS_BUCKET_MIN=1 VLLM_PROMPT_BS_BUCKET_STEP=1 VLLM_PROMPT_BS_BUCKET_MAX=1 \
VLLM_PROMPT_SEQ_BUCKET_MIN=384 VLLM_PROMPT_SEQ_BUCKET_MAX=384 \
VLLM_DECODE_BS_BUCKET_MIN=1 VLLM_DECODE_BS_BUCKET_MAX=1 \
VLLM_DECODE_BLOCK_BUCKET_MIN=512 VLLM_DECODE_BLOCK_BUCKET_MAX=512 \
python -m vllm.entrypoints.openai.api_server \
--model google/gemma-3-4b-it --max-num-batched-tokens 8192 --max-model-len 8192 --port 8000
```
* With 1.20.0
There's an issue on hpu graph side, when it deals with pixel_values.
So, you need to add `PT_HPUGRAPH_DISABLE_TENSOR_CACHE=false`

* Client command (from: https://rocm.blogs.amd.com/artificial-intelligence/deployingGemma-vllm/README.html)
> for text and image input
```
curl -X POST "http://localhost:8000/v1/chat/completions" \
  -H "Content-Type: application/json" \
  --data '{
    "model": "google/gemma-3-4b-it",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "Describe this image in one sentence."
          },
          {
            "type": "image_url",
            "image_url": {
              "url": "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
            }
          }
        ]
      }
    ]
  }' | jq
```
> for text only
```
curl -X POST "http://localhost:8000/v1/chat/completions" \
  -H "Content-Type: application/json" \
  --data '{
    "model": "google/gemma-3-4b-it",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "Describe the shape of an apple."
          }
        ]
      }
    ]
  }' | jq
```

