### PR TITLE
Fix exit issue

### DIFF
--- a/examples/offline_inference/qwen3_reranker.py
+++ b/examples/offline_inference/qwen3_reranker.py
@@ -78,3 +78,4 @@ if __name__ == "__main__":
     outputs = model.score(queries, documents)
 
     print([output.outputs.score for output in outputs])
+    model.llm_engine.model_executor.shutdown()


### PR DESCRIPTION
## Purpose

Fix exit issue
Exception ignored in: <function LLMEngine.__del__ at 0x7f672f8916c0>
Traceback (most recent call last):
  File "/home/mewang/workspace/vllm-fork/vllm/engine/llm_engine.py", line 520, in __del__
  File "/home/mewang/workspace/vllm-fork/vllm/executor/uniproc_executor.py", line 71, in shutdown                                                                                                                                         File "/home/mewang/workspace/vllm-fork/vllm/worker/hpu_worker.py", line 496, in shutdown
  File "/home/mewang/workspace/vllm-fork/vllm/worker/hpu_model_runner.py", line 2856, in shutdown_inc
  File "/home/mewang/workspace/vllm-fork/vllm/worker/hpu_model_runner.py", line 941, in _is_quant_with_inc                                                                                                                              AttributeError: 'NoneType' object has no attribute 'getenv'

## Test Plan

```bash
VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 python qwen3_reranker.py
```

## Test Result

The program exits without any issue