### PR TITLE
Disable merged prefill in embedding CI tests

### DIFF
--- a/.jenkins/embedding/run-tests.sh
+++ b/.jenkins/embedding/run-tests.sh
@@ -41,7 +41,6 @@ do
     export TP_SIZE=$TP_SIZE
     export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
     export VLLM_SKIP_WARMUP=true
-    export VLLM_MERGED_PREFILL=true
     export TQDM_BAR_FORMAT="{desc}: {percentage:3.0f}% {bar:10} | {n_fmt}/{total_fmt} [{elapsed}<{remaining}]" 
     RANDOM_SUFFIX=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 4; echo)
     JUNIT_FAMILY=""


### PR DESCRIPTION
Fixes GC error in embedding CI tests when merged prefill is enabled