### PR TITLE
Removed redundant variable for APC enablement

### DIFF
--- a/.jenkins/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.jenkins/lm-eval-harness/test_lm_eval_correctness.py
@@ -54,7 +54,6 @@ def launch_lm_eval(eval_config):
                  f"dtype={dtype}," \
                  f"max_model_len=4096," \
                  f"max_num_seqs={max_num_seqs}," \
-                 f"enable_prefix_caching=False," \
                  f"trust_remote_code={trust_remote_code}"
     if eval_config.get("fp8"):
         model_args += ",quantization=inc," \


### PR DESCRIPTION

Parameter `enable_prefix_caching` was set up twice, second time with fixed value on False
