### PR TITLE
Fix vllm crash when running with lm-eval

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2629,7 +2629,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
 
     def _pad_to_max_num_seqs(self, tensor, value):
         padding_needed = self.max_num_seqs - tensor.size(0)
-        if padding_needed:
+        if padding_needed > 0:
             padding = torch.full((padding_needed, *tensor.shape[1:]),
                                  value,
                                  device=tensor.device,


### PR DESCRIPTION
lm-eval crash in deepseek_r1 branch, because the padding_needed is negative.

> no_proxy=0.0.0.0 HF_ALLOW_CODE_EVAL=1 lm_eval --model local-completions --tasks lambada_openai --model_args model=/dataset/DeepSeek-R1-static,base_url=http://0.0.0.0:8688/v1/completions,trust_remote_code=True,max_gen_toks=1024  --confirm_run_unsafe_code --batch_size 1 --log_samples --output_path ./lm_eval_output
> 
> padding = torch.full((padding_needed, *tensor.shape[1:]),
> FATAL ERROR :: MODULE:PT_SYNHELPER Huge Size not supported:

