### PR TITLE
Fix shutdown issue of inc during exit

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3752,9 +3752,6 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             finalize_calibration(self.model.model)
             self._is_inc_finalized = True
 
-    def __del__(self):
-        self.shutdown_inc()
-
     def _patch_prev_output(self):
         assert len(self.cached_step_inputs) == len(self.cached_step_outputs), \
             f'''Inputs and outputs are out of sync!


### PR DESCRIPTION
Bug fix

- Fix bug during shuting down

Exception ignored in: <function HPUModelRunner.del at 0x7f02148c3880>
Traceback (most recent call last):
File "/usr/local/lib/python3.10/dist-packages/vllm/worker/hpu_model_runner.py", line 3505, in del
File "/usr/local/lib/python3.10/dist-packages/vllm/worker/hpu_model_runner.py", line 3492, in shutdown_inc
ImportError: sys.meta_path is None, Python is likely shutting down

Actually, when you use llm.llm_engine.model_executor.shutdown(), this inc shutdown will be called here:
https://github.com/HabanaAI/vllm-fork/blob/2b8dde98180c7216baf3dd438615b6ddcbf334d8/vllm/worker/hpu_worker.py#L505

The __del__ method is invoked when an object is destroyed, but Python's garbage collection mechanism does not guarantee ​​when​​ the del method will be executed, especially during program termination.
Since __del__ is not reliable, I remove shoutdown_inc from it.