### PR TITLE
[DeepSeek][G2] Use naive scaling and full pile

### DIFF
--- a/scripts/inc_woq_g2_bkc.md
+++ b/scripts/inc_woq_g2_bkc.md
@@ -76,7 +76,7 @@ Resulting full path: "/path/to/vllm-fork/scripts/nc_workspace_measure_kvache/inc
 
 ```bash
 cd vllm-fork
-huggingface-cli download Yi30/inc-woq-default-pile-one-cache-412-g2  --local-dir ./scripts/nc_workspace_measure_kvache
+huggingface-cli download Yi30/inc-woq-2282samples-514-g2  --local-dir ./scripts/nc_workspace_measure_kvache
 ```
 
 - Running the Benchmark


### PR DESCRIPTION
Depends on https://github.com/intel/neural-compressor/pull/2211.
Naive scaling: `backoff=1`, no `scaling_round_method`
Full pile: use all samples(> 1024) in pile for calibration, https://huggingface.co/Yi30/inc-woq-2282samples-514-g2