### PR TITLE
fix text only input for llama3.2

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -2015,7 +2015,7 @@ class LLMEngine:
         if not prompt_ids:
             if prompt_type == "encoder" and model_config.is_multimodal_model:
                 pass  # Mllama may have empty encoder inputs for text-only data
-            if prompt_inputs["type"] == "embeds":
+            elif prompt_inputs["type"] == "embeds":
                 pass
             else:
                 raise ValueError(f"The {prompt_type} prompt cannot be empty")


### PR DESCRIPTION
After PR #1166 , when give text-only input to llama3.2, the error will occur,
`ValueError: The encoder prompt cannot be empty`

This PR fix this minor error.