### PR TITLE
Change the INC block list to improve fp8 kvcache perf

### DIFF
--- a/scripts/quant_configs/inc_quant_per_channel_with_fp8kv_config.json
+++ b/scripts/quant_configs/inc_quant_per_channel_with_fp8kv_config.json
@@ -11,15 +11,7 @@
         "types": [],
         "names": [
             "lm_head",
-            "mlp\\.gate\\b",
-            "latent_cache_k_nodeq",
-            "latent_cache_v_nodeq",
-            "latent_cache_v",
-            "kv_b_proj",
-            "matmul_qk",
-            "matmul_av",
-            "block2batch_matmul",
-            "batch2block_matmul"
+            "mlp\\.gate\\b"
         ]
     },
     "dump_stats_path": "./scripts/nc_workspace_measure_kvcache/inc_measure_output"


### PR DESCRIPTION
To remove the extra memory copy for fp8 kvcache.
And no obvious accuracy drop was seen.
