### PR TITLE
Fixing prompt_logprobs list in delayed sampling

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3734,4 +3734,9 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 logprobs has {len(delayed_prompt_logprobs)} entries!'''
             for sg, real_logprobs in zip(seq_groups, delayed_prompt_logprobs):
                 if real_logprobs is not None:
-                    sg.seq_group.prompt_logprobs = real_logprobs
+                    # Prepending None just like in vllm.engine.output_processor\
+                    # .single_step.single_step_process_prompt_logprob, but
+                    # hence we are not going through async output processor
+                    # with data from prompt in delayed sampling scenario we
+                    # need to do that manually.
+                    sg.seq_group.prompt_logprobs = [None] + real_logprobs


### PR DESCRIPTION
Prepending missing [None] as the first value of prompt_logprobs when delayed sampling is enabled to be in sync with regular sampling scenario.

Example prompt_logprobs list w/a delayed sampling:
```
--------------------
Prompt logprob: None
Prompt logprob: {0: Logprob(logprob=-6.61875057220459, rank=89, decoded_token='!'), 755: Logprob(logprob=-2.90000057220459, rank=1, decoded_token='def')}
Prompt logprob: {0: Logprob(logprob=-6.565563201904297, rank=88, decoded_token='!'), 755: Logprob(logprob=-3.034313201904297, rank=1, decoded_token='def')}
Prompt logprob: {0: Logprob(logprob=-6.651154518127441, rank=92, decoded_token='!'), 755: Logprob(logprob=-2.9324045181274414, rank=1, decoded_token='def')}
Prompt logprob: {0: Logprob(logprob=-6.657766342163086, rank=93, decoded_token='!'), 755: Logprob(logprob=-3.064016342163086, rank=1, decoded_token='def')}
```
Example prompt logprobs list with delayed sampling (before my PR):
```
--------------------
Prompt logprob: {0: Logprob(logprob=-6.61875057220459, rank=89, decoded_token=None), 755: Logprob(logprob=-2.90000057220459, rank=1, decoded_token=None)}
Prompt logprob: {0: Logprob(logprob=-6.565563201904297, rank=88, decoded_token=None), 755: Logprob(logprob=-3.034313201904297, rank=1, decoded_token=None)}
Prompt logprob: {0: Logprob(logprob=-6.651154518127441, rank=92, decoded_token=None), 755: Logprob(logprob=-2.9324045181274414, rank=1, decoded_token=None)}
Prompt logprob: {0: Logprob(logprob=-6.657766342163086, rank=93, decoded_token=None), 755: Logprob(logprob=-3.064016342163086, rank=1, decoded_token=None)}
```
The PR synchronizes the prompt_logprobs length between the two approaches.
