### PR TITLE
Restrict transformers version to 4.53.3

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.51.1
+transformers >= 4.51.1, <= 4.53.3 
 huggingface-hub[hf_xet] >= 0.32.0  # Required for Xet downloads.
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.


### PR DESCRIPTION
New bug in latest transformers 4.54.0:
"ValueError: 'aimv2' is already used by a Transformers config, pick another name."

Any transformer version below this works fine. Hence restricting the version number in requirements/common.txt
