### PR TITLE
set device with local rank for PP>1 only

### DIFF
--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -205,7 +205,12 @@ class HPUWorker(LocalOrDistributedWorkerBase):
     def init_device(self) -> None:
         if self.device_config.device.type == "hpu":
             self.device = torch.device("hpu")
-            torch.hpu.set_device(self.local_rank)
+            if self.vllm_config.parallel_config.pipeline_parallel_size > 1:
+                # When using PCIe cards with pipeline parallelism enabled,
+                # set the HPU device using local_rank to maintain NUMA affinity.
+                torch.hpu.set_device(self.local_rank)
+            else:
+                torch.hpu.set_device(self.device)
         elif self.device_config.device_type == "cpu":
             self.device = torch.device("cpu")
         else:


### PR DESCRIPTION
Enable automatic device selection for workloads without PP.