### PR TITLE
[habana_main][bypass inc][fp8 kv cache] Enable FP8 KV cache bypass INC

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@45116d1
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@f21e935

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2024-2025 Habana Labs, Ltd. an Intel Company
 ###############################################################################
 
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type
 
@@ -11,8 +12,8 @@ import torch
 import vllm_hpu_extension.kernels as kernels
 import vllm_hpu_extension.ops as ops
 from vllm_hpu_extension.flags import enabled_flags
-from vllm_hpu_extension.utils import (Matmul, ModuleFusedSDPA, Softmax,
-                                      VLLMKVCache)
+from vllm_hpu_extension.utils import (FP8Matmul, Matmul, ModuleFusedSDPA,
+                                      Softmax, VLLMFP8KVCache, VLLMKVCache)
 
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionLayer,
@@ -162,13 +163,19 @@ class HPUMLAImpl(MLACommonImpl[HPUAttentionMetadata], torch.nn.Module):
                                alibi_slopes, sliding_window, kv_cache_dtype,
                                blocksparse_params, logits_soft_cap, attn_type,
                                **kwargs)
-
-        self.matmul_qk = Matmul()
+        self.enable_fp8_attn = kv_cache_dtype == 'fp8_inc' and os.environ.get(
+            'QUANT_CONFIG', None) is None
+        self.matmul_qk = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
         self.softmax = Softmax()
-        self.matmul_av = Matmul()
-        self.batch2block_matmul = Matmul()
-        self.block2batch_matmul = Matmul()
-        self.latent_cache_k = VLLMKVCache()
+        self.matmul_av = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
+        self.batch2block_matmul = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
+        self.block2batch_matmul = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
+        self.latent_cache_k = VLLMKVCache() if not self.enable_fp8_attn \
+            else VLLMFP8KVCache()
         self.fused_scaled_dot_product_attention = kernels.fsdpa()
 
         if "fsdpa" in enabled_flags():
@@ -369,17 +376,25 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             logger.warning_once(
                 "Using irope in HPU is not supported yet, it will fall back "
                 "to global attention for long context.")
+        self.enable_fp8_attn = kv_cache_dtype == 'fp8_inc' and os.environ.get(
+            'QUANT_CONFIG', None) is None
         self.kv_cache_dtype = kv_cache_dtype
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
-        self.matmul_qk = Matmul()
+        self.matmul_qk = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
         self.softmax = Softmax()
-        self.matmul_av = Matmul()
-        self.batch2block_matmul = Matmul()
-        self.block2batch_matmul = Matmul()
-        self.k_cache = VLLMKVCache()
-        self.v_cache = VLLMKVCache()
+        self.matmul_av = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
+        self.batch2block_matmul = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
+        self.block2batch_matmul = Matmul() if not self.enable_fp8_attn \
+            else FP8Matmul()
+        self.k_cache = VLLMKVCache() if self.enable_fp8_attn \
+            else VLLMFP8KVCache()
+        self.v_cache = VLLMKVCache() if self.enable_fp8_attn \
+            else VLLMFP8KVCache()
         HPUFusedSDPA = kernels.fsdpa()
         self.fused_scaled_dot_product_attention = None if HPUFusedSDPA is None \
             else ModuleFusedSDPA(HPUFusedSDPA)

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -391,9 +391,9 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             else FP8Matmul()
         self.block2batch_matmul = Matmul() if not self.enable_fp8_attn \
             else FP8Matmul()
-        self.k_cache = VLLMKVCache() if self.enable_fp8_attn \
+        self.k_cache = VLLMKVCache() if not self.enable_fp8_attn \
             else VLLMFP8KVCache()
-        self.v_cache = VLLMKVCache() if self.enable_fp8_attn \
+        self.v_cache = VLLMKVCache() if not self.enable_fp8_attn \
             else VLLMFP8KVCache()
         HPUFusedSDPA = kernels.fsdpa()
         self.fused_scaled_dot_product_attention = None if HPUFusedSDPA is None \


### PR DESCRIPTION
Currently, we will leverage INC to support fp8 kv cache
To use INC fp8 kv cache, we'll need to specify quant_config and kv_cache_dtype = fp8_inc.

This PR would like to provide bypass with native fp8 KV Cache support. Same method is adopted in TGI as well.

How to run
No need to add quant_config in env var. need to use kv_cache_dtype
```
--kv_cache_dtype=fp8_inc
```

Validation
```
PT_HPU_LAZY_MODE=1 \
VLLM_SKIP_WARMUP=true \
PT_HPU_ENABLE_LAZY_COLLECTIVES=true \
PT_HPU_WEIGHT_SHARING=0 \
lm_eval --model vllm \
  --model_args "pretrained=${MODEL_PATH},tensor_parallel_size=${TP_SIZE},distributed_executor_backend=mp,trust_remote_code=true,max_model_len=4096,use_v2_block_manager=True,dtype=bfloat16,enable_expert_parallel=True,max_num_seqs=128,kv_cache_dtype=fp8_inc" \
  --tasks gsm8k --num_fewshot "5" \
  --batch_size "128" --limit 256 --log_samples --output_path gsm8k_acc_${MODEL_NAME}.json
```
```
  "results": {
    "gsm8k": {
      "alias": "gsm8k",
      "exact_match,strict-match": 0.9765625,
      "exact_match_stderr,strict-match": 0.009474047852981757,
      "exact_match,flexible-extract": 0.9765625,
      "exact_match_stderr,flexible-extract": 0.009474047852981757
    }
  },
```

Future TODO:
some model also provided KV_scales in model, now I am testing with unit_scale, but it would with better accuracy using provided KV Scale.