### PR TITLE
Fix number of blocks for pipeline parallelism.

### DIFF
--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -354,7 +354,6 @@ class HPUWorker(LocalOrDistributedWorkerBase):
                              cache_block_size)
         num_hpu_blocks = max(num_hpu_blocks, 0)
         num_cpu_blocks = max(num_cpu_blocks, 0)
-        self.model_runner.bucketing_ctx.num_hpu_blocks = num_hpu_blocks
 
         if self.model_runner.lora_manager:
             self.model_runner.remove_all_loras()

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -356,8 +356,6 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         num_cpu_blocks = max(num_cpu_blocks, 0)
         self.model_runner.bucketing_ctx.num_hpu_blocks = num_hpu_blocks
 
-        self.model_runner.bucketing_ctx.num_hpu_blocks = num_hpu_blocks
-
         if self.model_runner.lora_manager:
             self.model_runner.remove_all_loras()
 
@@ -377,6 +375,8 @@ class HPUWorker(LocalOrDistributedWorkerBase):
 
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks
+        self.model_runner.bucketing_ctx.num_hpu_blocks = (
+                num_gpu_blocks // self.parallel_config.pipeline_parallel_size)
 
         with HabanaMemoryProfiler() as m:
             self._init_cache_engine()

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -376,7 +376,7 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks
         self.model_runner.bucketing_ctx.num_hpu_blocks = (
-                num_gpu_blocks // self.parallel_config.pipeline_parallel_size)
+            num_gpu_blocks // self.parallel_config.pipeline_parallel_size)
 
         with HabanaMemoryProfiler() as m:
             self._init_cache_engine()


### PR DESCRIPTION
Before this fix we would get flat_pa error because the number of blocks in the last bucket was not well divisable for pipeline parallelism cases.
In addition to that fix I removed a duplicated line in determine_num_available_blocks and moved it to cache initialization.