### PR TITLE
Downgrade transformers to 4.52.4 in CI tests

### DIFF
--- a/.jenkins/requirements-test-hpu.txt
+++ b/.jenkins/requirements-test-hpu.txt
@@ -1,3 +1,4 @@
 lm_eval==0.4.8
 pytest
 pytest_asyncio
+transformers==4.52.4 # workaround for Qwen2.5 issue with transformers 4.53.0


### PR DESCRIPTION
Temporary workaround to unblock CI tests after upgrading transformers to 4.53.0. The newest version causes issue on Qwen2.5VL:
```
E       TypeError: Qwen2_5_VLProcessor.__init__() got multiple values for argument 'image_processor'```
