### PR TITLE
Fix for KVCache Layerwise that breaks after rebase

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -143,7 +143,7 @@ class Attention(nn.Module):
         # opaque custom op. For other platforms, we directly call them
         # and let torch.compile handle them.
         self.use_direct_call = not current_platform.is_cuda_alike(
-        ) and not current_platform.is_cpu()
+        ) and not current_platform.is_cpu() and not torch.hpu.is_available()
 
         self.use_output = attn_backend.accept_output_buffer
         compilation_config = get_current_vllm_config().compilation_config


### PR DESCRIPTION
Fix for KVCache Layerwise that breaks after rebase

FIX #HS-6408

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing/overview.html>** (anything written below this line will be removed by GitHub Actions)
