### PR TITLE
Add exception code to avoid pure text models crashed by image inputs

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -572,8 +572,12 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
                 "increase this limit if the model supports it.")
 
         self._items_by_modality[modality].append(item)
-
-        return self._placeholder_str(modality, current_count)
+        try:
+            return self._placeholder_str(modality, current_count)
+        except TypeError as e:
+            logger.warning(f"Skipping unsupported modality '{modality}' for model "\
+                           f"'{self._model_config.hf_config.model_type}': {e}")
+            return None
 
     @abstractmethod
     def create_parser(self) -> "BaseMultiModalContentParser":


### PR DESCRIPTION
This PR aims to protect the backend vllm engine from crashing due to the inconsistent input, e.g. the image input to a pure text LLM model.

This is possible by applying the vllm engine as the backend of a user interface, such as openWebUI. Especially, in the openWebUI, when Capture button is used to take a snapshot of a webpage, the snapshot image could be committed together with the prompt.
![capture_button](https://github.com/user-attachments/assets/9465f1fc-7f1e-46cf-b307-e8a69f1d3287)

The image could be handled by multi-modality models, e.g. Qwen2.5-VL-7B, however, it will lead to the crash of the pure text models, such as Llama3.1-8B or Mistral-7B
![image](https://github.com/user-attachments/assets/03d6fbb3-d715-4c4e-a7dd-19a101bece08)

After applying this PR, a `400 Bad Request` will be responded to the user interface instead of the `500 Internal Server Error`, and the vllm engine will still be alive.
![after_pr_fix](https://github.com/user-attachments/assets/0c55b7b5-20ca-4501-bea6-1d955c990a8e)


<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing/overview.html>** (anything written below this line will be removed by GitHub Actions)
