### PR TITLE
Warmup opt: get into tp barrier in profile run only

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2864,7 +2864,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                             **execute_model_kwargs,
                             selected_token_indices=sampling_metadata.selected_token_indices
                         )
-                        if warmup_mode == True and is_dummy_run == False:
+                        if profile_run_mode == True and is_dummy_run == False:
                             torch.hpu.synchronize()
                             import torch.distributed as dist
                             if dist.is_initialized():


### PR DESCRIPTION
Warmup opt: get into tp barrier in profile run only, rather than each warmup bucket to expedite warmup progress