### PR TITLE
improve Deepseek-R1 accuracy by using multiply for fp8 weights dequantization

### DIFF
--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1158,13 +1158,16 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         def get_and_maybe_dequant_weights(layer: LinearBase):
             if not isinstance(layer.quant_method, UnquantizedLinearMethod):
                 if current_platform.is_hpu():
+
                     def get_scales(layer: LinearBase) -> torch.Tensor:
                         if hasattr(layer, "weight_scale_inv"):
                             return layer.weight_scale_inv
                         return layer.weight_scale
+
                     scales = get_scales(layer)
                     if len(scales.shape) == 1:
-                        ret = (layer.weight.to(act_dtype) * scales.unsqueeze(1)).to(act_dtype)
+                        ret = (layer.weight.to(act_dtype) *
+                               scales.unsqueeze(1)).to(act_dtype)
                         return ret
                 # NOTE: This should only be used offline, since it's O(N^3)
                 eye = torch.eye(layer.input_size_per_partition,

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1165,7 +1165,7 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
                         return layer.weight_scale
 
                     scales = get_scales(layer)
-                    if len(scales.shape) == 1:
+                    if len(scales.shape) < 2:
                         ret = (layer.weight.to(act_dtype) *
                                scales.unsqueeze(1)).to(act_dtype)
                         return ret

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1157,6 +1157,15 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
 
         def get_and_maybe_dequant_weights(layer: LinearBase):
             if not isinstance(layer.quant_method, UnquantizedLinearMethod):
+                if current_platform.is_hpu():
+                    def get_scales(layer: LinearBase) -> torch.Tensor:
+                        if hasattr(layer, "weight_scale_inv"):
+                            return layer.weight_scale_inv
+                        return layer.weight_scale
+                    scales = get_scales(layer)
+                    if len(scales.shape) == 1:
+                        ret = (layer.weight.to(act_dtype) * scales.unsqueeze(1)).to(act_dtype)
+                        return ret
                 # NOTE: This should only be used offline, since it's O(N^3)
                 eye = torch.eye(layer.input_size_per_partition,
                                 dtype=act_dtype,


### PR DESCRIPTION
Currtly, a fp8 GEMM is used to dequant the weights of a fp8 `Linear` layer, which impacts the accuracy slightly. This PR use `multiply` to do the dequantization.

gsm8k accuracy before PR:
vllm (pretrained=/models/DeepSeek-R1-G2,tensor_parallel_size=8,distributed_executor_backend=mp,trust_remote_code=true,max_model_len=4096,use_v2_block_manager=True,dtype=bfloat16,device=hpu), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9484|±  |0.0061|
|     |       |strict-match    |     5|exact_match|↑  |0.9484|±  |0.0061|

gsm8k accuracy before PR:
vllm (pretrained=/models/DeepSeek-R1-G2,tensor_parallel_size=8,distributed_executor_backend=mp,trust_remote_code=true,max_model_len=4096,use_v2_block_manager=True,dtype=bfloat16,device=hpu), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9530|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9515|±  |0.0059|
