### PR TITLE
Fix the error when VLLM_DECODE_BLOCK_BUCKET_STEP is not defined

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2158,7 +2158,11 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                  True)
             raise AssertionError("Finished profiling")
         if not self.is_pooler:
-            max_blocks = kv_caches[0][0].size(0) // int(os.getenv('VLLM_DECODE_BLOCK_BUCKET_STEP')) * int(os.getenv('VLLM_DECODE_BLOCK_BUCKET_STEP'))
+            max_blocks = (
+                kv_caches[0][0].size(0)
+                // int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", "128"))
+                * int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", "128"))
+            )
         self.bucketing_ctx.generate_prompt_buckets()
         if not self.is_pooler:
             self.bucketing_ctx.generate_decode_buckets(max_blocks)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2160,8 +2160,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if not self.is_pooler:
             max_blocks = (
                 kv_caches[0][0].size(0)
-                // int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", "128"))
-                * int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", "128"))
+                // int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", self.cache_config.block_size))
+                * int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", self.cache_config.block_size))
             )
         self.bucketing_ctx.generate_prompt_buckets()
         if not self.is_pooler:


### PR DESCRIPTION
Fix below exception:
[rank0]:     max_blocks = kv_caches[0][0].size(0) // int(os.getenv('VLLM_DECODE_BLOCK_BUCKET_STEP')) * int(os.getenv('VLLM_DECODE_BLOCK_BUCKET_STEP'))
[rank0]: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
