### PR TITLE
Set simple_compile_backend for HpuPlatform

### DIFF
--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -26,6 +26,7 @@ class HpuPlatform(Platform):
     dispatch_key: str = "HPU"
     ray_device_key: str = "HPU"
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
+    simple_compile_backend: str = "hpu_backend"
     supported_quantization: list[str] = [
         "compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu"
     ]

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -27,7 +27,8 @@ class HpuPlatform(Platform):
     dispatch_key: str = "HPU"
     ray_device_key: str = "HPU"
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
-    simple_compile_backend: str = "hpu_backend" if not is_fake_hpu() else "inductor"
+    simple_compile_backend: str = "hpu_backend" if not is_fake_hpu(
+    ) else "inductor"
     supported_quantization: list[str] = [
         "compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu"
     ]

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -7,6 +7,7 @@ import torch
 
 from vllm import envs
 from vllm.logger import init_logger
+from vllm.utils import is_fake_hpu
 
 from .interface import Platform, PlatformEnum, _Backend
 
@@ -26,7 +27,7 @@ class HpuPlatform(Platform):
     dispatch_key: str = "HPU"
     ray_device_key: str = "HPU"
     device_control_env_var: str = "HABANA_VISIBLE_MODULES"
-    simple_compile_backend: str = "hpu_backend"
+    simple_compile_backend: str = "hpu_backend" if not is_fake_hpu() else "inductor"
     supported_quantization: list[str] = [
         "compressed-tensors", "fp8", "inc", "awq_hpu", "gptq_hpu"
     ]


### PR DESCRIPTION
Fix for running Llama-3.1 in eager mode. So far `simple_compile_backend` was set to `inductor`, which is not supported.