### PR TITLE
Remove inference_mode() from platforms.hpu

### DIFF
--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -66,10 +66,6 @@ class HpuPlatform(Platform):
         return cls.device_name
 
     @classmethod
-    def inference_mode(cls):
-        return torch.no_grad()
-
-    @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
 
         scheduler_config = vllm_config.scheduler_config


### PR DESCRIPTION
Inference_mode() is causing recompilations with t.compile - we don't need it as we already put inference_mode on particular functions in model runner. It was introduced by Rebase 0.9.0.1 (https://github.com/HabanaAI/vllm-fork/pull/1507) - previously we didn't have such call.