### PR TITLE
Fix AttributeError during shutdown of RayDistributedExecutor #1599 (v1.22.0)

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -72,8 +72,6 @@ class RayDistributedExecutor(DistributedExecutorBase):
     uses_ray: bool = True
 
     def _init_executor(self) -> None:
-        # Store logger reference to prevent it from being destroyed before calling self.shutdown()
-        self._logger = logger
         self.forward_dag: Optional[ray.dag.CompiledDAG] = None
         if envs.VLLM_USE_V1:
             # V1 uses SPMD worker and compiled DAG
@@ -129,12 +127,12 @@ class RayDistributedExecutor(DistributedExecutorBase):
         self.shutdown_workers = True
         self.terminate_ray = True
 
-    def shutdown(self) -> None:
-        if hasattr(self, '_logger') and self._logger is not None:
-            self._logger.info(
+    def shutdown(self, logger=logger) -> None:
+        if logger is not None:
+            logger.info(
                 "Shutting down Ray distributed executor. If you see error log "
-                "from logging.cc regarding SIGTERM received, please ignore because "
-                "this is the expected termination process in Ray.")
+                "from logging.cc regarding SIGTERM received, please ignore "
+                "because this is the expected termination process in Ray.")
         if getattr(self, 'shutdown_workers', False):
             self.shutdown_workers = False
             getattr(self._run_workers, 'shutdown', lambda: None)()

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -136,12 +136,12 @@ class RayDistributedExecutor(DistributedExecutorBase):
                 "from logging.cc regarding SIGTERM received, please ignore because "
                 "this is the expected termination process in Ray.")
         if getattr(self, 'shutdown_workers', False):
-            self._run_workers("shutdown")
             self.shutdown_workers = False
+            getattr(self._run_workers, 'shutdown', lambda: None)()
         if getattr(self, 'terminate_ray', False):
+            self.terminate_ray = False
             for worker in self.workers:
                 worker.__ray_terminate__.remote()
-            self.terminate_ray = False
         if hasattr(self, "forward_dag") and self.forward_dag is not None:
             self.forward_dag.teardown()
             import ray


### PR DESCRIPTION
Same as https://github.com/HabanaAI/vllm-fork/pull/1599, but for v1.22.0_next:
This PR fixes two issues that occur during shutdown of `RayDistributedExecutor`:
- It caches `logger` as default argument in `shutdown()`, so it's not destroyed before called
- safely executes `self._run_workers` in `shutdown(self)