### PR TITLE
Add 256 as possible option within block-size arg

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1325,7 +1325,7 @@ class ModelConfig:
         return getattr(self.hf_config, "matryoshka_dimensions", None)
 
 
-BlockSize = Literal[1, 8, 16, 32, 64, 128]
+BlockSize = Literal[1, 8, 16, 32, 64, 128, 256]
 CacheDType = Literal["auto", "fp8", "fp8_e4m3", "fp8_e5m2", "fp8_inc"]
 PrefixCachingHashAlgo = Literal["builtin", "sha256"]
 


### PR DESCRIPTION
Bringing back option of 256 as possible block-size arg value, that has been lost in some of the last rebases.

It has been first added via https://github.com/HabanaAI/vllm-fork/pull/971

The options of arguments are now defined by unpacking predefined type hints
![image](https://github.com/user-attachments/assets/f1c0429b-6449-44a5-b0e8-326f465590ab)
https://github.com/HabanaAI/vllm-fork/blob/habana_main/vllm/engine/arg_utils.py#L611

