### PR TITLE
update benchmark scripts

### DIFF
--- a/scripts/benchmark_throughput.sh
+++ b/scripts/benchmark_throughput.sh
@@ -113,19 +113,29 @@ if [ "$model_path" = "" ]; then
     exit
 fi
 
-model_name=$( echo "$model_path" | awk -F/ '{print $NF}' )
+model_name=$( echo $model_path | sed 's:/*$::' | awk -F/ '{print $NF}' )
 
 if [ "$num_hpu" -gt 1 ]; then
     export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
-    unset HLS_MODULE_ID
-    if [ "$module_ids" != "None" ]; then
-        export HABANA_VISIBLE_MODULES=$module_ids
+fi
+
+if [[ $module_ids =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+    IFS="," read -r -a MODULES <<< "$module_ids"
+    # check if the length of module_ids is equal to num_hpu
+    if [ ${#MODULES[@]} -ne "$num_hpu" ]; then
+        echo "The number of module IDs should be equal to the number of HPUs."
+        exit
     fi
+    export HABANA_VISIBLE_MODULES=$module_ids
+
+    # set up numactl based on module ids
+    set_numactl
+elif [ "$module_ids" == "None" ]; then
+    echo "No module IDs specified, skip numactl"
+    NUMA_CTL=""
 else
-    unset HABANA_VISIBLE_MODULES
-    if [ "$module_ids" != "None" ]; then
-        export HLS_MODULE_ID=$module_ids
-    fi
+    echo "The specified module IDs should be a comma-separated list of integers instead of $module_ids."
+    exit
 fi
 
 device=$(hl-smi -Q name -f csv | tail -n 1)
@@ -215,17 +225,19 @@ else
     export VLLM_PROMPT_USE_FUSEDSDPA=true
 fi
 
-export TOKENIZERS_PARALLELISM=true
-export VLLM_GRAPH_RESERVED_MEM=${VLLM_GRAPH_RESERVED_MEM:-"0.2"}
-export VLLM_GRAPH_PROMPT_RATIO=${VLLM_GRAPH_PROMPT_RATIO:-"0.8"}
-gpu_memory_utilization=${VLLM_GPU_MEMORY_UTILIZATION:-"0.9"}
+# set up environment variables
+set_env
 
-set_numactl
+# set up bucketing based on input/output range and max_num_batched_tokens
 set_bucketing
 
+gpu_memory_utilization=${VLLM_GPU_MEMORY_UTILIZATION:-"0.9"}
+max_seq_len_to_capture=${VLLM_MAX_SEQ_LEN_TO_CAPTURE:-"8192"}
+
 ${NUMA_CTL} \
-python3 "$BASH_DIR/../benchmarks/benchmark_throughput.py" \
+python "$BASH_DIR/../benchmarks/benchmark_throughput.py" \
     --backend vllm \
+    --device hpu \
     --model "${model_path}" \
     --trust-remote-code \
     --tensor-parallel-size "${num_hpu}" \
@@ -238,9 +250,12 @@ python3 "$BASH_DIR/../benchmarks/benchmark_throughput.py" \
     --max-num-seqs "${max_num_seqs}" \
     --max-num-batched-tokens "${max_num_batched_tokens}" \
     --max-model-len "${max_model_len}" \
+    --max-seq-len-to-capture "$max_seq_len_to_capture" \
     --num-prompts "${num_prompts}" \
     --save-results "${case_name}"_result.json \
+    --use-v2-block-manager \
     --use-padding-aware-scheduling \
     --num-scheduler-steps "${scheduler_steps}" \
+    --distributed_executor_backend mp \
     --gpu-memory-utilization "${gpu_memory_utilization}" \
     |& tee "${case_name}".log

--- a/scripts/start_gaudi_vllm_server.sh
+++ b/scripts/start_gaudi_vllm_server.sh
@@ -107,7 +107,7 @@ if [ "$model_path" = "" ]; then
     exit
 fi
 
-model_name=$( echo "$model_path" | awk -F/ '{print $NF}' )
+model_name=$( echo $model_path | sed 's:/*$::' | awk -F/ '{print $NF}' )
 input_min=${input_range[0]}
 input_max=${input_range[1]}
 output_min=${output_range[0]}
@@ -119,17 +119,26 @@ fi
 
 if [ "$num_hpu" -gt 1 ]; then
     export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
-    unset HLS_MODULE_ID
-    if [ "$module_ids" != "None" ]; then
-        export HABANA_VISIBLE_MODULES=$module_ids
-    fi
-else
-    unset HABANA_VISIBLE_MODULES
-    if [ "$module_ids" != "None" ]; then
-        export HLS_MODULE_ID=$module_ids
-    fi
 fi
 
+if [[ $module_ids =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+    IFS="," read -r -a MODULES <<< "$module_ids"
+    # check if the length of module_ids is equal to num_hpu
+    if [ ${#MODULES[@]} -ne "$num_hpu" ]; then
+        echo "The number of module IDs should be equal to the number of HPUs."
+        exit
+    fi
+    export HABANA_VISIBLE_MODULES=$module_ids
+
+    # set up numactl based on module ids
+    set_numactl
+elif [ "$module_ids" == "None" ]; then
+    echo "No module IDs specified, skip numactl"
+    NUMA_CTL=""
+else
+    echo "The specified module IDs should be a comma-separated list of integers instead of $module_ids."
+    exit
+fi
 echo "Starting vllm server for ${model_name} from ${model_path} with input_range=[${input_min}, ${input_max}], output_range=[${output_min}, ${output_max}], max_num_seqs=${max_num_seqs}, max_num_batched_tokens=${max_num_batched_tokens}, max_model_len=${max_model_len} using ${num_hpu} HPUs with module_ids=${module_ids}"
 
 device=$(hl-smi -Q name -f csv | tail -n 1)
@@ -194,17 +203,20 @@ else
     export VLLM_PROMPT_USE_FUSEDSDPA=true
 fi
 
-export TOKENIZERS_PARALLELISM=true
-export VLLM_GRAPH_RESERVED_MEM=${VLLM_GRAPH_RESERVED_MEM:-"0.2"}
-export VLLM_GRAPH_PROMPT_RATIO=${VLLM_GRAPH_PROMPT_RATIO:-"0.8"}
-gpu_memory_utilization=${VLLM_GPU_MEMORY_UTILIZATION:-"0.9"}
 
-set_numactl
+# set up environment variables
+set_env
+
+# set up bucketing based on input/output range and max_num_batched_tokens
 set_bucketing
+
+gpu_memory_utilization=${VLLM_GPU_MEMORY_UTILIZATION:-"0.9"}
+max_seq_len_to_capture=${VLLM_MAX_SEQ_LEN_TO_CAPTURE:-"8192"}
 
 ${NUMA_CTL} \
 python3 -m vllm.entrypoints.openai.api_server \
     --host "${host}" --port "${port}" \
+    --device hpu \
     --model  "${model_path}" \
     --trust-remote-code \
     --tensor-parallel-size "${num_hpu}" \
@@ -214,7 +226,10 @@ python3 -m vllm.entrypoints.openai.api_server \
     --max-num-seqs "$max_num_seqs" \
     --max-num-batched-tokens "$max_num_batched_tokens" \
     --max-model-len "$max_model_len" \
+    --max-seq-len-to-capture "$max_seq_len_to_capture" \
+    --use-v2-block-manager \
     --use-padding-aware-scheduling \
     --num-scheduler-steps "${scheduler_steps}" \
+    --distributed_executor_backend mp \
     --gpu-memory-utilization "${gpu_memory_utilization}" \
     |& tee "${case_name}".log

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,22 +1,70 @@
 #! /bin/bash
 
-# set up numactl config according to HLS_MODULE_ID or HABANA_VISIBLE_MODULES
+# set -x
+
+# set up commen environment variables for vllm
+set_env(){
+    # pytorch bridge
+    export PT_HPU_WEIGHT_SHARING=${PT_HPU_WEIGHT_SHARING:-"0"}
+    export PT_HPU_LAZY_MODE=${PT_HPU_LAZY_MODE:-"1"}
+
+    # memory usage tuning
+    export VLLM_GPU_MEMORY_UTILIZATION=${VLLM_GPU_MEMORY_UTILIZATION:-"0.9"}
+    export VLLM_GRAPH_RESERVED_MEM=${VLLM_GRAPH_RESERVED_MEM:-"0.2"}
+    export VLLM_GRAPH_PROMPT_RATIO=${VLLM_GRAPH_PROMPT_RATIO:-"0.8"}
+    export VLLM_MAX_SEQ_LEN_TO_CAPTURE=${VLLM_MAX_SEQ_LEN_TO_CAPTURE:-"8192"}
+
+    # performance tuning
+    export VLLM_DELAYED_SAMPLING=${VLLM_DELAYED_SAMPLING:-"true"}
+    export VLLM_ZERO_PADDING=${VLLM_ZERO_PADDING:-"true"}
+
+    # MoE sepcific
+    export VLLM_EP_SIZE=${VLLM_EP_SIZE:-"${num_hpu}"}
+    export VLLM_DYNAMIC_MOE_MIN_TOKENS=${VLLM_DYNAMIC_MOE_MIN_TOKENS:-"256"}
+    export VLLM_DYNAMIC_MOE_MIN_EXPERTS_SINGLEHPU=${VLLM_DYNAMIC_MOE_MIN_EXPERTS_SINGLEHPU:-"32"}
+
+    # profiler
+    export VLLM_PROFILER_ENABLED=${VLLM_PROFILER_ENABLED:-"false"}
+    export VLLM_ENGINE_PROFILER_ENABLED=${VLLM_ENGINE_PROFILER_ENABLED:-"false"}
+    export VLLM_ENGINE_PROFILER_WARMUP_STEPS=${VLLM_ENGINE_PROFILER_WARMUP_STEPS:-"0"}
+    export VLLM_ENGINE_PROFILER_STEPS=${VLLM_ENGINE_PROFILER_STEPS:-"1"}
+    export VLLM_ENGINE_PROFILER_REPEAT=${VLLM_ENGINE_PROFILER_REPEAT:-"1"}
+
+    # network
+    default_host_ip=$( hostname -I | awk '{print $1}' )
+    default_ifname=$( ip -br addr show to ${default_host_ip} | awk '{print $1}' )
+    export VLLM_HOST_IP=${VLLM_HOST_IP:-"${default_host_ip}"}
+    export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-"${default_ifname}"}
+    export HCCL_SOCKET_IFNAME=${HCCL_SOCKET_IFNAME:-"${default_ifname}"}
+
+    # misc
+    export VLLM_WORKER_MULTIPROC_METHOD=${VLLM_WORKER_MULTIPROC_METHOD:-"spawn"}
+    export TOKENIZERS_PARALLELISM=${TOKENIZERS_PARALLELISM:-"true"}
+    export RAY_IGNORE_UNHANDLED_ERRORS=${RAY_IGNORE_UNHANDLED_ERRORS:-"1"}
+    export VLLM_RAY_DISABLE_LOG_TO_DRIVER=${VLLM_RAY_DISABLE_LOG_TO_DRIVER:-"1"}
+}
+
+# set up numactl for the specified module IDs
 set_numactl(){
-    HL_TOPO="hl-smi topo -c -N"
-    if [[ $HLS_MODULE_ID ]]; then
-        MODULES=("$HLS_MODULE_ID")
-    elif [[ $HABANA_VISIBLE_MODULES ]]; then
-        IFS="," read -r -a MODULES <<< "$HABANA_VISIBLE_MODULES"
+    if [ "$module_ids" != "None" ]; then
+        # Check if module_ids is a comma-separated list of integers
+        if [[ $module_ids =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+            IFS="," read -r -a MODULES <<< "$module_ids"
+        else
+            echo "The specified module IDs should be a comma-separated list of integers instead of $module_ids."
+            return
+        fi
     else
         echo no modules specified, skip numactl
         return
     fi
 
-    IFS=$'\n' read -r -a NODE_MEM <<< "$($HL_TOPO | grep "^[$(IFS="|" ; echo "${MODULES[*]}")]" | awk '{print $4}' | uniq)"
-    IFS=$'\n' read -r -a NODE_CPUS <<< "$($HL_TOPO | grep "^[$(IFS="|" ; echo "${MODULES[*]}")]" | awk '{print $2}' | uniq | sed 's/,//g')"
+    HL_TOPO="hl-smi topo -c -N"
+    NODE_MEM=($( echo -e "$($HL_TOPO | grep "^[$(IFS="|" ; echo "${MODULES[*]}")]" | awk '{print $4}' | uniq)" ))
+    NODE_CPUS=($( echo -e "$($HL_TOPO | grep "^[$(IFS="|" ; echo "${MODULES[*]}")]" | awk '{print $2}' | uniq | sed 's/,//g')" ))
 
     if [ "${#NODE_MEM[@]}" -gt 1 ] || [ "${#NODE_CPUS[@]}" -gt 1 ];then
-        echo "specified modules are not on the same numa node, skip numactl"
+        echo "The specified modules are not on the same NUMA node, skip numactl"
         return
     fi
     NUM_HPU_PER_NODE=$($HL_TOPO | grep -c "${NODE_CPUS[0]}")
@@ -34,7 +82,7 @@ set_numactl(){
     done
     CORES_STR=$(IFS="," ; echo "${CORES[*]}")
 
-    NUMA_CTL="numactl -C $CORES_STR -l"
+    NUMA_CTL="numactl -C $CORES_STR -m ${NODE_MEM[0]}"
     MODULES_STR=$(IFS=',' ; echo "${MODULES[@]}")
     echo "using '$NUMA_CTL' for module #.$MODULES_STR"
 }
@@ -59,7 +107,7 @@ set_bucketing(){
     export VLLM_PROMPT_BS_BUCKET_STEP=${VLLM_PROMPT_BS_BUCKET_STEP:-$prompt_bs_step}
     export VLLM_PROMPT_BS_BUCKET_MAX=${VLLM_PROMPT_BS_BUCKET_MAX:-$prompt_bs_max}
 
-    prompt_seq_step=128
+    prompt_seq_step=$block_size
     # prompt_seq_min = CEILING.MATH(input_min, prompt_seq_step)
     prompt_seq_min=$(( ($input_min + $prompt_seq_step -1) / $prompt_seq_step * $prompt_seq_step ))
     # prompt_seq_max = CEILING.MATH(input_max, prompt_seq_step) + prompt_seq_step
@@ -70,6 +118,8 @@ set_bucketing(){
 
     # decode_bs_step = ROUNDUP(max_num_seqs / 16, 0)
     decode_bs_step=$(( ($max_num_seqs + 15) / 16 ))
+    # decode_bs_step = min(decode_bs_step, 16)
+    decode_bs_step=$(( $decode_bs_step > 16 ? 16 : $decode_bs_step ))
     decode_bs_min=1
     # decode_bs_max = CEILING.MATH(max_num_seqs, decode_bs_step)
     decode_bs_max=$(( ($max_num_seqs + $decode_bs_step -1) / $decode_bs_step * $decode_bs_step ))
@@ -77,13 +127,15 @@ set_bucketing(){
     export VLLM_DECODE_BS_BUCKET_STEP=${VLLM_DECODE_BS_BUCKET_STEP:-$decode_bs_step}
     export VLLM_DECODE_BS_BUCKET_MAX=${VLLM_DECODE_BS_BUCKET_MAX:-$decode_bs_max}
 
-    decode_block_step=$decode_bs_max
+    decode_block_step=$block_size
     # decode_block_min = ROUNDUP(input_min / block_size, 0)
     decode_block_min=$(( ($input_min + $block_size - 1) / $block_size ))
     # decode_block_min = CEILING.MATH(decode_block_min, decode_block_step)
     decode_block_min=$(( ($decode_block_min + $decode_block_step -1) / $decode_block_step * $decode_block_step ))
     # decode_block_max = (CEILING.MATH(input_max + output_max, block_size) + decode_bs_max
     decode_block_max=$(( (($input_max + $output_max + $block_size -1) / $block_size + 1) * $decode_bs_max))
+    # decode_block_max = (CEILING.MATH(decode_block_max, decode_block_step)
+    decode_block_max=$(( ($decode_block_max + $decode_block_step -1) / $decode_block_step * $decode_block_step ))
     export VLLM_DECODE_BLOCK_BUCKET_MIN=${VLLM_DECODE_BLOCK_BUCKET_MIN:-$decode_block_min}
     export VLLM_DECODE_BLOCK_BUCKET_STEP=${VLLM_DECODE_BLOCK_BUCKET_STEP:-$decode_block_step}
     export VLLM_DECODE_BLOCK_BUCKET_MAX=${VLLM_DECODE_BLOCK_BUCKET_MAX:-$decode_block_max}


### PR DESCRIPTION
update benchmark scripts:
- Fix device selection caused by `unset HABANA_VISIBLE_MODULES`.
- Setup numactl based on selected `module_ids`.
- Refine the decoding bucketing config by setting `decode_block_step=block_size`.
- Move the common ENVs to `set_env()` in `utils.sh`.