### PR TITLE
fix llama3.2 HPUGraph mode acc problem after rebase

### DIFF
--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -3,7 +3,6 @@ import dataclasses
 import gc
 import itertools
 import math
-from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
 
 import habana_frameworks.torch as htorch
@@ -208,8 +207,8 @@ class HPUEncoderDecoderModelRunner(
         return htorch.hpu.wrap_in_hpu_graph(
             HpuModelAdapterEncoderDecoder(*args, **kwargs),
             disable_tensor_cache=True,
-        ) if htorch.utils.internal.is_lazy() else HpuModelAdapterEncoderDecoder(
-            *args, **kwargs)
+        ) if htorch.utils.internal.is_lazy(
+        ) else HpuModelAdapterEncoderDecoder(*args, **kwargs)
 
     def prepare_model_input(
         self,


### PR DESCRIPTION
This PR target to fix #1219 

After commit https://github.com/HabanaAI/vllm-fork/commit/09332dcdb43c4666fcaca709d5113f00771df1ff, `attn_metadata` was removed from forward args of mllama, caused graph capture problem under HPUGraph mode.

After this PR, the output under HPUGraph mode will become correct, as a side effect, since we involve hpu graphs for vision part, guess it will also bring some throughput improvement. 