### PR TITLE
Fix pooling (classify or embed) model returns nan when dtype is float16 (or downcasted to float16)

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -397,7 +397,7 @@ class HpuModelAdapter(torch.nn.Module):
             mask = attn_mask.logical_or(len_mask).logical_or(len_mask_v)
             off_value = -3E38  #small number, avoid nan and overflow
             if dtype == torch.float16:
-                off_value = -63000
+                off_value = -63000    # a small value close to float16.min
         else:
             mask = attn_mask.logical_or(
                 len_mask)  #no need for len_mask_v as decode overwrites it

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -396,6 +396,8 @@ class HpuModelAdapter(torch.nn.Module):
             len_mask_v = len_mask.view(batch_size, 1, seq_len, 1)
             mask = attn_mask.logical_or(len_mask).logical_or(len_mask_v)
             off_value = -3E38  #small number, avoid nan and overflow
+            if dtype == torch.float16:
+                off_value = -63000
         else:
             mask = attn_mask.logical_or(
                 len_mask)  #no need for len_mask_v as decode overwrites it


### PR DESCRIPTION
cc: @yangulei @ranzhejiang @czhu15 
