### PR TITLE
[deepseek_r1] revert disable contiguous_pa for Gaudi2.

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -25,7 +25,6 @@ import torch.nn as nn
 import vllm_hpu_extension.environment as environment
 from vllm_hpu_extension.bucketing import HPUBucketingContext
 from vllm_hpu_extension.flags import enabled_flags
-from vllm_hpu_extension.ops import is_hpu_gaudi2
 from vllm_hpu_extension.ops import LoraMask as LoraMask
 from vllm_hpu_extension.ops import batch2block, block2batch
 from vllm_hpu_extension.profiler import (HabanaHighLevelProfiler,
@@ -245,6 +244,7 @@ def get_path_to_rope(model: torch.nn.Module):
 
     # Return the result if found, otherwise None
     return path_to_rope
+
 
 class HpuModelAdapter:
 
@@ -767,9 +767,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.dp_awared_padding = self.dp_size > 1
 
         self._set_gc_threshold()
-        self.use_contiguous_pa = (os.environ.get(
-            "VLLM_CONTIGUOUS_PA",
-            "false" if is_hpu_gaudi2() else "true").lower() == "true")
+        self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
+                                                'true').lower() == 'true'
         if vllm_config.speculative_config is not None \
             and self.use_contiguous_pa:
             raise ValueError(


### PR DESCRIPTION
Found accuracy issue when contiguous_pa is disabled. Revert original PR as hotfix.

Revert "by default disable contiguous_pa on Gaudi2. (#1345)"

This reverts commit 146c97c79dfedf28c5b5d3f784346d4b0e369504.

