### PR TITLE
[aice/v1.21.0] Enable logprobs/prompt_logprobs on delayed sampling

### DIFF
--- a/vllm/worker/hpu_enc_dec_model_runner.py
+++ b/vllm/worker/hpu_enc_dec_model_runner.py
@@ -19,7 +19,8 @@ from vllm.sampling_params import SamplingParams
 from vllm.sequence import (CompletionSequenceGroupOutput, IntermediateTensors,
                            Logprob, SequenceGroupMetadata, SequenceOutput)
 from vllm.utils import bind_kv_cache, is_fake_hpu
-from vllm.worker.hpu_model_runner import (HpuModelAdapter, HPUModelRunnerBase,
+from vllm.worker.hpu_model_runner import (CachedStepOutput, HpuModelAdapter,
+                                          HPUModelRunnerBase,
                                           ModelInputForHPUWithSamplingMetadata,
                                           setup_profiler, subtuple)
 from vllm.worker.model_runner_base import (
@@ -691,7 +692,7 @@ class HPUEncoderDecoderModelRunner(
                     if num_steps > 1:
                         output = output.sampled_token_ids
                         self.cached_step_outputs.append(
-                            output.detach().clone())
+                            CachedStepOutput(output))
                 htorch.core.mark_step()
                 if i < num_steps - 1:
                     if i == 0:
@@ -784,8 +785,8 @@ class HPUEncoderDecoderModelRunner(
         sampler_outputs = []
         num_outputs = len(self.cached_step_outputs)
         for i in range(num_outputs):
-            next_token_ids = self.cached_step_outputs.pop(0)
-            next_token_ids = next_token_ids.cpu().tolist()
+            next_token_ids = self.cached_step_outputs.pop(
+                0).token_ids.cpu().tolist()
             sampler_output = self._make_decode_output(
                 next_token_ids, model_input.sampling_metadata.seq_groups)
             sampler_outputs.append(sampler_output)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -784,17 +784,20 @@ class CachedStepOutput:
     logprobs: Optional[torch.Tensor] = None
     deffered_sample_results: Optional[SampleResultArgsType] = None
     sampling_metadata: Optional[SamplingMetadata] = None
+    is_prompt: Optional[bool] = False
 
     def __init__(
             self,
             token_ids: torch.Tensor,
             logprobs: Optional[torch.Tensor] = None,
             deffered_sample_results: Optional[SampleResultArgsType] = None,
-            sampling_metadata: Optional[SamplingMetadata] = None):
+            sampling_metadata: Optional[SamplingMetadata] = None,
+            is_prompt: Optional[bool] = False):
         self.token_ids = token_ids
         self.logprobs = logprobs
         self.deffered_sample_results = deffered_sample_results
         self.sampling_metadata = sampling_metadata
+        self.is_prompt = is_prompt
 
 
 class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
@@ -3377,7 +3380,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                             CachedStepOutput(
                                 token_ids, output.logprobs,
                                 output.deferred_sample_results_args,
-                                sampling_metadata))
+                                sampling_metadata, is_prompt))
                         self.cached_step_inputs.append(model_input)
                 htorch.core.mark_step()
                 if use_delayed_sampling \

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3578,7 +3578,24 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             return
         model_input = self.cached_step_inputs.pop(0)
         model_output = self.cached_step_outputs.pop(0)
-        delayed_tokens = model_output.token_ids.cpu().squeeze(-1).tolist()
+
+        assert model_output.sampling_metadata is not None, \
+            'Sampling metadata is required to patch the output!'
+        seq_groups = model_output.sampling_metadata.seq_groups
+        logprobs_required = any(seq_group.sampling_params.logprobs is not None
+                                for seq_group in seq_groups)
+        prompt_logprobs_required = any(
+            seq_group.sampling_params.prompt_logprobs is not None
+            for seq_group in seq_groups)
+
+        if model_output.is_prompt and prompt_logprobs_required:
+            sample_idx_tensor = torch.tensor(
+                [sdx for sg in seq_groups for sdx in sg.sample_indices])
+
+            sampled_tokens = model_output.token_ids[sample_idx_tensor, :]
+            delayed_tokens = sampled_tokens.cpu().squeeze(-1).tolist()
+        else:
+            delayed_tokens = model_output.token_ids.cpu().squeeze(-1).tolist()
 
         ctx = model_input.async_callback.keywords["ctx"]  # type: ignore
         # If there's no output to patch with, which is usually the case when
@@ -3602,17 +3619,31 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         self.has_patched_prev_output = True
 
         delayed_logprobs = None
-        assert model_output.sampling_metadata is not None, \
-            'Sampling metadata is required to patch the output!'
-        logprobs_required = any(
-            seq_group.sampling_params.logprobs is not None
-            for seq_group in model_output.sampling_metadata.seq_groups)
-        if logprobs_required:
+        delayed_prompt_logprobs = None
+        if logprobs_required or prompt_logprobs_required:
+            # We are one step ahead, so prompt is already marked as a computed.
+            # We need to reset the computed tokens count to 0,
+            # so that we can recompute the prompt logprobs.
+            computed_tokens = []
+            if model_output.is_prompt:
+                for seq_group in seq_groups:
+                    seq_ids = seq_group.seq_ids
+                    assert len(seq_ids) == 1  # prompt has only 1 seq id.
+                    seq_data = seq_group.seq_data[seq_ids[0]]
+                    computed_tokens.append(seq_data.get_num_computed_tokens())
+                    seq_data._num_computed_tokens = 0
             sampling_results = get_pythonized_sample_results(
                 model_output.deffered_sample_results)
-            _, delayed_logprobs = get_logprobs(model_output.logprobs,
-                                               model_output.sampling_metadata,
-                                               sampling_results)
+            delayed_prompt_logprobs, delayed_logprobs = get_logprobs(
+                model_output.logprobs, model_output.sampling_metadata,
+                sampling_results)
+
+            # Reset the computed tokens count to the original value.
+            if model_output.is_prompt:
+                for seq_group in seq_groups:
+                    seq_ids = seq_group.seq_ids
+                    seq_data = seq_group.seq_data[seq_ids[0]]
+                    seq_data.update_num_computed_tokens(computed_tokens.pop(0))
 
         # Another hack. We need to pass the logprobs to the output data,
         # which are part of scheduler output.

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -22,6 +22,7 @@ import habana_frameworks.torch as htorch
 import habana_frameworks.torch.internal.bridge_config as bc
 import torch
 import vllm_hpu_extension.environment as environment
+from attr import dataclass
 from vllm_hpu_extension.bucketing.common import get_bucketing_context
 from vllm_hpu_extension.flags import enabled_flags
 from vllm_hpu_extension.ops import LoraMask as LoraMask
@@ -44,7 +45,10 @@ from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
-from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
+from vllm.model_executor.layers.sampler import (SampleResultArgsType,
+                                                SamplerOutput, get_logprobs,
+                                                get_pythonized_sample_results,
+                                                get_sampler)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
 from vllm.model_executor.model_loader import get_model
@@ -774,6 +778,25 @@ class ModelInputForHPUWithSamplingMetadata(ModelInputForHPU):
         return cls(**tensor_dict)
 
 
+@dataclass
+class CachedStepOutput:
+    token_ids: torch.Tensor
+    logprobs: Optional[torch.Tensor] = None
+    deffered_sample_results: Optional[SampleResultArgsType] = None
+    sampling_metadata: Optional[SamplingMetadata] = None
+
+    def __init__(
+            self,
+            token_ids: torch.Tensor,
+            logprobs: Optional[torch.Tensor] = None,
+            deffered_sample_results: Optional[SampleResultArgsType] = None,
+            sampling_metadata: Optional[SamplingMetadata] = None):
+        self.token_ids = token_ids
+        self.logprobs = logprobs
+        self.deffered_sample_results = deffered_sample_results
+        self.sampling_metadata = sampling_metadata
+
+
 class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     """
     Helper class for shared methods between GPU model runners.
@@ -884,7 +907,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         # For both multi-step scheduling and delayed sampling
         self.is_single_step = \
             self.vllm_config.scheduler_config.num_scheduler_steps == 1
-        self.cached_step_outputs: List[torch.Tensor] = []
+        self.cached_step_outputs: List[CachedStepOutput] = []
         self.is_pooler = False
         self.is_causal = is_causal
         # For delayed sampling
@@ -3087,7 +3110,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 target_indices = [
                     cur_seq_id_pos.get(psi, -1) for psi in prev_seq_ids
                 ]
-                padding = self.cached_step_outputs[i].size(0) - len(
+                padding = self.cached_step_outputs[i].token_ids.size(0) - len(
                     target_indices)
                 target_indices.extend([-1] * padding)
                 target_indices = torch.tensor(
@@ -3095,7 +3118,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     device=model_input.input_tokens.device,
                     dtype=model_input.input_tokens.dtype)
                 model_input.input_tokens.index_copy_(
-                    0, target_indices, self.cached_step_outputs[i])
+                    0, target_indices, self.cached_step_outputs[i].token_ids)
                 htorch.core.mark_step()
 
         if not model_input.is_first_multi_step:
@@ -3345,11 +3368,16 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     )
                     if num_steps > 1:
                         output = output.sampled_token_ids
-                        self.cached_step_outputs.append(output)
+                        self.cached_step_outputs.append(
+                            CachedStepOutput(output))
                     if use_delayed_sampling and self.is_driver_worker:
-                        output = self._pad_to_max_num_seqs(
+                        token_ids = self._pad_to_max_num_seqs(
                             output.sampled_token_ids, DUMMY_TOKEN_ID)
-                        self.cached_step_outputs.append(output)
+                        self.cached_step_outputs.append(
+                            CachedStepOutput(
+                                token_ids, output.logprobs,
+                                output.deferred_sample_results_args,
+                                sampling_metadata))
                         self.cached_step_inputs.append(model_input)
                 htorch.core.mark_step()
                 if use_delayed_sampling \
@@ -3481,7 +3509,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         sampler_outputs = []
         num_outputs = len(self.cached_step_outputs)
         for i in range(num_outputs):
-            next_token_ids = self.cached_step_outputs.pop(0)
+            next_token_ids = self.cached_step_outputs.pop(0).token_ids
             next_token_ids = next_token_ids.cpu().tolist()
             sampler_output = self._make_decode_output(
                 next_token_ids, model_input.sampling_metadata.seq_groups)
@@ -3549,8 +3577,9 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         if len(self.cached_step_inputs) == 0:
             return
         model_input = self.cached_step_inputs.pop(0)
-        delayed_output = self.cached_step_outputs.pop(0).cpu().squeeze(
-            -1).tolist()
+        model_output = self.cached_step_outputs.pop(0)
+        delayed_tokens = model_output.token_ids.cpu().squeeze(-1).tolist()
+
         ctx = model_input.async_callback.keywords["ctx"]  # type: ignore
         # If there's no output to patch with, which is usually the case when
         # we're starting a new request after all requests are completed.
@@ -3560,10 +3589,10 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
         output_data = ctx.output_queue[0]
         assert len(output_data.outputs) == 1
-        for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
+        for fake_out, real_out in zip(output_data.outputs[0], delayed_tokens):
             fake_out.samples[0].output_token = real_out
         for sg, real_out in zip(output_data.seq_group_metadata_list,
-                                delayed_output):
+                                delayed_tokens):
             assert len(sg.seq_data) == 1
             seq_data = list(sg.seq_data.values())[0]
             # This is a hack. Assigning output_token_ids triggers
@@ -3571,3 +3600,26 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             seq_data.output_token_ids_array[-1] = real_out
             seq_data._cached_all_token_ids[-1] = real_out
         self.has_patched_prev_output = True
+
+        delayed_logprobs = None
+        assert model_output.sampling_metadata is not None, \
+            'Sampling metadata is required to patch the output!'
+        logprobs_required = any(
+            seq_group.sampling_params.logprobs is not None
+            for seq_group in model_output.sampling_metadata.seq_groups)
+        if logprobs_required:
+            sampling_results = get_pythonized_sample_results(
+                model_output.deffered_sample_results)
+            _, delayed_logprobs = get_logprobs(model_output.logprobs,
+                                               model_output.sampling_metadata,
+                                               sampling_results)
+
+        # Another hack. We need to pass the logprobs to the output data,
+        # which are part of scheduler output.
+        if logprobs_required and delayed_logprobs is not None:
+            for sg, real_logprobs in zip(
+                    output_data.scheduler_outputs.scheduled_seq_groups,
+                    delayed_logprobs):
+                assert len(sg.seq_group.seqs) == 1
+                assert len(real_logprobs) == 1
+                sg.seq_group.first_seq.output_logprobs[-1] = real_logprobs[0]


### PR DESCRIPTION
## Purpose
enable return prompt_logprobs and logprobs when delayed sampling is on.

## Test Result

VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 vllm serve meta-llama/Meta-Llama-3-8B

root@800671-3:/# no_proxy=0.0.0.0 HF_ALLOW_CODE_EVAL=1 lm_eval --model local-completions --tasks lambada_openai,hellaswag,winogrande,piqa,mmlu,truthfulqa_mc1,openbookqa,boolq,arc_easy,arc_challenge --model_args model=meta-llama/Meta-Llama-3-8B,base_url=http://0.0.0.0:8000/v1/completions,max_gen_toks=1024 --confirm_run_unsafe_code 

2025-07-16:08:37:53 INFO     [loggers.evaluation_tracker:280] Output path not provided, skipping saving results aggregated
local-completions (model=meta-llama/Meta-Llama-3-8B,base_url=http://0.0.0.0:8000/v1/completions,max_gen_toks=1024), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|                 Tasks                 |Version|Filter|n-shot|  Metric  |   |Value |   |Stderr|
|---------------------------------------|------:|------|-----:|----------|---|-----:|---|-----:|
|arc_challenge                          |      1|none  |     0|acc       |↑  |0.5026|±  |0.0146|
|                                       |       |none  |     0|acc_norm  |↑  |0.5307|±  |0.0146|
|arc_easy                               |      1|none  |     0|acc       |↑  |0.8030|±  |0.0082|
|                                       |       |none  |     0|acc_norm  |↑  |0.7774|±  |0.0085|
|boolq                                  |      2|none  |     0|acc       |↑  |0.8113|±  |0.0068|
|hellaswag                              |      1|none  |     0|acc       |↑  |0.6018|±  |0.0049|
|                                       |       |none  |     0|acc_norm  |↑  |0.7914|±  |0.0041|
|lambada_openai                         |      1|none  |     0|acc       |↑  |0.7691|±  |0.0059|
|                                       |       |none  |     0|perplexity|↓  |3.0966|±  |0.0570|
|mmlu                                   |      2|none  |      |acc       |↑  |0.6196|±  |0.0038|
| - humanities                          |      2|none  |      |acc       |↑  |0.5484|±  |0.0066|
|  - formal_logic                       |      1|none  |     0|acc       |↑  |0.3968|±  |0.0438|
|  - high_school_european_history       |      1|none  |     0|acc       |↑  |0.7333|±  |0.0345|
|  - high_school_us_history             |      1|none  |     0|acc       |↑  |0.8039|±  |0.0279|
|  - high_school_world_history          |      1|none  |     0|acc       |↑  |0.8101|±  |0.0255|
|  - international_law                  |      1|none  |     0|acc       |↑  |0.7769|±  |0.0380|
|  - jurisprudence                      |      1|none  |     0|acc       |↑  |0.7315|±  |0.0428|
|  - logical_fallacies                  |      1|none  |     0|acc       |↑  |0.7239|±  |0.0351|
|  - moral_disputes                     |      1|none  |     0|acc       |↑  |0.6994|±  |0.0247|
|  - moral_scenarios                    |      1|none  |     0|acc       |↑  |0.2380|±  |0.0142|
|  - philosophy                         |      1|none  |     0|acc       |↑  |0.7363|±  |0.0250|
|  - prehistory                         |      1|none  |     0|acc       |↑  |0.7284|±  |0.0247|
|  - professional_law                   |      1|none  |     0|acc       |↑  |0.4583|±  |0.0127|
|  - world_religions                    |      1|none  |     0|acc       |↑  |0.8129|±  |0.0299|
| - other                               |      2|none  |      |acc       |↑  |0.7020|±  |0.0078|
|  - business_ethics                    |      1|none  |     0|acc       |↑  |0.5800|±  |0.0496|
|  - clinical_knowledge                 |      1|none  |     0|acc       |↑  |0.7358|±  |0.0271|
|  - college_medicine                   |      1|none  |     0|acc       |↑  |0.6301|±  |0.0368|
|  - global_facts                       |      1|none  |     0|acc       |↑  |0.2900|±  |0.0456|
|  - human_aging                        |      1|none  |     0|acc       |↑  |0.6547|±  |0.0319|
|  - management                         |      1|none  |     0|acc       |↑  |0.8544|±  |0.0349|
|  - marketing                          |      1|none  |     0|acc       |↑  |0.8547|±  |0.0231|
|  - medical_genetics                   |      1|none  |     0|acc       |↑  |0.8500|±  |0.0359|
|  - miscellaneous                      |      1|none  |     0|acc       |↑  |0.8135|±  |0.0139|
|  - nutrition                          |      1|none  |     0|acc       |↑  |0.7320|±  |0.0254|
|  - professional_accounting            |      1|none  |     0|acc       |↑  |0.4468|±  |0.0297|
|  - professional_medicine              |      1|none  |     0|acc       |↑  |0.7096|±  |0.0276|
|  - virology                           |      1|none  |     0|acc       |↑  |0.5482|±  |0.0387|
| - social sciences                     |      2|none  |      |acc       |↑  |0.7325|±  |0.0078|
|  - econometrics                       |      1|none  |     0|acc       |↑  |0.3947|±  |0.0460|
|  - high_school_geography              |      1|none  |     0|acc       |↑  |0.7727|±  |0.0299|
|  - high_school_government_and_politics|      1|none  |     0|acc       |↑  |0.8601|±  |0.0250|
|  - high_school_macroeconomics         |      1|none  |     0|acc       |↑  |0.6282|±  |0.0245|
|  - high_school_microeconomics         |      1|none  |     0|acc       |↑  |0.6849|±  |0.0302|
|  - high_school_psychology             |      1|none  |     0|acc       |↑  |0.8202|±  |0.0165|
|  - human_sexuality                    |      1|none  |     0|acc       |↑  |0.7710|±  |0.0369|
|  - professional_psychology            |      1|none  |     0|acc       |↑  |0.6895|±  |0.0187|
|  - public_relations                   |      1|none  |     0|acc       |↑  |0.6909|±  |0.0443|
|  - security_studies                   |      1|none  |     0|acc       |↑  |0.7429|±  |0.0280|
|  - sociology                          |      1|none  |     0|acc       |↑  |0.8308|±  |0.0265|
|  - us_foreign_policy                  |      1|none  |     0|acc       |↑  |0.8700|±  |0.0338|
| - stem                                |      2|none  |      |acc       |↑  |0.5344|±  |0.0086|
|  - abstract_algebra                   |      1|none  |     0|acc       |↑  |0.3100|±  |0.0465|
|  - anatomy                            |      1|none  |     0|acc       |↑  |0.6741|±  |0.0405|
|  - astronomy                          |      1|none  |     0|acc       |↑  |0.6776|±  |0.0380|
|  - college_biology                    |      1|none  |     0|acc       |↑  |0.7708|±  |0.0351|
|  - college_chemistry                  |      1|none  |     0|acc       |↑  |0.4300|±  |0.0498|
|  - college_computer_science           |      1|none  |     0|acc       |↑  |0.5000|±  |0.0503|
|  - college_mathematics                |      1|none  |     0|acc       |↑  |0.3900|±  |0.0490|
|  - college_physics                    |      1|none  |     0|acc       |↑  |0.3725|±  |0.0481|
|  - computer_security                  |      1|none  |     0|acc       |↑  |0.7900|±  |0.0409|
|  - conceptual_physics                 |      1|none  |     0|acc       |↑  |0.5362|±  |0.0326|
|  - electrical_engineering             |      1|none  |     0|acc       |↑  |0.5931|±  |0.0409|
|  - elementary_mathematics             |      1|none  |     0|acc       |↑  |0.4365|±  |0.0255|
|  - high_school_biology                |      1|none  |     0|acc       |↑  |0.7387|±  |0.0250|
|  - high_school_chemistry              |      1|none  |     0|acc       |↑  |0.5172|±  |0.0352|
|  - high_school_computer_science       |      1|none  |     0|acc       |↑  |0.6500|±  |0.0479|
|  - high_school_mathematics            |      1|none  |     0|acc       |↑  |0.3926|±  |0.0298|
|  - high_school_physics                |      1|none  |     0|acc       |↑  |0.3974|±  |0.0400|
|  - high_school_statistics             |      1|none  |     0|acc       |↑  |0.5139|±  |0.0341|
|  - machine_learning                   |      1|none  |     0|acc       |↑  |0.4196|±  |0.0468|
|openbookqa                             |      1|none  |     0|acc       |↑  |0.3460|±  |0.0213|
|                                       |       |none  |     0|acc_norm  |↑  |0.4480|±  |0.0223|
|piqa                                   |      1|none  |     0|acc       |↑  |0.7954|±  |0.0094|
|                                       |       |none  |     0|acc_norm  |↑  |0.8090|±  |0.0092|
|truthfulqa_mc1                         |      2|none  |     0|acc       |↑  |0.2754|±  |0.0156|
|winogrande                             |      1|none  |     0|acc       |↑  |0.7293|±  |0.0125|

|      Groups      |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------------------|------:|------|------|------|---|-----:|---|-----:|
|mmlu              |      2|none  |      |acc   |↑  |0.6196|±  |0.0038|
| - humanities     |      2|none  |      |acc   |↑  |0.5484|±  |0.0066|
| - other          |      2|none  |      |acc   |↑  |0.7020|±  |0.0078|
| - social sciences|      2|none  |      |acc   |↑  |0.7325|±  |0.0078|
| - stem           |      2|none  |      |acc   |↑  |0.5344|±  |0.0086|


