### PR TITLE
Replace in-place add with out-of-place add in layernorm forward_hpu.

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -177,7 +177,7 @@ class RMSNorm(CustomOp):
             return self.forward_native(x, residual)
         if residual is not None:
             orig_shape = x.shape
-            residual += x.view(residual.shape)
+            residual = residual + x.view(residual.shape)
             # Note: HPUFusedRMSNorm requires 3D tensors as inputs
             x = HPUFusedRMSNorm.apply(residual, self.weight,
                                       self.variance_epsilon)


### PR DESCRIPTION
This in-place add forces extra mark_step and for Pipeline Parallelism requires enabling tensor cache.
Out-of-place add requires extra allocation and deallocation (gc) but does not force mark_step and doesn't require enabling tensor cache for Pipeline Parallelism.