### PR TITLE
add missing transpose in MultiHeadAttention

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -351,6 +351,7 @@ class MultiHeadAttention(nn.Module):
                                                      key,
                                                      value,
                                                      scale=self.scale)
+            out = out.transpose(1, 2)
 
         elif self.attn_backend == _Backend.PALLAS_VLLM_V1:
             query, key, value = (x.transpose(1, 2)


### PR DESCRIPTION
Since commit 09332dcdb43c4666fcaca709d5113f00771df1ff, transpose in MultiHeadAttention was removed, guess it was by mistake, re-add it again.