### PR TITLE
Specify out_shape for block_softmax_adjustment

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@796ebed
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@dev/kdamaszke/fix-bsa-out-shape

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -9,4 +9,4 @@ numpy==1.26.4
 tabulate
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@dev/kdamaszke/fix-bsa-out-shape
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@1b642c3


### PR DESCRIPTION
Provide `out_shape` for `block_softmax_adjustment` op to handle cases with non-5D attention tensors.
PR in vllm-hpu-extension: https://github.com/HabanaAI/vllm-hpu-extension/pull/252