### PR TITLE
[deepseek_r1] set module id to the local rank

### DIFF
--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -206,7 +206,7 @@ class HPUWorker(LocalOrDistributedWorkerBase):
     def init_device(self) -> None:
         if self.device_config.device.type == "hpu":
             self.device = torch.device("hpu")
-            torch.hpu.set_device(self.device)
+            torch.hpu.set_device(self.local_rank)
         elif self.device_config.device_type == "cpu":
             self.device = torch.device("cpu")
         else:


### PR DESCRIPTION
This PR choose the HPU device according to the local rank instead of the first available one. Choosing the first available HPU will results in:
- random mapping between the `local_rank` and the `module_id` as the process of each rank starts in random order.
- failure to select specified devices with `HABANA_VISIBLE_MODULES`.

The random mapping may cause cross-NUMA access in inter-node pipeline-parallel and cross-group HCCL call for PCIe SKU. 