### PR TITLE
Patch for calling different MoE (BF16 or FP8).

### DIFF
--- a/scripts/qwen3/01-benchmark-online-30B-fp8.sh
+++ b/scripts/qwen3/01-benchmark-online-30B-fp8.sh
@@ -170,7 +170,7 @@ for req_in_out in "${req_in_out_list[@]}"; do
         --model ${model} \
         --tokenizer ${tokenizer} \
         --dataset-name sonnet \
-        --dataset-path ../benchmarks/sonnet.txt \
+        --dataset-path ../../benchmarks/sonnet.txt \
         --request-rate ${request_rate} \
         --percentile-metrics ttft,tpot,itl,e2el \
         --ignore-eos \

--- a/scripts/qwen3/Quant_QWen3-FP8.md
+++ b/scripts/qwen3/Quant_QWen3-FP8.md
@@ -32,9 +32,10 @@ pip install -e .
 - Calibration 
 
 ```bash
-cd vllm-fork/scripts-fp8
+cd vllm-fork/scripts/qwen3
+pip install datasets
 export OFFICIAL_MODEL=/path/to/qwen/model
-bash /run_qwen.sh calib ${OFFICIAL_MODEL}
+bash ./run_qwen.sh calib ${OFFICIAL_MODEL}
 ```
 
 ```


### PR DESCRIPTION
BF16 MoE needs some values for static MoE, while inc FP8 is unnecessary. The patch checks these different cases. 
