### PR TITLE
Reduce GPU mem util to 0.7 for vLLM crash on Gaudi PCIE

### DIFF
--- a/scripts/quickstart/start_vllm.sh
+++ b/scripts/quickstart/start_vllm.sh
@@ -122,7 +122,7 @@ block_size=128
 if (( max_model_len <= 16384 )); then
 	export VLLM_GPU_MEMORY_UTILIZATION=0.85
 else
-	export VLLM_GPU_MEMORY_UTILIZATION=0.75
+	export VLLM_GPU_MEMORY_UTILIZATION=0.7
 fi
 export VLLM_GRAPH_RESERVED_MEM=0.2
 export VLLM_GRAPH_PROMPT_RATIO=0


### PR DESCRIPTION
Because libfrabic need consume some HBM memory, reduce util to 0.7. Or else vLLM may crash in 32k model length (30k/2k)