### PR TITLE
[SW-235047] port PR 1629 to 1.21.3 - use w8a8 path for per_channel for performance regression fixing

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -442,7 +442,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 cutlass_block_fp8_supported=self.cutlass_block_fp8_supported,
             )
 
-        if current_platform.is_hpu():
+        if self.block_quant and current_platform.is_hpu():
             if layer.weight_scale.dim() > 1:
                 weight_scale = layer.weight_scale.transpose(0, 1)
             else:


### PR DESCRIPTION
original PR to habana_main:
https://github.com/HabanaAI/vllm-fork/pull/1629
