### PR TITLE
Fix topk_ids dtype communication error for the DP case

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1023,9 +1023,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
                 topk_ids_across_dp = get_forward_context(
                 ).dp_metadata.topk_ids_across_dp
-                topk_ids = layer.multicast_fn(topk_ids,
+                topk_ids = layer.multicast_fn(topk_ids.to(torch.int32),
                                               cu_tokens_across_dp_cpu,
-                                              topk_ids_across_dp)
+                                              topk_ids_across_dp).long()
 
                 topk_weights_across_dp = get_forward_context(
                 ).dp_metadata.topk_weights_across_dp


### PR DESCRIPTION
HCCL does not support int64 dtype, so we need to cast topk_ids down to int32 for the DP case.
