### PR TITLE
[deepseek_r1] enable batched tokens slicing for static quant + dynamic MoE

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -507,6 +507,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def __init__(self, quant_config: Fp8Config):
         self.quant_config = quant_config
         self.block_quant = self.quant_config.weight_block_size is not None
+        
+        # Slicing the batched tokens for DynamicMoE to reduce the memory consumption
+        self.moe_slice_length = int(os.environ.get("VLLM_MOE_SLICE_LENGTH", 8192))
+
         self.moe_n_slice = int(os.environ.get("VLLM_MOE_N_SLICE", 8))
         self.enable_dmoe_dynamic_scale = os.environ.get("VLLM_DMOE_DYNAMIC_SCALE", False) in ["1", "true"]
         self.use_static_moe = os.environ.get("VLLM_USE_STATIC_MOE", "0") in ["1", "true"]
@@ -1012,21 +1016,50 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 x_fp8 = torch.ops.hpu.cast_to_fp8_v2(x, 1.0/x_scale, False, False, torch.float8_e4m3fn)[0]
             else:
                 x_fp8 = x
-            final_hidden_states = torch.ops.hpu.mixture_of_experts(
-                hidden_states=x_fp8,
-                expert_routing_table=(topk_ids.to(torch.int64) - ep_shift),
-                router_weights=topk_weights.to(x.dtype),
-                w12=self.w13_weight_list,
-                w3=self.w2_weight_list,
-                d_scale_hidden_states=x_scale,
-                d_scale_intermediate_hidden_states=self.w2_input_scale_list,
-                d_scale_w12=self.w13_weight_scale_list,
-                d_scale_w3=self.w2_weight_scale_list,
-                permuted_weights=True,
-                activation="silu",
-                experts_min=0,
-                experts_max=(num_experts - 1),
-            )
+            topk_weights = topk_weights.to(torch.bfloat16)
+            batched_tokens = x.shape[0]
+            selected_experts = (topk_ids.to(torch.int64) - ep_shift)
+            if batched_tokens > self.moe_slice_length:
+                final_hidden_states_list = []
+                n_slice = (batched_tokens + self.moe_slice_length -
+                           1) // self.moe_slice_length
+                for i in range(n_slice):
+                    s = i * self.moe_slice_length
+                    e = batched_tokens if i == (n_slice -
+                                    1) else (i + 1) * self.moe_slice_length
+                    current_hidden_states = torch.ops.hpu.mixture_of_experts(
+                    hidden_states=x_fp8[s:e, ...],
+                    expert_routing_table=selected_experts[s:e, ...],
+                    router_weights=topk_weights[s:e, ...],
+                    w12=self.w13_weight_list,
+                    w3=self.w2_weight_list,
+                    d_scale_hidden_states=x_scale,
+                    d_scale_intermediate_hidden_states=self.w2_input_scale_list,
+                    d_scale_w12=self.w13_weight_scale_list,
+                    d_scale_w3=self.w2_weight_scale_list,
+                    permuted_weights=True,
+                    activation="silu",
+                    experts_min=0,
+                    experts_max=(num_experts - 1),
+                    )
+                    final_hidden_states_list.append(current_hidden_states)
+                final_hidden_states = torch.cat(final_hidden_states_list, dim=0)
+            else:
+                final_hidden_states = torch.ops.hpu.mixture_of_experts(
+                    hidden_states=x_fp8,
+                    expert_routing_table=selected_experts,
+                    router_weights=topk_weights,
+                    w12=self.w13_weight_list,
+                    w3=self.w2_weight_list,
+                    d_scale_hidden_states=x_scale,
+                    d_scale_intermediate_hidden_states=self.w2_input_scale_list,
+                    d_scale_w12=self.w13_weight_scale_list,
+                    d_scale_w3=self.w2_weight_scale_list,
+                    permuted_weights=True,
+                    activation="silu",
+                    experts_min=0,
+                    experts_max=(num_experts - 1),
+                )
             return final_hidden_states.view(-1, x.shape[1])
 
         def do_dynamic_moe_with_dynamic_scaling(x, topk_ids, topk_weights, w13_weight_fp8, w2_weight_fp8, moe_n_slice, n_expert_slice, w13_weight_scale_inv_fp8=None, w2_weight_scale_inv_fp8=None):


### PR DESCRIPTION
The dynamic MoE kernel consumes large device memory with large batched tokens, especially during the profiling run. Adding a slicing which could be configured by ENV `VLLM_MOE_SLICE_LENGTH` could control the max tokens passed to the kernel and reduce the memory usage as shown below for a BS=1, seq_len=32768 case.

VLLM_MOE_SLICE_LENGTH | profiling run memory (GiB)
-- | --
4096 | 1.004
8192 | 1.801
16384 | 3.389
32768 | 6.528