### PR TITLE
Remove sync point in warmup

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2569,7 +2569,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                     temperature=temperature,
                     ctx=ctx) for i, b in enumerate(blocks)
             ]
-        torch.hpu.synchronize()
         profiler = None
         if is_pt_profiler_run and self.is_driver_worker:
             profiler = setup_profiler()


### PR DESCRIPTION
Testing for parallel compilation - currently we're blocking at each warmup iteration (bucket), rather than submitting all graphs to be compiled and letting PT bridge handle the parallelization.