### PR TITLE
Pad the batch size to a bucket batch size

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1874,6 +1874,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         _, max_seq_len = self.bucketing_ctx.get_max_prompt_shape()
         max_batch_size = min(self.max_num_seqs,
                              self.max_num_batched_tokens // max_seq_len)
+        max_batch_size = self.bucketing_ctx.get_padded_batch_size(
+            max_batch_size, True)
 
         self.warmup_scenario(max_batch_size, max_seq_len, True, kv_caches,
                              False, True, is_profile_run=True)


### PR DESCRIPTION
It might result in runtime error if the batch size is not padded to a bucket batch size.

E.g.

[rank0]:   File "/workspace/aicse.vllm-habana/vllm/model_executor/custom_op.py", line 25, in forward
[rank0]:     return self._forward_method(*args, **kwargs)
[rank0]:   File "/workspace/aicse.vllm-habana/vllm/model_executor/layers/rotary_embedding.py", line 268, in forward_hpu
[rank0]:     key = key.view(num_tokens, -1, self.head_size)
[rank0]: RuntimeError: shape '[9216, -1, 128]' is invalid for input of size 4128768

Note before commit 0f513bd, the batch size passed to self.warmup_scenario() was the maximum batch size in all buckets for prompt, so requring the batch size passed to self.warup_scenario() matches one of a bucket after commit 0f513bd is logical.

FILL IN THE PR DESCRIPTION HERE

FIX #xxxx (*link existing issues this PR will resolve*)

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing/overview.html>** (anything written below this line will be removed by GitHub Actions)
