### PR TITLE
[deepseek_r1] fix warmup logic form contiguous_pa

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2157,14 +2157,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             self.warmup_scenario(int(bs), int(seq_len), is_prompt, kv_caches,
                                  True)
             raise AssertionError("Finished profiling")
-        if not self.is_pooler:
-            max_blocks = (
-                kv_caches[0][0].size(0)
-                // int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", self.cache_config.block_size))
-                * int(os.getenv("VLLM_DECODE_BLOCK_BUCKET_STEP", self.cache_config.block_size))
-            )
         self.bucketing_ctx.generate_prompt_buckets()
         if not self.is_pooler:
+            max_blocks = kv_caches[0][0].size(0)
             self.bucketing_ctx.generate_decode_buckets(max_blocks)
         if not htorch.utils.internal.is_lazy() and not self.enforce_eager:
             multiplier = 3 if os.getenv('VLLM_REGIONAL_COMPILATION',


### PR DESCRIPTION
When contiguous_pa is enabled, the decode graph is not warmed-up for the max block_id. 
See example below, when the total number of HPU blocks is 1974, the decode graph should be warmed-up for (bs, 1974). 

> INFO 05-28 03:29:33 executor_base.py:110] # HPU blocks: 1974, # CPU blocks: 954

Need to work with https://github.com/HabanaAI/vllm-hpu-extension/pull/201

In habana_main, this code has been updated.



