### PR TITLE
[SW-228628] Enable Deepseek R1 in torch compile mode

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -712,9 +712,6 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        if is_hpu:
-            import habana_frameworks.torch as htorch
-
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.config = config

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -715,12 +715,6 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
         if is_hpu:
             import habana_frameworks.torch as htorch
 
-            assert htorch.utils.internal.is_lazy(), \
-                (
-                "Deepseek currently supports only lazy mode on HPU, "
-                "please set PT_HPU_LAZY_MODE=1"
-                )
-
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.config = config


### PR DESCRIPTION
I removed assert that was blocking torch compile mode. Tested this and it works. Was able to even create vllm-benchmark scenario with gsm8k dataset.

{"task_name": "gsm8k", "accuracy": 0.952, "target_accuracy": 0.96875, "performance": 389, "valid": true}