### PR TITLE
[deepseek_r1] use vllm-hpu-extension/deepseek_r1

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@ecb60e4
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@deepseek_r1


### PR DESCRIPTION
We can push the modifications specified to Deepseek-R1 and useful commits from the main branch to `vllm-hpu-extension/deepseek_r1`.

@czhu15 Please help to notify the reviewers and the related developers.