### PR TITLE
[llama/qwen3/deepseek related] Enable Expert Parallel and custom_routing_func for HPU

### DIFF
--- a/.jenkins/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-ep.yaml
+++ b/.jenkins/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-ep.yaml
@@ -1,0 +1,12 @@
+model_name: "/mnt/weka/data/mlperf_models/Mixtral-8x7B-Instruct-v0.1"
+tasks:
+- name: "gsm8k_cot"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.6967
+  - name: "exact_match,flexible-extract"
+    value: 0.6952
+limit: 250
+num_fewshot: 8
+dtype: "bfloat16"
+enable_expert_parallel: True

--- a/.jenkins/lm-eval-harness/configs/models-large-ep.txt
+++ b/.jenkins/lm-eval-harness/configs/models-large-ep.txt
@@ -1,0 +1,1 @@
+Mixtral-8x7B-Instruct-v0.1-ep.yaml

--- a/.jenkins/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.jenkins/lm-eval-harness/test_lm_eval_correctness.py
@@ -45,6 +45,7 @@ def fail_on_exit():
 
 def launch_lm_eval(eval_config):
     trust_remote_code = eval_config.get('trust_remote_code', False)
+    enable_expert_parallel = eval_config.get('enable_expert_parallel', False)
     dtype = eval_config.get('dtype', 'bfloat16')
     max_num_seqs = eval_config.get('max_num_seqs', 128)
     model_args = f"pretrained={eval_config['model_name']}," \
@@ -55,7 +56,8 @@ def launch_lm_eval(eval_config):
                  f"max_model_len=4096," \
                  f"max_num_seqs={max_num_seqs}," \
                  f"enable_prefix_caching=False," \
-                 f"trust_remote_code={trust_remote_code}"
+                 f"trust_remote_code={trust_remote_code}," \
+                 f"enable_expert_parallel={enable_expert_parallel}"
     if eval_config.get("fp8"):
         model_args += ",quantization=inc," \
             "kv_cache_dtype=fp8_inc," \

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -48,6 +48,9 @@ stages:
       - name: v0_gsm8k_large_g3_tp2_part2
         flavor: g3.s
         command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-2.txt -t 2
+      - name: v0_gsm8k_large_g3_tp2_ep
+        flavor: g3.s
+        command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large-ep.txt -t 2
       - name: v0_gsm8k_large_g2_tp4
         flavor: g2.m
         command: export PT_HPU_LAZY_MODE=1 && cd .jenkins/lm-eval-harness && bash run-tests.sh -c configs/models-large.txt -t 4

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@50a112a
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@7df7dd0

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -268,23 +268,36 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         e_score_correction_bias: Optional[torch.Tensor] = None,
         apply_router_weight_on_input: bool = False,
         activation: str = "silu",
+        **kwargs,
     ) -> torch.Tensor:
-        assert not use_grouped_topk
-        assert num_expert_group is None
-        assert topk_group is None
-        assert custom_routing_function is None
-        assert layer is not None
-        assert apply_router_weight_on_input is False
-        if scoring_func != "softmax":
-            raise NotImplementedError(
-                "Only softmax scoring function is supported for HPU.")
-        if e_score_correction_bias is not None:
-            raise NotImplementedError(
-                "Expert score correction bias is not supported for HPU.")
-        # return layer.hpu_fused_moe(x, layer.w13_weight, layer.w2_weight,
-        #                            router_logits, top_k)
-        if layer is not None:
-            return layer.hpu_fused_moe(x, router_logits, top_k)
+        if use_grouped_topk or custom_routing_function is not None:
+            topk_weights, topk_ids = FusedMoE.select_experts(
+                hidden_states=x,
+                router_logits=router_logits,
+                use_grouped_topk=use_grouped_topk,
+                top_k=top_k,
+                renormalize=renormalize,
+                topk_group=topk_group,
+                num_expert_group=num_expert_group,
+                custom_routing_function=custom_routing_function,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias)
+        else:
+            import torch.nn.functional as F
+            topk_weights = F.softmax(router_logits, dim=1, dtype=torch.float32)
+            topk_weights, topk_ids = torch.topk(topk_weights, top_k, dim=-1)
+            topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+            topk_weights = topk_weights.to(x.dtype)
+
+        topk_ids = topk_ids.view(*x.shape[:-1], -1)
+        topk_weights = topk_weights.view(*x.shape[:-1], -1)
+        return layer.moe_op(
+            x,
+            topk_ids.to(torch.int64),
+            topk_weights.to(x.dtype),
+            permuted_weights=True,
+            activation="silu",
+        )
 
     def forward_tpu(
         self,
@@ -490,8 +503,30 @@ class FusedMoE(torch.nn.Module):
             raise ValueError("Only softmax scoring function is supported for "
                              "non-grouped topk.")
         if is_hpu:
-            from vllm_hpu_extension.ops import DynamicFusedMOE
-            self.hpu_fused_moe = DynamicFusedMOE(self.global_num_experts)
+            # local_num_experts is global_num_experts // ep_size
+            num_experts = self.local_num_experts
+            ep_shift = self.ep_rank * num_experts
+            from vllm_hpu_extension.ops import (VllmMixtureOfExpertsOp,
+                                                VllmMixtureOfExpertsOpFP8)
+
+            from vllm.model_executor.layers.quantization.fp8 import (
+                Fp8MoEMethod)
+
+            experts_min, experts_max = ep_shift, num_experts + ep_shift - 1
+            if quant_config is not None and isinstance(self.quant_method,
+                                                       Fp8MoEMethod):
+                moe_op = VllmMixtureOfExpertsOpFP8(
+                    num_experts,
+                    experts_min,
+                    experts_max,
+                )
+            else:
+                moe_op = VllmMixtureOfExpertsOp(
+                    num_experts,
+                    experts_min,
+                    experts_max,
+                )
+            self.moe_op = moe_op
 
         # Note: get_quant_method will look at the layer's local_num_experts
         # for heuristic purposes, so it must be initialized first.
@@ -572,7 +607,7 @@ class FusedMoE(torch.nn.Module):
     def _load_per_channel_weight_scale(self, expert_data: torch.Tensor,
                                        shard_dim: int, shard_id: str,
                                        loaded_weight: torch.Tensor,
-                                       tp_rank: int):
+                                       tp_rank: int, expert_id: int):
         # for per channel weight quantization
         if shard_id == "w2":
             expert_data.copy_(loaded_weight)
@@ -581,7 +616,8 @@ class FusedMoE(torch.nn.Module):
                            shard_dim=shard_dim,
                            loaded_weight=loaded_weight,
                            expert_data=expert_data,
-                           tp_rank=tp_rank)
+                           tp_rank=tp_rank,
+                           expert_id=expert_id)
 
     def _load_w13(self,
                   expert_data: torch.Tensor,
@@ -607,9 +643,8 @@ class FusedMoE(torch.nn.Module):
             expert_data = expert_data.narrow(shard_dim, shard_size, shard_size)
         expert_data.copy_(loaded_weight)
 
-        if is_hpu:
-            self.hpu_fused_moe.MoeOp.w13_list[expert_id].set_weight(
-                orig_exp_data)
+        if is_hpu and isinstance(self.quant_method, UnquantizedFusedMoEMethod):
+            self.moe_op.w13_list[expert_id].set_weight(orig_exp_data)
 
     def _load_w2(self,
                  expert_data: torch.Tensor,
@@ -629,8 +664,8 @@ class FusedMoE(torch.nn.Module):
                                                  shard_size)
         # w2, down_proj: Load into only logical weight of w2.
         expert_data.copy_(loaded_weight)
-        if is_hpu:
-            self.hpu_fused_moe.MoeOp.w2_list[expert_id].set_weight(expert_data)
+        if is_hpu and isinstance(self.quant_method, UnquantizedFusedMoEMethod):
+            self.moe_op.w2_list[expert_id].set_weight(expert_data)
 
     def _load_single_value(self, param: torch.nn.Parameter,
                            loaded_weight: torch.Tensor, expert_id: int):
@@ -753,7 +788,8 @@ class FusedMoE(torch.nn.Module):
                     shard_dim=shard_dim,
                     loaded_weight=loaded_weight,
                     expert_data=expert_data,
-                    tp_rank=self.tp_rank)
+                    tp_rank=self.tp_rank,
+                    expert_id=expert_id)
             elif quant_method in [
                     FusedMoeWeightScaleSupported.GROUP.value,
                     FusedMoeWeightScaleSupported.BLOCK.value,


### PR DESCRIPTION
PR is reply on the https://github.com/HabanaAI/vllm-hpu-extension/pull/170

This is PR is only to enable shared MOE codes for deepseek/llama4 if #1161 can't be approved

1. add Expert parallel support for HPU which will be used for Qwen3, llama4, deepseek
2. HPU moe enabled custom_routing_function which will be used by llama4
3. HPU moe enabled use_grouped_topk which will be used by deepseek-v3/R1

Test:
1. EP test on Mixtral 8*7B with TP2

