### PR TITLE
Set hpu-extension to f3d5b09

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -6,4 +6,4 @@ ray
 triton==3.1.0
 setuptools>=77.0.3
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@ad55828
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@f3d5b09


### PR DESCRIPTION
Upgrading vllm-hpu-extension with change introducing the fused_block_softmax op.

More information on the op: https://github.com/HabanaAI/vllm-hpu-extension/pull/238

Package vllm-hpu-extension has already been merged to habana_main branch via https://github.com/HabanaAI/vllm-fork/pull/1545

