### PR TITLE
[SW-219737][habana_main] Support MTP to deepseek

### DIFF
--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -165,6 +165,13 @@ stages:
   #       command: >-
   #         PT_HPU_LAZY_MODE=1 VLLM_USE_V1=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
   #         pytest -v tests/spec_decode/e2e/test_eagle_correctness.py::test_eagle_e2e_greedy_correctness
+  - name: test_deepseek_mtp
+    steps:
+      -name: test_deepseek_mtp_correctness
+        flavor: g3
+        command: >-
+          PT_HPU_LAZY_MODE=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
+          pytest -v tests/spec_decode/e2e/test_mtp_correctness.py::test_mtp_e2e_greedy_correctness
   - name: tests_lora
     steps:
       - name: test_llama_lora

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -164,9 +164,9 @@ stages:
         command: >-
           PT_HPU_LAZY_MODE=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 
           pytest -v tests/spec_decode/e2e/test_eagle_correctness.py::test_eagle_e2e_greedy_correctness
-   - name: test_deepseek_mtp
+  - name: test_deepseek_mtp
     steps:
-      -name: test_deepseek_mtp_correctness
+      - name: test_deepseek_mtp_correctness
         flavor: g3
         command: >-
           PT_HPU_LAZY_MODE=1 VLLM_CONTIGUOUS_PA=false VLLM_SKIP_WARMUP=True 

--- a/tests/spec_decode/e2e/test_mtp_correctness.py
+++ b/tests/spec_decode/e2e/test_mtp_correctness.py
@@ -51,7 +51,10 @@ PRECISION = "bfloat16"
         "model_name": MAIN_MODEL,
 
         # GPU memory utilization
-        "gpu_memory_utilization": 0.85
+        "gpu_memory_utilization": 0.85,
+
+        # scheduler
+        "use_padding_aware_scheduling": False,
     }])
 @pytest.mark.parametrize("per_test_common_llm_kwargs", [{}])
 @pytest.mark.parametrize("baseline_llm_kwargs", [{}])

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2617,6 +2617,8 @@ class SpeculativeConfig:
             ray_workers_use_nsight=target_parallel_config.
             ray_workers_use_nsight,
             placement_group=target_parallel_config.placement_group,
+            enable_expert_parallel=target_parallel_config.
+            enable_expert_parallel,
         )
 
         return draft_parallel_config

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -170,6 +170,9 @@ class RMSNorm(CustomOp):
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         from vllm_hpu_extension.kernels import rms_norm
         HPUFusedRMSNorm = rms_norm()
+        if x.dim() < 3:
+            # fix an known bug before synapse 1.21 release
+            HPUFusedRMSNorm = None
         if HPUFusedRMSNorm is None:
             return self.forward_native(x, residual)
         if residual is not None:

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -77,7 +77,7 @@ class HPUWorker(LocalOrDistributedWorkerBase):
             or (speculative_config.draft_model_config.hf_config.model_type \
                 == model_config.hf_config.model_type) \
             or (speculative_config.draft_model_config.hf_config.model_type
-                not in ["medusa", "mlp_speculator", "eagle"]) \
+                not in ["medusa", "mlp_speculator", "eagle", "deepseek_mtp"]) \
                     else {"return_hidden_states": True}
 
         is_encoder_decoder_model = self._is_encoder_decoder_model()


### PR DESCRIPTION
https://jira.habana-labs.com/browse/SW-219737

1. enable MTP
2. add a MTP UT with small model
3. cherry-pick a commit to fix cpu fallback

Tested with Deepseek_r1 locally:
This accept rate is 0.84% with osl=1024
![image](https://github.com/user-attachments/assets/4e9fe920-9a79-43ee-8077-415d364b38ea)


```
from typing import List
from vllm import LLM, SamplingParams

import argparse
import os
import random
import time
import argparse

# get file location
file_path = os.path.abspath(__file__)

# Parse the command-line arguments.
parser = argparse.ArgumentParser()
parser.add_argument("--model", type=str, default=model_path, help="The model path.")
parser.add_argument("--tokenizer", type=str, default=None, help="The model path.")
parser.add_argument("--tp_size", type=int, default=1, help="The number of threads.")
parser.add_argument("--num_spec_tokens", type=int, default=1, help="The number of threads.")
parser.add_argument("--isl", type=int, default=1024, help="input sequence length.")
parser.add_argument("--osl", type=int, default=1024, help="output sequence length.")
parser.add_argument("--nprompts", type=int, default=4, help="The number of prompts.")
parser.add_argument("--max_num_seqs", type=int, default=None, help="The max number of sequences.")
args = parser.parse_args()

os.environ["VLLM_SKIP_WARMUP"] = "true"
os.environ["HABANA_VISIBLE_DEVICES"] = "ALL"
os.environ["PT_HPU_ENABLE_LAZY_COLLECTIVES"] = "true"
os.environ["PT_HPU_WEIGHT_SHARING"] = "0"
os.environ["VLLM_CONTIGUOUS_PA"]="false"

def time_generation(llm: LLM, prompts: List[str],
                    sampling_params: SamplingParams, num_spec_tokens=1):
    # Generate texts from the prompts. The output is a list of RequestOutput
    # objects that contain the prompt, generated text, and other information.
    # Warmup first
    llm.generate(prompts, sampling_params)
    start = time.time()
    outputs = llm.generate(prompts, sampling_params)
    end = time.time()
    latency_per_token = (end - start) / sum(
        [len(o.outputs[0].token_ids) for o in outputs])
    # Print the outputs.
    ret = []
    for output in outputs:
        generated_text = output.outputs[0].text
        ret.append(generated_text)
    
    acceptance_counts = [0] * (num_spec_tokens + 1)
    for output in outputs:
        for step, count in enumerate(
                output.metrics.spec_token_acceptance_counts):
            acceptance_counts[step] += count
    
    return ret, latency_per_token, acceptance_counts

if __name__ == "__main__":

    # Sample prompts.
    prompts = [
        "Hello, my name is",
        "0.999 compares to 0.9 is ",
        "The capital of France is",
        "The future of AI is",
    ]

    num_spec_tokens = args.num_spec_tokens
    # Create a sampling params object.
    sampling_params = SamplingParams(temperature=0, max_tokens=args.osl, ignore_eos=True)
    model = args.model
    param = {}
    
    llm = LLM(
        model=model, 
        tokenizer=args.tokenizer,
        tensor_parallel_size=args.tp_size,
        distributed_executor_backend='mp',
        trust_remote_code=True,
        max_model_len=16384,
        dtype="bfloat16",
        gpu_memory_utilization=0.8,
        enable_expert_parallel=True,
        speculative_config={
            "num_speculative_tokens": num_spec_tokens,
        },
        **param
    )

    # Generate texts from the prompts. The output is a list of RequestOutput objects
    # that contain the prompt, generated text, and other information.
    ret_spec, latency_per_token_spec, acc_rate = time_generation(llm, prompts,
                                                       sampling_params, num_spec_tokens)
    
    # Print the outputs.
    print("=============== Summary ===============")
    print("Latency per token: ", latency_per_token_spec)
    print("Acceptance rate: ", acc_rate)
    print("Generated texts:")
    for i, output in enumerate(ret_spec):
        print(f"Prompt {i}: {prompts[i]}")
        print(f"Output {i}: {output}")
        print("=======================================")
    if hasattr(llm.llm_engine.model_executor, "shutdown"):
        llm.llm_engine.model_executor.shutdown()
    del llm
```
