### PR TITLE
WA for CI - pkg resources

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -551,7 +551,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
         ray.get(parallel_worker_tasks)
 
     def _check_ray_cgraph_installation(self):
-        import pkg_resources
+        import pkg_resources # type: ignore
         from packaging import version
 
         required_version = version.parse("2.43.0")


### PR DESCRIPTION
WA for:
Error: vllm/executor/ray_distributed_executor.py:554: error: Library stubs not installed for "pkg_resources"  [import-untyped]