### PR TITLE
Set hpu-extension to 61dafb3

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -7,4 +7,4 @@ ray
 triton==3.1.0
 setuptools>=77.0.3
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@b2698bf
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@61dafb3


### PR DESCRIPTION
Upgrading vllm-hpu-extension with change introducing the fix for unsupported block_softmax_adjustment in fp16 precision
