### PR TITLE
Don't include syncing weights in compilation

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1485,6 +1485,8 @@ class QKVCrossParallelLinear(LinearBase):
     @property
     def q_proj_decoder(self) -> ColumnParallelLinear:
         layer = self.proj["q_proj_decoder"]
+        if torch.compiler.is_compiling():
+            return layer
         for name, param in self.named_parameters():
             target_param = getattr(layer, name, None)
             if target_param is not None:
@@ -1496,6 +1498,8 @@ class QKVCrossParallelLinear(LinearBase):
     @property
     def kv_proj_encoder(self) -> QKVParallelLinear:
         layer = self.proj["kv_proj_encoder"]
+        if torch.compiler.is_compiling():
+            return layer
         for name, param in self.named_parameters():
             target_param = getattr(layer, name, None)
             if target_param is not None:


### PR DESCRIPTION
Syncing weight attributes is only necessary during model loading process. Currently, it happens at every forward of the QKVCrossParallelLinear layer, which caused errors in dynamo, since it can't trace *vars* function call called inside the *sync_weight_attrs* method. I disabled the weight syncing mechanism if the model is being traced by dynamo.
