### PR TITLE
Update Force Channel FP8 Check

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -745,10 +745,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.environ.get("VLLM_HPU_CONVERT_TO_FP8UZ", "false").lower() in
     ("1", "true"),
 
-    # Convert block fp8 to channel fp8 for HPU
+    # Convert block fp8 to channel fp8 for HPU without INC
+    # If `QUANT_CONFIG` is set, this will be forced to false.
     "VLLM_HPU_FORCE_CHANNEL_FP8":
     lambda: os.environ.get("VLLM_HPU_FORCE_CHANNEL_FP8", "true").lower() in
-    ("1", "true"),
+    ("1", "true") and os.environ.get("QUANT_CONFIG", None) is None,
+
     # Rank of the process in the data parallel setting
     "VLLM_DP_RANK":
     lambda: int(os.getenv("VLLM_DP_RANK", "0")),


### PR DESCRIPTION
Starting with1.22, INC also supports dynamic quantization. To make things smoother for users, and after discussing with @xuechendi , we plan to updat how we handle the force channel fp8 check:

- If the user provides a `QUANT_CONFIG`, we assume the intention is to use INC for either dynamic or static quantization.
- If no `QUANT_CONFIG` is provided but the user passes an FP8 model, the workflow defaults to the built-in dynamic quantization path w/o INC.

cc @thuang6 @czhu15 @yangulei 