### PR TITLE
fix dummy sequence length setting in llama3.2

### DIFF
--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -448,7 +448,10 @@ class HPUEncoderDecoderModelRunner(
             max_mm_tokens,
             self.mm_registry,
             is_encoder_data=True)
-        seq_len = max(seq_len, 1)
+        max_mm_num = max(
+            self.mm_registry.get_mm_limits_per_prompt(
+                self.model_config).values())
+        seq_len = max(seq_len, max_mm_num)
         if is_prompt:
             output_len = 0
             block_tables = None


### PR DESCRIPTION
In llama3.2, the minimum seq length of dummy sequence is set to 1, which is not expected in cases that models allow multiple images as encoder input. Without this PR, the terminal will keep reporting warnings like below,
```
WARNING 05-08 05:24:25 [profiling.py:242] The sequence length used for profiling 
(max_num_batched_tokens / max_num_seqs = 1) is too short to hold the multi-modal embeddings 
in the worst case (4 tokens in total, out of which {'image': 25616} are reserved for multi-modal embeddings). 
This may cause certain multi-modal inputs to fail during inference, even when the input text is short. 
To avoid this, you should increase `max_model_len`, reduce `max_num_seqs`, and/or reduce `mm_counts`.
```
This PR will eliminate the above warnings.

To reproduce, you need to add `--limit-mm-per-prompt {"images": 4}` in engine args.
