### PR TITLE
Fix fixture duplication in async_engine tests

### DIFF
--- a/tests/async_engine/test_async_llm_engine.py
+++ b/tests/async_engine/test_async_llm_engine.py
@@ -155,7 +155,6 @@ def uid() -> str:
                         }, {
                             "enforce_eager": True
                         }])
-@pytest_asyncio.fixture(scope="module")
 async def async_engine(request):
     # We cannot use monkeypatch since this is a module
     # scoped fixture and monkeypatch is function scoped.


### PR DESCRIPTION
Fix fixture duplication in async_engine tests after [HabanaAI/vllm-fork#1130](https://github.com/HabanaAI/vllm-fork/pull/1130)
