### PR TITLE
[SW-229036] out of box fp8 Dynamic scaling support

### DIFF
--- a/.jenkins/lm-eval-harness/configs/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic.yaml
+++ b/.jenkins/lm-eval-harness/configs/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic.yaml
@@ -1,0 +1,14 @@
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-hf-baseline.sh -m meta-llama/Meta-Llama-3-8B-Instruct -b 32 -l 250 -f 5 -t 1
+model_name: "/mnt/weka/llm/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.88
+  - name: "exact_match,flexible-extract"
+    value: 0.88
+limit: 256
+num_fewshot: 5
+dtype: "bfloat16"
+trust_remote_code: True
+enable_expert_parallel: True

--- a/.jenkins/lm-eval-harness/configs/Qwen3-30B-A3B-FP8.yaml
+++ b/.jenkins/lm-eval-harness/configs/Qwen3-30B-A3B-FP8.yaml
@@ -1,0 +1,13 @@
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-hf-baseline.sh -m meta-llama/Meta-Llama-3-8B-Instruct -b 32 -l 250 -f 5 -t 1
+model_name: "/mnt/weka/llm/Qwen3-30B-A3B-FP8"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.9
+  - name: "exact_match,flexible-extract"
+    value: 0.9
+limit: 256
+num_fewshot: 5
+dtype: "bfloat16"
+trust_remote_code: True

--- a/.jenkins/lm-eval-harness/configs/Qwen3-30B-A3B-FP8.yaml
+++ b/.jenkins/lm-eval-harness/configs/Qwen3-30B-A3B-FP8.yaml
@@ -6,7 +6,7 @@ tasks:
   - name: "exact_match,strict-match"
     value: 0.9
   - name: "exact_match,flexible-extract"
-    value: 0.9
+    value: 0.8
 limit: 256
 num_fewshot: 5
 dtype: "bfloat16"

--- a/.jenkins/lm-eval-harness/configs/models-fp8-blockfp8.txt
+++ b/.jenkins/lm-eval-harness/configs/models-fp8-blockfp8.txt
@@ -1,0 +1,1 @@
+Qwen3-30B-A3B-FP8.yaml

--- a/.jenkins/lm-eval-harness/configs/models-fp8-compressedtensor.txt
+++ b/.jenkins/lm-eval-harness/configs/models-fp8-compressedtensor.txt
@@ -1,0 +1,1 @@
+Llama-4-Scout-17B-16E-Instruct-FP8-dynamic.yaml

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -115,6 +115,20 @@ stages:
           cd .jenkins/lm-eval-harness && 
           PT_HPU_LAZY_MODE=1 
           bash run-tests.sh -c configs/models-fp8.txt -t 2
+  - name: test_gsm8k_fp8_bypass_inc
+    steps:
+      - name: gsm8k_fp8_llama4_scout_g3_tp2_compressed_tensor
+        flavor: g3
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-fp8-compressedtensor.txt -t 2
+      - name: gsm8k_fp8_qwen3_30B_g3_tp1_block_scale
+        flavor: g3
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-fp8-blockfp8.txt -t 1
   - name: test_gsm8k_mss
     steps:
       - name: gsm8k_small_g3_tp1_mss

--- a/.jenkins/test_config.yaml
+++ b/.jenkins/test_config.yaml
@@ -118,16 +118,22 @@ stages:
   - name: test_gsm8k_fp8_bypass_inc
     steps:
       - name: gsm8k_fp8_llama4_scout_g3_tp2_compressed_tensor
-        flavor: g3
+        flavor: g3.s
         command: >-
           cd .jenkins/lm-eval-harness && 
           PT_HPU_LAZY_MODE=1 
           bash run-tests.sh -c configs/models-fp8-compressedtensor.txt -t 2
-      - name: gsm8k_fp8_qwen3_30B_g3_tp1_block_scale
+      - name: gsm8k_fp8_qwen3_30B_g3_tp1_block_scale_dynamic
         flavor: g3
         command: >-
           cd .jenkins/lm-eval-harness && 
           PT_HPU_LAZY_MODE=1 
+          bash run-tests.sh -c configs/models-fp8-blockfp8.txt -t 1
+      - name: gsm8k_fp8_qwen3_30B_g3_tp1_block_scale_dequant
+        flavor: g3
+        command: >-
+          cd .jenkins/lm-eval-harness && 
+          PT_HPU_LAZY_MODE=1 VLLM_HPU_FORCE_CHANNEL_FP8=0 
           bash run-tests.sh -c configs/models-fp8-blockfp8.txt -t 1
   - name: test_gsm8k_mss
     steps:

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@987d9d2
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@3c7e722d22503a087ab9745f993b41d4636ffcc1

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@78eb3f3
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@5329bdb

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@3c7e722d22503a087ab9745f993b41d4636ffcc1
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@78eb3f3

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
     VLLM_CUDART_SO_PATH: Optional[str] = None
     VLLM_USE_HPU_CONTIGUOUS_CACHE_FETCH: bool = True
     VLLM_HPU_USE_DELAYED_SAMPLING: bool = False
+    VLLM_HPU_FORCE_CHANNEL_FP8: bool = True
     VLLM_DP_RANK: int = 0
     VLLM_DP_RANK_LOCAL: int = -1
     VLLM_DP_SIZE: int = 1
@@ -655,6 +656,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # between each step.
     "VLLM_HPU_USE_DELAYED_SAMPLING":
     lambda: os.environ.get("VLLM_DELAYED_SAMPLING", "false").lower() in
+    ("1", "true"),
+
+    # Convert block fp8 to channel fp8 for HPU
+    "VLLM_HPU_FORCE_CHANNEL_FP8":
+    lambda: os.environ.get("VLLM_HPU_FORCE_CHANNEL_FP8", "true").lower() in
     ("1", "true"),
 
     # Rank of the process in the data parallel setting

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -551,8 +551,8 @@ class FusedMoE(torch.nn.Module):
                     experts_max,
                 )
             elif quant_config is not None:
-                if hasattr(quant_config,
-                           "block_quant") and quant_config.block_quant:
+                if hasattr(quant_config, "weight_block_size"
+                           ) and not envs.VLLM_HPU_FORCE_CHANNEL_FP8:
                     moe_op = VllmMixtureOfExpertsOpFP8(
                         num_experts,
                         experts_min,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -538,26 +538,32 @@ class FusedMoE(torch.nn.Module):
         if is_hpu:
             num_experts = self.local_num_experts
             ep_shift = self.ep_rank * num_experts
-            from vllm_hpu_extension.ops import (VllmMixtureOfExpertsOp,
-                                                VllmMixtureOfExpertsOpFP8)
-
-            from vllm.model_executor.layers.quantization.fp8 import (
-                Fp8MoEMethod)
+            from vllm_hpu_extension.ops import (
+                VllmMixtureOfExpertsOp, VllmMixtureOfExpertsOpFP8,
+                VllmMixtureOfExpertsOpFP8PerChannel)
 
             experts_min, experts_max = ep_shift, num_experts + ep_shift - 1
-            if quant_config is not None and isinstance(self.quant_method,
-                                                       Fp8MoEMethod):
-                moe_op = VllmMixtureOfExpertsOpFP8(
-                    num_experts,
-                    experts_min,
-                    experts_max,
-                )
-            else:
+            if quant_config is None or isinstance(self.quant_method,
+                                                  UnquantizedFusedMoEMethod):
                 moe_op = VllmMixtureOfExpertsOp(
                     num_experts,
                     experts_min,
                     experts_max,
                 )
+            elif quant_config is not None:
+                if hasattr(quant_config,
+                           "block_quant") and quant_config.block_quant:
+                    moe_op = VllmMixtureOfExpertsOpFP8(
+                        num_experts,
+                        experts_min,
+                        experts_max,
+                    )
+                else:
+                    moe_op = VllmMixtureOfExpertsOpFP8PerChannel(
+                        num_experts,
+                        experts_min,
+                        experts_max,
+                    )
             self.moe_op = moe_op
         self.quant_method.create_weights(layer=self, **moe_quant_params)
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -207,6 +207,10 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             layer.w2_input_scale = torch.nn.Parameter(
                 layer.w2_input_scale.max(), requires_grad=False)
 
+        if current_platform.is_hpu():
+            import vllm_hpu_extension.ops as hpu_ops
+            layer = hpu_ops.fp8_channel_moe_prepare_weights(layer)
+            return
         if current_platform.is_fp8_fnuz():
             # Normalize the weights and scales
             w13_weight, w13_weight_scale, w13_input_scale = \
@@ -293,6 +297,23 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         apply_router_weight_on_input: bool = False,
         activation: str = "silu",
     ) -> torch.Tensor:
+        if current_platform.is_hpu():
+            return self.forward_hpu(
+                x=x,
+                layer=layer,
+                router_logits=router_logits,
+                top_k=top_k,
+                renormalize=renormalize,
+                use_grouped_topk=use_grouped_topk,
+                topk_group=topk_group,
+                num_expert_group=num_expert_group,
+                global_num_experts=global_num_experts,
+                expert_map=expert_map,
+                custom_routing_function=custom_routing_function,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias,
+                activation=activation,
+                apply_router_weight_on_input=apply_router_weight_on_input)
 
         topk_weights, topk_ids = FusedMoE.select_experts(
             hidden_states=x,
@@ -324,6 +345,50 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             w2_scale=layer.w2_weight_scale,
             a1_scale=layer.w13_input_scale,
             a2_scale=layer.w2_input_scale)
+
+    def forward_hpu(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        use_grouped_topk: bool,
+        top_k: int,
+        router_logits: torch.Tensor,
+        renormalize: bool,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        global_num_experts: int = -1,
+        expert_map: Optional[torch.Tensor] = None,
+        custom_routing_function: Optional[Callable] = None,
+        scoring_func: str = "softmax",
+        e_score_correction_bias: Optional[torch.Tensor] = None,
+        apply_router_weight_on_input: bool = False,
+        activation: str = "silu",
+        **kwargs,
+    ):
+        input_shape = x.shape
+        x = x.view(-1, x.shape[-1])
+        topk_weights, topk_ids = FusedMoE.select_experts(
+            hidden_states=x,
+            router_logits=router_logits,
+            use_grouped_topk=use_grouped_topk,
+            top_k=top_k,
+            renormalize=renormalize,
+            topk_group=topk_group,
+            num_expert_group=num_expert_group,
+            custom_routing_function=custom_routing_function,
+            scoring_func=scoring_func,
+            e_score_correction_bias=e_score_correction_bias)
+
+        topk_ids = topk_ids.view(*x.shape[:-1], -1)
+        topk_weights = topk_weights.view(*x.shape[:-1], -1)
+        output = layer.moe_op(
+            x,
+            topk_ids.to(torch.int64),
+            topk_weights.to(x.dtype),
+            permuted_weights=True,
+            activation=activation,
+        )
+        return output.view(*input_shape)
 
 
 class CompressedTensorsW8A8Fp8MoECutlassMethod(CompressedTensorsMoEMethod):

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -332,7 +332,8 @@ class Fp8LinearMethod(LinearMethodBase):
             assert self.quant_config.activation_scheme == "dynamic"
             size_k_first = False
             if current_platform.is_hpu():
-                layer = hpu_ops.fp8_block_linear_postprocess_weights(layer)
+                layer = hpu_ops.fp8_block_linear_postprocess_weights(
+                    layer, envs.VLLM_HPU_FORCE_CHANNEL_FP8)
                 return
             if current_platform.is_fp8_fnuz():
                 weight, weight_scale_inv, _ = \
@@ -423,16 +424,13 @@ class Fp8LinearMethod(LinearMethodBase):
         if self.block_quant:
             assert self.quant_config.weight_block_size is not None
             if current_platform.is_hpu():
-                return hpu_ops.apply_block_fp8_linear_hpu_dequant(
+                return hpu_ops.apply_block_fp8_linear_hpu(
                     input=x,
-                    weight=layer.weight,
+                    layer=layer,
                     block_size=self.quant_config.weight_block_size,
-                    weight_scale=layer.weight_scale_inv,
-                    input_scale=layer.input_scale,
                     bias=bias,
-                    original_M=layer.orig_M,
-                    original_N=layer.orig_N,
                     do_unpad=True,
+                    force_channel_fp8=envs.VLLM_HPU_FORCE_CHANNEL_FP8,
                 )
             return torch.ops.vllm.apply_w8a8_block_fp8_linear(
                 input=x,
@@ -444,6 +442,14 @@ class Fp8LinearMethod(LinearMethodBase):
                 cutlass_block_fp8_supported=self.cutlass_block_fp8_supported,
             )
 
+        if current_platform.is_hpu():
+            weight_scale = layer.weight_scale.transpose(0, 1)
+            return hpu_ops.apply_fp8_linear_hpu(input=x,
+                                                weight=layer.weight,
+                                                weight_scale=weight_scale,
+                                                input_scale=layer.input_scale,
+                                                bias=bias,
+                                                trans_B=False)
         return self.fp8_linear.apply(input=x,
                                      weight=layer.weight,
                                      weight_scale=layer.weight_scale,
@@ -629,7 +635,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             assert self.quant_config.activation_scheme == "dynamic"
             if current_platform.is_hpu():
                 import vllm_hpu_extension.ops as hpu_ops
-                layer = hpu_ops.fp8_block_moe_prepare_weights(layer)
+                layer = hpu_ops.fp8_block_moe_prepare_weights(
+                    layer, envs.VLLM_HPU_FORCE_CHANNEL_FP8)
                 return
             if current_platform.is_fp8_fnuz():
                 w13_weight, w13_weight_scale_inv, w13_input_scale = \
@@ -836,6 +843,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         apply_router_weight_on_input: bool = False,
         activation: str = "silu",
     ) -> torch.Tensor:
+        if current_platform.is_hpu():
+            return self.forward_hpu(
+                layer,
+                x,
+                use_grouped_topk,
+                top_k,
+                router_logits,
+                renormalize,
+                topk_group=topk_group,
+                num_expert_group=num_expert_group,
+                global_num_experts=global_num_experts,
+                expert_map=expert_map,
+                custom_routing_function=custom_routing_function,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                activation=activation)
         from vllm.model_executor.layers.fused_moe import fused_experts
 
         topk_weights, topk_ids = FusedMoE.select_experts(
@@ -851,11 +875,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             e_score_correction_bias=e_score_correction_bias,
         )
 
-        if current_platform.is_hpu():
-            topk_ids = topk_ids.view(*x.shape[:-1], -1)
-            topk_weights = topk_weights.view(*x.shape[:-1], -1)
-            return layer.moe_op(x, topk_ids.to(torch.int64),
-                                topk_weights.to(x.dtype))
         if self.use_marlin:
             return torch.ops.vllm.fused_marlin_moe(
                 x,
@@ -890,6 +909,56 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             block_shape=self.quant_config.weight_block_size,
             allow_deep_gemm=self.allow_deep_gemm,
         )
+
+    def forward_hpu(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        use_grouped_topk: bool,
+        top_k: int,
+        router_logits: torch.Tensor,
+        renormalize: bool,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        global_num_experts: int = -1,
+        expert_map: Optional[torch.Tensor] = None,
+        custom_routing_function: Optional[Callable] = None,
+        scoring_func: str = "softmax",
+        e_score_correction_bias: Optional[torch.Tensor] = None,
+        apply_router_weight_on_input: bool = False,
+        activation: str = "silu",
+        **kwargs,
+    ):
+        input_shape = x.shape
+        x = x.view(-1, x.shape[-1])
+        if use_grouped_topk or custom_routing_function is not None:
+            topk_weights, topk_ids = FusedMoE.select_experts(
+                hidden_states=x,
+                router_logits=router_logits,
+                use_grouped_topk=use_grouped_topk,
+                top_k=top_k,
+                renormalize=renormalize,
+                topk_group=topk_group,
+                num_expert_group=num_expert_group,
+                custom_routing_function=custom_routing_function,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias)
+        else:
+            import torch.nn.functional as F
+            topk_weights = F.softmax(router_logits, dim=1, dtype=torch.float32)
+            topk_weights, topk_ids = torch.topk(topk_weights, top_k, dim=-1)
+            topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+            topk_weights = topk_weights.to(x.dtype)
+        topk_ids = topk_ids.view(*x.shape[:-1], -1)
+        topk_weights = topk_weights.view(*x.shape[:-1], -1)
+        output = layer.moe_op(
+            x,
+            topk_ids.to(torch.int64),
+            topk_weights.to(x.dtype),
+            permuted_weights=True,
+            activation=activation,
+        )
+        return output.view(*input_shape)
 
 
 class Fp8KVCacheMethod(BaseKVCacheMethod):

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -628,6 +628,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if self.block_quant:
             assert self.quant_config.activation_scheme == "dynamic"
             if current_platform.is_hpu():
+                import vllm_hpu_extension.ops as hpu_ops
                 layer = hpu_ops.fp8_block_moe_prepare_weights(layer)
                 return
             if current_platform.is_fp8_fnuz():
@@ -741,6 +742,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     layer.w13_input_scale.max(), requires_grad=False)
                 layer.w2_input_scale = torch.nn.Parameter(
                     layer.w2_input_scale.max(), requires_grad=False)
+            if current_platform.is_hpu():
+                import vllm_hpu_extension.ops as hpu_ops
+                layer = hpu_ops.fp8_channel_moe_prepare_weights(layer)
+                return
             if current_platform.is_fp8_fnuz():
                 # Normalize the weights and scales
                 w13_weight, w13_weight_scale, w13_input_scale = \


### PR DESCRIPTION
https://jira.habana-labs.com/browse/SW-229036

Add a new env var: VLLM_HPU_FORCE_CHANNEL_FP8, default is 1 => all fp8 block scale will be converted to channel scale.
For running with INC static quant, need to set VLLM_HPU_FORCE_CHANNEL_FP8=0

This PR has depenencies on https://github.com/HabanaAI/vllm-hpu-extension/pull/185


1. support fp8 models with "compressed-tensor" quant_method
    https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
    https://huggingface.co/RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
2. support fp8 models with "block_scale fp8" quant_method
    https://huggingface.co/Qwen/Qwen3-30B-A3B-FP8
    https://huggingface.co/Qwen/Qwen3-235B-A22B-FP8
    https://huggingface.co/deepseek-ai/DeepSeek-R1
3. Add 4 new UT to test both compressed-tensor and block_scale fp8
    UT1: test compressed_tensor with llama4-scout
    UT2: test block scale fp8 with qwen3-30B - block_scale convert to per-channel during model loading
    UT3: test block scale fp8 with qwen3-30B - runtime dequent fp8 to bf16
    UT4: test block scale fp8 with qwen3-30B - INC convert block fp8 to per channel [Same way we did for deepseek inc path]

Quality check:
1. verified accuracy
** Deepseek **
vllm (pretrained=/mnt/weka/data/pytorch/DeepSeek-R1/,tensor_parallel_size=8,distributed_executor_backend=mp,trust_remote_code=true,max_model_len=4096,use_v2_block_manager=True,dtype=bfloat16,enable_expert_parallel=True,max_num_seqs=128), gen_kwargs: (None), limit: 256.0, num_fewshot: 5, batch_size: 128

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9688|±  |0.0109|
|     |       |strict-match    |     5|exact_match|↑  |0.9688|±  |0.0109|


** Qwen3-30B **
vllm (pretrained=/mnt/weka/llm/Qwen3-30B-A3B-FP8/,tensor_parallel_size=8,distributed_executor_backend=mp,trust_remote_code=true,max_model_len=4096,use_v2_block_manager=True,dtype=bfloat16,enable_expert_parallel=True,max_num_seqs=128), gen_kwargs: (None), limit: 256.0, num_fewshot: 5, batch_size: 128

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8828|±  |0.0201|
|     |       |strict-match    |     5|exact_match|↑  |0.9297|±  |0.0160|


** llama4-Maverick **
vllm (pretrained=/mnt/weka/llm/Llama-4-Maverick-17B-128E-Instruct-FP8/,tensor_parallel_size=8,max_model_len=4096,max_num_seqs=1024,gpu_memory_utilization=0.8,use_v2_block_manager=True,dtype=bfloat16,max_gen_toks=2048,disable_log_stats=False,enable_expert_parallel=True), gen_kwargs: (None), limit: 0.1, num_fewshot: 0, batch_size: 128

|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |      2|custom-extract|      |exact_match|↑  |0.8089|±  |0.0109|
| - biology         |      1|custom-extract|     0|exact_match|↑  |0.9167|±  |0.0328|
| - business        |      1|custom-extract|     0|exact_match|↑  |0.8354|±  |0.0420|
| - chemistry       |      1|custom-extract|     0|exact_match|↑  |0.8772|±  |0.0309|
| - computer_science|      1|custom-extract|     0|exact_match|↑  |0.8293|±  |0.0595|
| - economics       |      1|custom-extract|     0|exact_match|↑  |0.8941|±  |0.0336|
| - engineering     |      1|custom-extract|     0|exact_match|↑  |0.7423|±  |0.0446|
| - health          |      1|custom-extract|     0|exact_match|↑  |0.7561|±  |0.0477|
| - history         |      1|custom-extract|     0|exact_match|↑  |0.5897|±  |0.0798|
| - law             |      1|custom-extract|     0|exact_match|↑  |0.6126|±  |0.0464|
| - math            |      1|custom-extract|     0|exact_match|↑  |0.9559|±  |0.0177|
| - other           |      1|custom-extract|     0|exact_match|↑  |0.6882|±  |0.0483|
| - philosophy      |      1|custom-extract|     0|exact_match|↑  |0.7200|±  |0.0641|
| - physics         |      1|custom-extract|     0|exact_match|↑  |0.9077|±  |0.0255|
| - psychology      |      1|custom-extract|     0|exact_match|↑  |0.7875|±  |0.0460|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|------|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.8089|±  |0.0109|
