### PR TITLE
remove token_types for non-rerank models

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3130,7 +3130,6 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             sampling_metadata = model_input.sampling_metadata
             real_batch_size = model_input.real_batch_size
             batch_size_padded = model_input.batch_size_padded
-            tensor_types = model_input.tensor_types
             assert input_tokens is not None
             assert input_positions is not None
             assert sampling_metadata is not None
@@ -3193,7 +3192,6 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 "intermediate_tensors": intermediate_tensors,
                 "lora_mask": lora_mask,
                 "virtual_engine": model_input.virtual_engine,
-                "tensor_types": tensor_types,
                 **(model_input.multi_modal_kwargs or {}),
             }
             if previous_hidden_states is not None:

--- a/vllm/worker/hpu_pooling_model_runner.py
+++ b/vllm/worker/hpu_pooling_model_runner.py
@@ -92,7 +92,8 @@ class HPUPoolingModelRunner(
             "intermediate_tensors": intermediate_tensors,
             "lora_mask": lora_mask,
         }
-        if hasattr(model_input, "token_types") and model_input.token_types is not None:
+        if hasattr(model_input,
+                   "token_types") and model_input.token_types is not None:
             execute_model_kwargs.update(
                 {"token_type_ids": model_input.token_types})
 

--- a/vllm/worker/hpu_pooling_model_runner.py
+++ b/vllm/worker/hpu_pooling_model_runner.py
@@ -92,7 +92,7 @@ class HPUPoolingModelRunner(
             "intermediate_tensors": intermediate_tensors,
             "lora_mask": lora_mask,
         }
-        if model_input.token_types is not None:
+        if hasattr(model_input, "token_types") and model_input.token_types is not None:
             execute_model_kwargs.update(
                 {"token_type_ids": model_input.token_types})
 


### PR DESCRIPTION
Forward arguments of non-rerank models don't need token_types.
