### PR TITLE
[deepseek_r1] decrease default max_seq_len_to_capture from 8192->4096 to reduce prompt graph

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -136,7 +136,7 @@ class EngineArgs:
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
     enforce_eager: Optional[bool] = None
-    max_seq_len_to_capture: int = 8192
+    max_seq_len_to_capture: int = 4096
     disable_custom_all_reduce: bool = False
     tokenizer_pool_size: int = 0
     # Note: Specifying a tokenizer pool by passing a class


### PR DESCRIPTION
The default max_seq_len_to_capture(8192) captures too many prompt graphs. As as result, the number of hpu blocks are decreased. It impacts the performance for long seq input, such as 8k/1k.

The change is aligned to https://github.com/yangulei/vllm-fork/commit/14c4b51d46007b45064368817f0d39f571097378

