### PR TITLE
Pin lm_eval to 0.4.8

### DIFF
--- a/.jenkins/requirements-test-hpu.txt
+++ b/.jenkins/requirements-test-hpu.txt
@@ -1,3 +1,3 @@
-lm_eval
+lm_eval==0.4.8
 pytest
 pytest_asyncio


### PR DESCRIPTION
lm_eval 0.4.9 causes model loading errors
