### PR TITLE
Optimized prefill phase for DeepSeek-R1

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1019,7 +1019,7 @@ def grouped_topk(hidden_states: torch.Tensor,
     if renormalize:
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
 
-    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+    return topk_weights.to(torch.bfloat16), topk_ids.to(torch.int64)
 
 
 def get_config_dtype_str(dtype: torch.dtype,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1034,7 +1034,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                                                   topk_weights_across_dp)
 
             batched_tokens = x.shape[0]
-            #selected_experts = (topk_ids.to(torch.int64) - ep_shift)
 
             if batched_tokens > self.moe_slice_length:
                 final_hidden_states_list = []

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -509,7 +509,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.block_quant = self.quant_config.weight_block_size is not None
         
         # Slicing the batched tokens for DynamicMoE to reduce the memory consumption
-        self.moe_slice_length = int(os.environ.get("VLLM_MOE_SLICE_LENGTH", 8192))
+        self.moe_slice_length = int(os.environ.get("VLLM_MOE_SLICE_LENGTH", 128000))
 
         self.moe_n_slice = int(os.environ.get("VLLM_MOE_N_SLICE", 8))
         self.enable_dmoe_dynamic_scale = os.environ.get("VLLM_DMOE_DYNAMIC_SCALE", False) in ["1", "true"]
@@ -1016,7 +1016,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 x_fp8 = torch.ops.hpu.cast_to_fp8_v2(x, 1.0/x_scale, False, False, torch.float8_e4m3fn)[0]
             else:
                 x_fp8 = x
-            topk_weights = topk_weights.to(torch.bfloat16)
+            
             if layer.dp_size > 1:
                 cu_tokens_across_dp_cpu = get_forward_context(
                 ).dp_metadata.cu_tokens_across_dp_cpu
@@ -1034,7 +1034,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                                                   topk_weights_across_dp)
 
             batched_tokens = x.shape[0]
-            selected_experts = (topk_ids.to(torch.int64) - ep_shift)
+            #selected_experts = (topk_ids.to(torch.int64) - ep_shift)
+
             if batched_tokens > self.moe_slice_length:
                 final_hidden_states_list = []
                 n_slice = (batched_tokens + self.moe_slice_length -
@@ -1044,26 +1045,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     e = batched_tokens if i == (n_slice -
                                     1) else (i + 1) * self.moe_slice_length
                     current_hidden_states = torch.ops.hpu.mixture_of_experts(
-                    hidden_states=x_fp8[s:e, ...],
-                    expert_routing_table=selected_experts[s:e, ...],
-                    router_weights=topk_weights[s:e, ...],
-                    w12=self.w13_weight_list,
-                    w3=self.w2_weight_list,
-                    d_scale_hidden_states=x_scale,
-                    d_scale_intermediate_hidden_states=self.w2_input_scale_list,
-                    d_scale_w12=self.w13_weight_scale_list,
-                    d_scale_w3=self.w2_weight_scale_list,
-                    permuted_weights=True,
-                    activation="silu",
-                    experts_min=0,
-                    experts_max=(num_experts - 1),
+                        hidden_states=x_fp8[s:e, ...],
+                        expert_routing_table=topk_ids[s:e, ...],
+                        router_weights=topk_weights[s:e, ...],
+                        w12=self.w13_weight_list,
+                        w3=self.w2_weight_list,
+                        d_scale_hidden_states=x_scale,
+                        d_scale_intermediate_hidden_states=self.w2_input_scale_list,
+                        d_scale_w12=self.w13_weight_scale_list,
+                        d_scale_w3=self.w2_weight_scale_list,
+                        permuted_weights=True,
+                        activation="silu",
+                        experts_min=ep_shift,
+                        experts_max=(num_experts + ep_shift - 1),
                     )
                     final_hidden_states_list.append(current_hidden_states)
                 final_hidden_states = torch.cat(final_hidden_states_list, dim=0)
             else:
                 final_hidden_states = torch.ops.hpu.mixture_of_experts(
                     hidden_states=x_fp8,
-                    expert_routing_table=selected_experts,
+                    expert_routing_table=topk_ids,
                     router_weights=topk_weights,
                     w12=self.w13_weight_list,
                     w3=self.w2_weight_list,
@@ -1073,8 +1074,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     d_scale_w3=self.w2_weight_scale_list,
                     permuted_weights=True,
                     activation="silu",
-                    experts_min=0,
-                    experts_max=(num_experts - 1),
+                    experts_min=ep_shift,
+                    experts_max=(num_experts + ep_shift - 1),
                 )
             return final_hidden_states.view(-1, x.shape[1])
 
@@ -1091,8 +1092,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
                 current_hidden_states = torch.ops.hpu.mixture_of_experts(
                                             hidden_states=x_fp8,
-                                            expert_routing_table=topk_ids.to(torch.int64),
-                                            router_weights=topk_weights.to(x.dtype),
+                                            expert_routing_table=topk_ids,
+                                            router_weights=topk_weights,
                                             w12=w13_list_slice,
                                             w3=w2_list_slice,
                                             d_scale_hidden_states=x_scale,
@@ -1127,8 +1128,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
                 current_hidden_states = torch.ops.hpu.mixture_of_experts(
                                             hidden_states=x,
-                                            expert_routing_table=topk_ids.to(torch.int64),
-                                            router_weights=topk_weights.to(x.dtype),
+                                            expert_routing_table=topk_ids,
+                                            router_weights=topk_weights,
                                             w12=w13_list_slice,
                                             w3=w2_list_slice,
                                             permuted_weights=True,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -160,20 +160,24 @@ class DeepseekV2MoE(nn.Module):
         num_tokens = batch_size * seq_len
         hidden_states = hidden_states.view(-1, hidden_dim)
         num_tokens = hidden_states.shape[0]
-        if self.n_shared_experts is not None:
-            shared_output = self.shared_experts(hidden_states)
+        
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
         if is_hpu:
-            final_hidden_states = self.experts(
+            moe_hidden_states = self.experts(
                 hidden_states=hidden_states.view(batch_size, seq_len, hidden_dim),
                 router_logits=router_logits) * self.routed_scaling_factor
         else:
-            final_hidden_states = self.experts(
+            moe_hidden_states = self.experts(
                 hidden_states=hidden_states,
                 router_logits=router_logits) * self.routed_scaling_factor
-        if shared_output is not None:
-            final_hidden_states = final_hidden_states + shared_output
+        
+        if self.n_shared_experts is not None:
+            final_hidden_states = self.shared_experts(hidden_states)
+            final_hidden_states.add_(moe_hidden_states)
+        else:
+            final_hidden_states = moe_hidden_states
+
         if self.tp_size > 1:
             final_hidden_states = tensor_model_parallel_all_reduce(
                 final_hidden_states)


### PR DESCRIPTION
1. Move shared expert after MoE to overlap down proj with TPC kernels.
2. Remove cast for topk_ids and topk_weights to reduce TPC operations.
3. Remove topk_ids adjustment and use experts_min/experts_max instead to reduce TPC operations.

Accuracy result:
|Tasks|Version|     Filter    |n-shot|  Metric   |  |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9591|± |0.0055|
|     |      |strict-match    |     5|exact_match|↑  |0.9583|± |0.0055|
 
 
|  Tasks |Version|  Filter   |n-shot|Metric|   |Value |  |Stderr|
|---------|------:|-----------|-----:|------|---|-----:|---|-----:|
|humaneval|      1|create_test|     0|pass@1|  |0.7683|±  | 0.033|
