### PR TITLE
Update vllm-hpu-extension commit to `03d5800` to load RedHatAI fp8 model.

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@5329bdb
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@03d5800


### PR DESCRIPTION
the issue as the PR descripted https://github.com/HabanaAI/vllm-hpu-extension/pull/184, and have merged in vllm-hpu-extension repo side, so I update the commit to use it.
