### PR TITLE
Fix penalty crash in deepseek

### DIFF
--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -15,7 +15,10 @@ def get_token_bin_counts_and_mask(
     bin_counts = torch.zeros((num_seqs, vocab_size + 1),
                              dtype=torch.long,
                              device=tokens.device)
-    bin_counts.scatter_add_(1, tokens, torch.ones_like(tokens))
+    # To workaround scatter_add_ crash
+    # TODO: revert when the crash is fixed, as scatter_add
+    # fallback to CPU
+    bin_counts = bin_counts.scatter_add(1, tokens, torch.ones_like(tokens))
     bin_counts = bin_counts[:, :vocab_size]
     mask = bin_counts > 0
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -84,6 +84,7 @@ VLLM_DELAYED_SAMPLING = os.environ.get('VLLM_DELAYED_SAMPLING',
                                        'false').lower() == 'true'
 DUMMY_TOKEN_ID = -1
 
+_SAMPLING_EPS = 1e-5
 
 class PhaseType(Enum):
     PREFILL = 'prefill'
@@ -2873,8 +2874,21 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 if not self.is_driver_worker:
                     return []
 
+                is_prev_output_patched = False
                 if use_delayed_sampling:
                     fake_output = self._delayed_sampler_outputs(model_input)
+                    if not model_input.is_prompt:
+                        penalty_are_requested = any([
+                            abs(sg.sampling_params.presence_penalty) >= _SAMPLING_EPS
+                            or abs(sg.sampling_params.frequency_penalty) >= _SAMPLING_EPS
+                            or abs(sg.sampling_params.repetition_penalty) >= _SAMPLING_EPS
+                            for sg in sampling_metadata.seq_groups])
+                        # If penalty is requsted, move _patch_prev_output
+                        # before sampler, as output_token_ids is required
+                        # but not yet updated for some requests.
+                        if penalty_are_requested:
+                            is_prev_output_patched =True
+                            self._patch_prev_output()
 
                 with self.profiler.record_event(
                         'internal', ('sample_'
@@ -2891,7 +2905,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         output = output.sampled_token_ids
                         self.cached_step_outputs.append(output)
                     if use_delayed_sampling and self.is_driver_worker:
-                        self._patch_prev_output()
+                        if not is_prev_output_patched:
+                            self._patch_prev_output()
                         output = self._pad_to_max_num_seqs(
                             output.sampled_token_ids, DUMMY_TOKEN_ID)
                         self.cached_step_outputs.append(output)


### PR DESCRIPTION
This PR is to fix vLLM crash when penalty is enabled in sampling for deepseek.

1. Fix the wrong input in output_tokens when delayed sampling is enabled.
2. Workaround scatter_add_ crash in 1.20.1.

