### PR TITLE
Remove duplicate kv_b_proj from models using MLA

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -885,6 +885,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                         "false") in ("1", "true")
                     config = FP8Config.from_json_file(
                         os.getenv("QUANT_CONFIG", ""))
+                    self._inc_preprocess_(self.model, config)
                     if config.measure:
                         self.model = prepare(self.model, config)
                     elif config.quantize:
@@ -2074,6 +2075,18 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.warmup_scenario(max_batch_size, max_seq_len, True, kv_caches,
                              False, True)
         return
+
+    def _remove_duplicate_submodules_(self, model, inc_config):
+        for layer in model.model.layers:
+            self_attn = layer.self_attn
+            # delete attr kv_b_proj in self_attn,
+            # as they have been transferred to the MLAImpl.
+            if hasattr(self_attn, "mla_attn") and hasattr(
+                    self_attn, "kv_b_proj"):
+                delattr(self_attn, "kv_b_proj")
+
+    def _inc_preprocess_(self, model: torch.nn.Module, inc_config):
+        self._remove_duplicate_submodules_(model, inc_config)
 
     def warmup_scenario(self,
                         batch_size,


### PR DESCRIPTION
Deepseek in our definition has two places where kv_b_proj is defined: in `self_attn.kv_b_proj` and `self_attn.impl.kv_b_proj` . First one isn't used, but at the model initialization is present, which makes inc try to quantize it. Because at the measurement it wasn't used, there are no measurements for this specific object and it causes it to crash.