### PR TITLE
by default disable contiguous_pa on Gaudi2.

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -245,6 +245,8 @@ def get_path_to_rope(model: torch.nn.Module):
     # Return the result if found, otherwise None
     return path_to_rope
 
+def is_gaudi2() -> bool:
+    return htorch.hpu.get_device_name() == "GAUDI2"
 
 class HpuModelAdapter:
 
@@ -767,7 +769,11 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.dp_awared_padding = self.dp_size > 1
 
         self._set_gc_threshold()
-        self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
+        if is_gaudi2():
+            self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
+                                                'false').lower() == 'true'
+        else:
+            self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
                                                 'true').lower() == 'true'
         if vllm_config.speculative_config is not None \
             and self.use_contiguous_pa:


### PR DESCRIPTION
For Gaudi2, contiguous_pa did not bring performance improvement. Submit PR to by default disable this feature.

Performance Data below is collected from static_quant/8card/tp=8.

bs | input | output | disable contiguous_pa output_throughput | enable contiguous_pa  output_throughput |  improvement%
-- | -- | -- | -- | -- | --
16 | 1024 | 1024 | 298.12 | 288.64 | 3% |  
32 | 1024 | 1024 | 484.29 | 449.96 | 8% |  
64 | 1024 | 1024 | 721.48 | 674.31 | 7% |  
128 | 1024 | 1024 | 1069.22 | 985.19 | 9% |  
16 | 2048 | 2048 | 291 | 281.17 | 3% |  
32 | 2048 | 2048 | 453 | 432.44 | 5% |  
64 | 2048 | 2048 | 651.06 | 608.42 | 7% |  
16 | 2048 | 1024 | 284.94 | 277.03 | 3% |  
32 | 2048 | 1024 | 432.14 | 412.75 | 5% |  
64 | 2048 | 1024 | 622.1 | 598.86 | 4% |  
16 | 8192 | 1024 | 205.08 | 199.79 | 3% |  
32 | 8192 | 1024 | 258.83 | 245.81 | 5% |  


