### PR TITLE
[SW-229993] bug fix reported in SW-229993 - IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -581,7 +581,10 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
 
         """
         if current_platform.is_hpu():
-            weight_scale = layer.weight_scale.transpose(0, 1)
+            if layer.weight_scale.dim() > 1:
+                weight_scale = layer.weight_scale.transpose(0, 1)
+            else:
+                weight_scale = layer.weight_scale
             return hpu_ops.apply_fp8_linear_hpu(input=x,
                                                 weight=layer.weight,
                                                 weight_scale=weight_scale,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -443,7 +443,10 @@ class Fp8LinearMethod(LinearMethodBase):
             )
 
         if current_platform.is_hpu():
-            weight_scale = layer.weight_scale.transpose(0, 1)
+            if layer.weight_scale.dim() > 1:
+                weight_scale = layer.weight_scale.transpose(0, 1)
+            else:
+                weight_scale = layer.weight_scale
             return hpu_ops.apply_fp8_linear_hpu(input=x,
                                                 weight=layer.weight,
                                                 weight_scale=weight_scale,


### PR DESCRIPTION
This is a bug fix for https://jira.habana-labs.com/browse/SW-229993

Validated the same model and now it runs OK
2025-05-29:01:07:32,806 INFO     [lm_eval.loggers.evaluation_tracker:290] Saving per-sample results for: gsm8k
vllm (pretrained=/mnt/weka/data/pytorch/llama3/Meta-Llama-3-8B-Instruct-AutoFP8/,tensor_parallel_size=1,distributed_executor_backend=mp,trust_remote_code=true,max_model_len=4096,use_v2_block_manager=True,dtype=bfloat16,max_num_seqs=128), gen_kwargs: (None), limit: 256.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7383|±  |0.0275|
|     |       |strict-match    |     5|exact_match|↑  |0.7422|±  |0.0274|
