### PR TITLE
Fix INC Finalization Check

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3040,10 +3040,12 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         can_finalize_inc = False
         from contextlib import suppress
         with suppress(AttributeError):
-            can_finalize_inc = (self.model_config.quantization == 'inc') and \
-                (self.model.model is not None) and \
-                self.inc_initialized_successfully and \
-                not getattr(self, "_is_inc_finalized", False)
+            can_finalize_inc = (
+                self._is_quant_with_inc()
+                and (self.model.model is not None)
+                and self.inc_initialized_successfully
+                and not getattr(self, "_is_inc_finalized", False)
+            )
         if can_finalize_inc:
             from neural_compressor.torch.quantization import (
                 finalize_calibration)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3040,12 +3040,10 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         can_finalize_inc = False
         from contextlib import suppress
         with suppress(AttributeError):
-            can_finalize_inc = (
-                self._is_quant_with_inc()
-                and (self.model.model is not None)
-                and self.inc_initialized_successfully
-                and not getattr(self, "_is_inc_finalized", False)
-            )
+            can_finalize_inc = (self._is_quant_with_inc()
+                                and (self.model.model is not None)
+                                and self.inc_initialized_successfully and
+                                not getattr(self, "_is_inc_finalized", False))
         if can_finalize_inc:
             from neural_compressor.torch.quantization import (
                 finalize_calibration)


### PR DESCRIPTION
When re-quantizing Deepseek R1, we do not pass `quantization` as `inc`, as we need to load FP8 weights.
Instead, we update INC finalization condition by checking the `QUANT_CONFIG`.

cc @thuang6 @zhenwei-intel 