### PR TITLE
Fix AttributeError during shutdown of RayDistributedExecutor

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -72,8 +72,6 @@ class RayDistributedExecutor(DistributedExecutorBase):
     uses_ray: bool = True
 
     def _init_executor(self) -> None:
-        # Logger reference prevents garbage collection during shutdown()
-        self._logger = logger
         self.forward_dag: Optional[ray.dag.CompiledDAG] = None
         if envs.VLLM_USE_V1:
             # V1 uses SPMD worker and compiled DAG
@@ -129,9 +127,9 @@ class RayDistributedExecutor(DistributedExecutorBase):
         self.shutdown_workers = True
         self.terminate_ray = True
 
-    def shutdown(self) -> None:
-        if hasattr(self, '_logger') and self._logger is not None:
-            self._logger.info(
+    def shutdown(self, logger=logger) -> None:
+        if logger is not None:
+            logger.info(
                 "Shutting down Ray distributed executor. If you see error log "
                 "from logging.cc regarding SIGTERM received, please ignore "
                 "because this is the expected termination process in Ray.")


### PR DESCRIPTION
This PR fixes two issues that occurs during shutdown() of `RayDistributedExecutor`:
- It stores logger reference, so it's not destroyed before `shutdown(self)` is called
```
Exception ignored in: <function LLMEngine.__del__ at 0x7f1fb8e39f30>
Traceback (most recent call last):
  File "/workspace/vllm/vllm/engine/llm_engine.py", line 520, in __del__
  File "/workspace/vllm/vllm/executor/ray_distributed_executor.py", line 131, in shutdown
AttributeError: 'NoneType' object has no attribute 'info'
Exception ignored in: <function RayDistributedExecutor.__del__ at 0x7f1fa30aaa70>
Traceback (most recent call last):
  File "/workspace/vllm/vllm/executor/ray_distributed_executor.py", line 659, in __del__
  File "/workspace/vllm/vllm/executor/ray_distributed_executor.py", line 131, in shutdown
AttributeError: 'NoneType' object has no attribute 'info'
```
- safely executes `self._run_workers` in `shutdown(self)`
```
--- Logging error ---
Exception ignored in: <function RayDistributedExecutor.__del__ at 0x7f3c5c966a70>
Traceback (most recent call last):  
  File "/workspace/vllm/vllm/executor/ray_distributed_executor.py", line 662, in __del__  
  File "/workspace/vllm/vllm/executor/ray_distributed_executor.py", line 139, in shutdown  
  File "/workspace/vllm/vllm/executor/ray_distributed_executor.py", line 543, in _run_workers  
  File "/workspace/vllm/vllm/worker/worker_base.py", line 649, in execute_method  
  File "/usr/lib/python3.10/logging/__init__.py", line 1512, in exception  
  File "/usr/lib/python3.10/logging/__init__.py", line 1506, in error  
  File "/usr/lib/python3.10/logging/__init__.py", line 1624, in _log  
  File "/usr/lib/python3.10/logging/__init__.py", line 1634, in handle  
  File "/usr/lib/python3.10/logging/__init__.py", line 1696, in callHandlers  
  File "/usr/lib/python3.10/logging/__init__.py", line 968, in handle  
  File "/usr/lib/python3.10/logging/__init__.py", line 1108, in emit  
  File "/usr/lib/python3.10/logging/__init__.py", line 1022, in handleError  
  File "/usr/lib/python3.10/traceback.py", line 120, in print_exception  
  File "/usr/local/lib/python3.10/dist-packages/exceptiongroup/_formatting.py", line 246, in format  
  File "/usr/local/lib/python3.10/dist-packages/exceptiongroup/_formatting.py", line 62, in emit
TypeError: 'NoneType' object is not callable 
```