### PR TITLE
optimize transfer time. use mooncake put/get_unsafe. 

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -73,6 +73,7 @@ class MooncakeStoreConnector(KVConnectorBase):
             dtype = torch.float8_e4m3fn
         else:
             dtype = torch.bfloat16
+        self.dtype = dtype
         self.padding_k_tensor = torch.zeros((self.block_size, self.k_v_head_size), dtype=dtype, device="hpu")
         self.padding_v_tensor = torch.zeros((self.block_size, self.v_head_size), dtype=dtype, device="hpu")
         self.cache_k = VLLMKVCache()
@@ -364,7 +365,7 @@ class MooncakeStoreConnector(KVConnectorBase):
             load_kvcache_key = f"{load_key_prefix}_0"
             shape = (61, num_blocks * 128, self.k_v_head_size)
             # remote_kv = self.kv_store.get(load_kvcache_key)
-            remote_kv = self.kv_store.get_unsafe(load_kvcache_key, shape)
+            remote_kv = self.kv_store.get_unsafe(load_kvcache_key, shape, self.dtype)
             hidden_key = f"{load_key_prefix}_hidden_0"
             hidden = self.kv_store.get(hidden_key)
             

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -244,7 +244,7 @@ class MooncakeStoreConnector(KVConnectorBase):
         start_time = time.time()
         input_tokens_tensor_cpu = model_input.input_tokens.to("cpu") # shape: [batch_size, seq_len_padding_to_128]
         torch.hpu.synchronize()
-        logger.info(f"input tokens tensor cpu time: {time.time() - start_time}")
+        logger.debug(f"input tokens tensor cpu time: {time.time() - start_time}")
         seq_lens = model_input.attn_metadata.seq_lens # 2D list
         start_layer = model_executable.model.start_layer
         end_layer = model_executable.model.end_layer

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -338,9 +338,9 @@ class MooncakeStoreConnector(KVConnectorBase):
             block_indices_tensor = torch.tensor(block_indices_list[start_block_idx:end_block_idx], device="hpu", dtype=torch.int32 )
             # we think this is a padding sequence, so we skip it. but we still need write kv cache
             if slen == 1:
-                for i in range(model_executable.model.model.start_layer,
-                               model_executable.model.model.end_layer):
-                    current_layer_idx = i - model_executable.model.model.start_layer
+                for i in range(model_executable.model.start_layer,
+                               model_executable.model.end_layer):
+                    current_layer_idx = i - model_executable.model.start_layer
                     kv_cache = kv_caches[current_layer_idx]
                     # key_cache, value_cache = kv_cache[0], kv_cache[1]
                     key_cache = kv_cache[0]

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
@@ -208,13 +208,13 @@ class MooncakeStore(KVLookupBufferBase):
         logger.info(f"contiguous time: {end_serde - start_serde}, put time: {end_put - end_serde}")
 
 
-    def get_unsafe(self, key: str, shape) -> Optional[torch.Tensor]:
+    def get_unsafe(self, key: str, shape, dtype) -> Optional[torch.Tensor]:
         """Get KVCache from Mooncake Store without type checking"""
         start_get = time.time()
         data = self.store.get(key)
         end_get = time.time()
         if data:
-            tensor = torch.frombuffer(data, dtype=torch.bfloat16)
+            tensor = torch.frombuffer(data, dtype=dtype)
             tensor = tensor.reshape(shape)
             end_from_buffer = time.time()
             logger.info(f"from buffer time: {end_from_buffer - end_get}, get time: {end_get - start_get}")

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
@@ -205,7 +205,7 @@ class MooncakeStore(KVLookupBufferBase):
             logger.error("Failed to put value into Mooncake Store: %s", err)
             raise TypeError("Mooncake Store Put Type Error.") from err
         end_put = time.time()
-        logger.info(f"contiguous time: {end_serde - start_serde}, put time: {end_put - end_serde}")
+        logger.debug(f"contiguous time: {end_serde - start_serde}, put time: {end_put - end_serde}")
 
 
     def get_unsafe(self, key: str, shape, dtype) -> Optional[torch.Tensor]:
@@ -217,6 +217,6 @@ class MooncakeStore(KVLookupBufferBase):
             tensor = torch.frombuffer(data, dtype=dtype)
             tensor = tensor.reshape(shape)
             end_from_buffer = time.time()
-            logger.info(f"from buffer time: {end_from_buffer - end_get}, get time: {end_get - start_get}")
+            logger.debug(f"from buffer time: {end_from_buffer - end_get}, get time: {end_get - start_get}")
             return tensor
         return None

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2867,7 +2867,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 else:
                     logger.debug("Bypassing model execution")
 
-                torch.hpu.synchronize()
+                # torch.hpu.synchronize()
                 # Sending KV cache in distributed KV cache transfer setting
                 # NOTE: the send operation is non-blocking
                 cur_time = time.time()

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2867,7 +2867,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 else:
                     logger.debug("Bypassing model execution")
 
-                # torch.hpu.synchronize()
+                torch.hpu.synchronize()
                 # Sending KV cache in distributed KV cache transfer setting
                 # NOTE: the send operation is non-blocking
                 cur_time = time.time()


### PR DESCRIPTION
important! please be aware we need internal mooncake!
<!--- pyml disable-next-line no-emphasis-as-heading -->
