### PR TITLE
Fix text-only prompt in Llama Vision

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1635,6 +1635,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             seq_lens_tensor=seq_lens_tensor,
             encoder_seq_lens=encoder_seq_lens,
             encoder_seq_lens_tensor=encoder_seq_lens_tensor,
+            max_encoder_seq_len=max(encoder_seq_lens, default=0),
             cross_slot_mapping=cross_slot_mapping,
             context_lens_tensor=context_lens_tensor,
             num_prefills=real_num_seqs,


### PR DESCRIPTION
Fixes text-only prompts in Llama Vision. Without setting `max_encoder_seq_lens` we are not skipping `cross_attention` for text-only prompts, which results in None's `key` and `value`.