### PR TITLE
Sampler output transfer from prefill to decode

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/base.py
@@ -8,7 +8,7 @@ The class provides two primary abstract methods:
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Tuple, Union, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import torch
 
@@ -161,16 +161,12 @@ class KVConnectorBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def send_sampler_output(
-        self,
-        sampling_metadata: "SamplingMetadata",
-        output: "SamplerOutput"
-    ) -> None:
+    def send_sampler_output(self, sampling_metadata: "SamplingMetadata",
+                            output: "SamplerOutput") -> None:
         raise NotImplementedError
 
     @abstractmethod
     def recv_sampler_output(
-            self,
-            sampling_metadata: "SamplingMetadata"
+            self, sampling_metadata: "SamplingMetadata"
     ) -> Optional["SamplerOutput"]:
         raise NotImplementedError

--- a/vllm/distributed/kv_transfer/kv_connector/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/base.py
@@ -12,12 +12,12 @@ from typing import TYPE_CHECKING, List, Tuple, Union, Optional
 
 import torch
 
-from vllm.model_executor import SamplingMetadata
-from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import IntermediateTensors
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.model_executor import SamplingMetadata
+    from vllm.model_executor.layers.sampler import SamplerOutput
     from vllm.worker.hpu_model_runner import (
         ModelInputForHPUWithSamplingMetadata)
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
@@ -163,14 +163,14 @@ class KVConnectorBase(ABC):
     @abstractmethod
     def send_sampler_output(
         self,
-        sampling_metadata: SamplingMetadata,
-        output: SamplerOutput
+        sampling_metadata: "SamplingMetadata",
+        output: "SamplerOutput"
     ) -> None:
         raise NotImplementedError
 
     @abstractmethod
     def recv_sampler_output(
             self,
-            sampling_metadata: SamplingMetadata
-    ) -> Optional[SamplerOutput]:
+            sampling_metadata: "SamplingMetadata"
+    ) -> Optional["SamplerOutput"]:
         raise NotImplementedError

--- a/vllm/distributed/kv_transfer/kv_connector/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/base.py
@@ -8,10 +8,12 @@ The class provides two primary abstract methods:
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Tuple, Union, Optional
 
 import torch
 
+from vllm.model_executor import SamplingMetadata
+from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import IntermediateTensors
 
 if TYPE_CHECKING:
@@ -156,4 +158,19 @@ class KVConnectorBase(ABC):
         attn_metadata: object, kv_caches: List[torch.Tensor]
     ) -> Tuple[Union[torch.Tensor, IntermediateTensors], bool,
                "ModelInputForHPUWithSamplingMetadata"]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def send_sampler_output(
+        self,
+        sampling_metadata: SamplingMetadata,
+        output: SamplerOutput
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def recv_sampler_output(
+            self,
+            sampling_metadata: SamplingMetadata
+    ) -> Optional[SamplerOutput]:
         raise NotImplementedError

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -603,10 +603,9 @@ class MooncakeStoreConnector(KVConnectorBase):
             sampler_output = self.sampler_output_decoder.decode(
                 sampler_output_bytes)
             outputs.append(sampler_output)
-            logger.debug(
-                "Get sampler output: %s, time: %s",
-                sampler_output_key,
-                time.time() - start_time)
+            logger.debug("Get sampler output: %s, time: %s",
+                         sampler_output_key,
+                         time.time() - start_time)
 
         # All the sample outputs are received
         return SamplerOutput(outputs=outputs)

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -8,15 +8,20 @@ database-style KVStore.
 """
 import hashlib
 import time
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Tuple, Union, Optional
 
 import torch
+import msgspec
+import numpy as np
 
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
+from vllm.executor.msgspec_utils import decode_hook, encode_hook
 from vllm.logger import init_logger
-from vllm.sequence import IntermediateTensors
+from vllm.model_executor import SamplingMetadata
+from vllm.model_executor.layers.sampler import SamplerOutput
+from vllm.sequence import IntermediateTensors, CompletionSequenceGroupOutput
 
 if TYPE_CHECKING:
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
@@ -84,6 +89,10 @@ class MooncakeStoreConnector(KVConnectorBase):
             (self.block_size, self.v_head_size), dtype=dtype, device="hpu")
         self.cache_k = VLLMKVCache()
         self.cache_v = VLLMKVCache()
+
+        self.sampler_output_decoder = msgspec.msgpack.Decoder(
+            CompletionSequenceGroupOutput, dec_hook=decode_hook)
+        self.sampler_output_encoder = msgspec.msgpack.Encoder(enc_hook=encode_hook)
 
     def close(self) -> None:
         """Close the buffer and release resources.
@@ -501,6 +510,95 @@ class MooncakeStoreConnector(KVConnectorBase):
     def tensor_hash(tensor: torch.Tensor) -> int:
         """Calculate the hash value of the tensor."""
         tensor_bytes = tensor.clone().detach().cpu().numpy().tobytes()
-        hash_object = hashlib.blake2b(tensor_bytes)
+        return MooncakeStoreConnector.hash_bytes(tensor_bytes)
+
+    @staticmethod
+    def hash_list(v):
+        input_bytes = np.array(v).tobytes()
+        return MooncakeStoreConnector.hash_bytes(input_bytes)
+
+    @staticmethod
+    def hash_bytes(v):
+        hash_object = hashlib.blake2b(v)
         hash_hex = hash_object.hexdigest()
         return int(hash_hex[:16], 16)
+
+    def wait_for_key(self, key, timeout_in_seconds):
+        if timeout_in_seconds is None:
+            # default to 10 minutes
+            timeout_in_seconds = 60 * 10
+        timeout = time.time() + timeout_in_seconds
+        while self.kv_store.is_exist(key) is False:
+            if time.time() > timeout:
+                return False
+            time.sleep(0.01)
+        return True
+
+    def get_sampler_output_key(self, seq_group_to_sample):
+        # Use first seq data for prompt tokens
+        prompt_token_ids = seq_group_to_sample.seq_data[0].prompt_token_ids
+        sampling_params = seq_group_to_sample.sampling_params
+
+        # Prepare the store key
+        prompt_prefix = self.hash_list(prompt_token_ids)
+        sampling_bytes = self.sampler_output_encoder.encode(
+            sampling_params)
+        sampling_prefix = self.hash_bytes(sampling_bytes)
+        sampler_output_key = f"{prompt_prefix}_sampling_{sampling_prefix}_{self.rank}"
+        return sampler_output_key
+
+    def send_sampler_output(
+            self,
+            sampling_metadata: SamplingMetadata,
+            output: SamplerOutput
+    ) -> None:
+        seq_groups_to_sample = sampling_metadata.seq_groups
+        outputs = output.outputs
+        assert len(seq_groups_to_sample) == len(outputs),\
+            "Sequence groups to sample must be the same size with the sampler outputs."
+        for seq_group_to_sample, sampler_output_of_seq_group in zip(
+                seq_groups_to_sample, outputs):
+            start_time = time.time()
+            sampler_output_key = self.get_sampler_output_key(seq_group_to_sample)
+
+            # Use msgpack to encode to bytes
+            sampler_output_bytes = self.sampler_output_encoder.encode(
+                sampler_output_of_seq_group)
+
+            self.kv_store.put_bytes(sampler_output_key, sampler_output_bytes)
+            logger.debug(
+                "Put sampler output: %s, time: %s",
+                sampler_output_key, time.time() - start_time)
+
+    def recv_sampler_output(
+            self, sampling_metadata: SamplingMetadata
+    ) -> Optional[SamplerOutput]:
+        seq_groups_to_sample = sampling_metadata.seq_groups
+        outputs: List[CompletionSequenceGroupOutput] = []
+        for seq_group_to_sample in seq_groups_to_sample:
+            start_time = time.time()
+            sampler_output_key = self.get_sampler_output_key(seq_group_to_sample)
+            if not self.wait_for_key(sampler_output_key, 10):
+                logger.warning(
+                    "Sampler output with key: %s is not ready in 10 seconds",
+                    sampler_output_key)
+                return None
+
+            sampler_output_bytes = self.kv_store.get_bytes(sampler_output_key)
+            if not sampler_output_bytes:
+                logger.warning(
+                    "Sampler output with key: %s doesn't exist",
+                    sampler_output_key)
+                return None
+
+            # Use msgpack to decode the bytes to CompletionSequenceGroupOutput
+            sampler_output = self.sampler_output_decoder.decode(
+                sampler_output_bytes)
+            outputs.append(sampler_output)
+            logger.debug(
+                "Get sampler output: %s, time: %s",
+                sampler_output_key, time.time() - start_time)
+
+        # All the sample outputs are received
+        return SamplerOutput(
+            outputs=outputs)

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
@@ -235,6 +235,25 @@ class MooncakeStore(KVLookupBufferBase):
             return tensor
         return None
 
+    def put_bytes(
+        self,
+        key: str,
+        value: bytes,
+    ) -> None:
+        """Put bytes data to Mooncake Store"""
+        try:
+            self.store.put(key, value)
+        except TypeError as err:
+            logger.error("Failed to put value into Mooncake Store: %s", err)
+            raise TypeError("Mooncake Store Put Type Error.") from err
+
+    def get_bytes(self, key: str) -> bytes:
+        try:
+            return self.store.get(key)
+        except TypeError as err:
+            logger.error("Failed to get value from Mooncake Store: %s", err)
+            raise TypeError("Mooncake Store Get Type Error.") from err
+
     def is_exist(self, key: str) -> bool:
         """Check if the key exists in the Mooncake Store"""
         return self.store.isExist(key) == 1

--- a/vllm/distributed/kv_transfer/kv_transfer_agent.py
+++ b/vllm/distributed/kv_transfer/kv_transfer_agent.py
@@ -5,7 +5,10 @@ This implementation is a shim wrapper on two APIs exposed by `kv_connector`:
 1. `send_kv_caches_and_hidden_states`
 2. `recv_kv_caches_and_hidden_states
 """
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Tuple, Union, Optional
+
+from vllm.model_executor import SamplingMetadata
+from vllm.model_executor.layers.sampler import SamplerOutput
 
 if TYPE_CHECKING:
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
@@ -110,3 +113,16 @@ class KVTransferAgent:
                "ModelInputForHPUWithSamplingMetadata"]:
         return self.connector.recv_kv_caches_and_hidden_states_hpu(
             model_executable, model_input, attn_metadata, kv_caches)
+
+    def send_sampler_output(
+        self,
+        sampling_metadata: SamplingMetadata,
+        output: SamplerOutput
+    ) -> None:
+        self.connector.send_sampler_output(sampling_metadata, output)
+
+    def recv_sampler_output(
+            self,
+            sampling_metadata: SamplingMetadata
+    ) -> Optional[SamplerOutput]:
+        return self.connector.recv_sampler_output(sampling_metadata)

--- a/vllm/distributed/kv_transfer/kv_transfer_agent.py
+++ b/vllm/distributed/kv_transfer/kv_transfer_agent.py
@@ -7,10 +7,9 @@ This implementation is a shim wrapper on two APIs exposed by `kv_connector`:
 """
 from typing import TYPE_CHECKING, List, Tuple, Union, Optional
 
-from vllm.model_executor import SamplingMetadata
-from vllm.model_executor.layers.sampler import SamplerOutput
-
 if TYPE_CHECKING:
+    from vllm.model_executor import SamplingMetadata
+    from vllm.model_executor.layers.sampler import SamplerOutput
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
     from vllm.worker.hpu_model_runner import \
         ModelInputForHPUWithSamplingMetadata
@@ -116,13 +115,13 @@ class KVTransferAgent:
 
     def send_sampler_output(
         self,
-        sampling_metadata: SamplingMetadata,
-        output: SamplerOutput
+        sampling_metadata: "SamplingMetadata",
+        output: "SamplerOutput"
     ) -> None:
         self.connector.send_sampler_output(sampling_metadata, output)
 
     def recv_sampler_output(
             self,
-            sampling_metadata: SamplingMetadata
-    ) -> Optional[SamplerOutput]:
+            sampling_metadata: "SamplingMetadata"
+    ) -> Optional["SamplerOutput"]:
         return self.connector.recv_sampler_output(sampling_metadata)

--- a/vllm/distributed/kv_transfer/kv_transfer_agent.py
+++ b/vllm/distributed/kv_transfer/kv_transfer_agent.py
@@ -5,7 +5,7 @@ This implementation is a shim wrapper on two APIs exposed by `kv_connector`:
 1. `send_kv_caches_and_hidden_states`
 2. `recv_kv_caches_and_hidden_states
 """
-from typing import TYPE_CHECKING, List, Tuple, Union, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from vllm.model_executor import SamplingMetadata
@@ -113,15 +113,11 @@ class KVTransferAgent:
         return self.connector.recv_kv_caches_and_hidden_states_hpu(
             model_executable, model_input, attn_metadata, kv_caches)
 
-    def send_sampler_output(
-        self,
-        sampling_metadata: "SamplingMetadata",
-        output: "SamplerOutput"
-    ) -> None:
+    def send_sampler_output(self, sampling_metadata: "SamplingMetadata",
+                            output: "SamplerOutput") -> None:
         self.connector.send_sampler_output(sampling_metadata, output)
 
     def recv_sampler_output(
-            self,
-            sampling_metadata: "SamplingMetadata"
+            self, sampling_metadata: "SamplingMetadata"
     ) -> Optional["SamplerOutput"]:
         return self.connector.recv_sampler_output(sampling_metadata)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -626,6 +626,8 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_PP_USE_CPU_COMS", "0"))),
     "VLLM_USE_ASYNC_TRANSFER_IN_PD":
     lambda: bool(int(os.getenv("VLLM_USE_ASYNC_TRANSFER_IN_PD", "0"))),
+    "VLLM_USE_PREFILL_OUTPUT":
+    lambda: bool(int(os.getenv("VLLM_USE_PREFILL_OUTPUT", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -96,6 +96,7 @@ if TYPE_CHECKING:
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_USE_ASYNC_TRANSFER_IN_PD: bool = False
+    VLLM_USE_PREFILL_OUTPUT: bool = False
 
 
 def get_default_cache_root():

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -797,6 +797,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             max_workers=1)
         self.use_async_kv_transfer_in_pd = envs.VLLM_USE_ASYNC_TRANSFER_IN_PD
         logger.info("will use async pd: %s", self.use_async_kv_transfer_in_pd)
+        self.use_prefill_output = envs.VLLM_USE_PREFILL_OUTPUT
+        logger.info("will use prefill output: %s", self.use_prefill_output)
 
     def _set_gc_threshold(self) -> None:
         """
@@ -2864,7 +2866,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 # received KV caches
                 # NOTE: The receive operation is blocking
                 bypass_model_exec = False
-                if self.need_recv_kv(model_input, kv_caches, warmup_mode):
+                need_recv_kv = self.need_recv_kv(model_input, kv_caches, warmup_mode)
+                if need_recv_kv:
                     # we assume kv cache is recved and put into the dict!
                     def tensor_hash(tensor: torch.Tensor) -> int:
                         """Calculate the hash value of the tensor."""
@@ -3008,7 +3011,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 # Sending KV cache in distributed KV cache transfer setting
                 # NOTE: the send operation is non-blocking
 
-                if self.need_send_kv(model_input, kv_caches, warmup_mode):
+                need_send_kv = self.need_send_kv(model_input, kv_caches, warmup_mode)
+                if need_send_kv:
                     cur_time = time.time()
 
                     def sync_send_kv_caches(hidden_states):
@@ -3146,6 +3150,13 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 if not self.is_driver_worker:
                     return []
 
+                # Need receive the output from prefill
+                if need_recv_kv and self.use_prefill_output:
+                    output = self.recv_prefill_output(sampling_metadata)
+                    if output is not None:
+                        return [output]
+                    # Sample to get output if failed to get from prefill
+
                 is_prev_output_patched = False
                 if use_delayed_sampling:
                     fake_output = self._delayed_sampler_outputs(model_input)
@@ -3177,6 +3188,10 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         logits=logits,
                         sampling_metadata=sampling_metadata,
                     )
+                    # Note: speculative decoding, multi-step and delayed sampling
+                    # are not supported for this logic
+                    if need_send_kv and self.use_prefill_output:
+                        self.send_prefill_output(sampling_metadata, output)
                     if num_steps > 1:
                         output = output.sampled_token_ids
                         self.cached_step_outputs.append(output)
@@ -3390,3 +3405,14 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             seq_data.output_token_ids_array[-1] = real_out
             seq_data._cached_all_token_ids[-1] = real_out
         self.has_patched_prev_output = True
+
+    def send_prefill_output(self, sampling_metadata, output):
+        get_kv_transfer_group().send_sampler_output(
+            sampling_metadata,
+            output
+        )
+
+    def recv_prefill_output(self, sampling_metadata):
+        # Since the output is small we do a sync receive
+        return get_kv_transfer_group().recv_sampler_output(
+            sampling_metadata)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2866,7 +2866,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 # received KV caches
                 # NOTE: The receive operation is blocking
                 bypass_model_exec = False
-                need_recv_kv = self.need_recv_kv(model_input, kv_caches, warmup_mode)
+                need_recv_kv = self.need_recv_kv(model_input, kv_caches,
+                                                 warmup_mode)
                 if need_recv_kv:
                     # we assume kv cache is recved and put into the dict!
                     def tensor_hash(tensor: torch.Tensor) -> int:
@@ -3011,7 +3012,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 # Sending KV cache in distributed KV cache transfer setting
                 # NOTE: the send operation is non-blocking
 
-                need_send_kv = self.need_send_kv(model_input, kv_caches, warmup_mode)
+                need_send_kv = self.need_send_kv(model_input, kv_caches,
+                                                 warmup_mode)
                 if need_send_kv:
                     cur_time = time.time()
 
@@ -3407,12 +3409,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         self.has_patched_prev_output = True
 
     def send_prefill_output(self, sampling_metadata, output):
-        get_kv_transfer_group().send_sampler_output(
-            sampling_metadata,
-            output
-        )
+        get_kv_transfer_group().send_sampler_output(sampling_metadata, output)
 
     def recv_prefill_output(self, sampling_metadata):
         # Since the output is small we do a sync receive
-        return get_kv_transfer_group().recv_sampler_output(
-            sampling_metadata)
+        return get_kv_transfer_group().recv_sampler_output(sampling_metadata)


### PR DESCRIPTION
## Purpose
Currently both prefill and decode phase generate the first token for P/D disaggregation case. Ideally, we use the first token generate from the prefill phase and transfer the sampler output from prefill to decode so that we get the same output from both prefill and decode without sampling twice.

One note to the difference with KV cache transfer. KV cache is key on the prompt token ids only. The sampler output is more than depending on the prompt token ids, it also depends on the sampling params. It is possible that there are two requests with the same prompt token ids but with different sampling params which we expect different sample outputs. Due to this, the transfer of sample output cannot be combined directly into the KV cache logic.

Considering the sampler output is relatively small, we currently implement only the sync transfer.

## Test Plan
Run 1P and 1D instance with VLLM_USE_PREFILL_OUTPUT environment variable set to True.