### PR TITLE
Fixes HPU graph run for Gemma3 vision inputs

### DIFF
--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -413,6 +413,12 @@ class Gemma3Model(nn.Module):
         inputs_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[torch.Tensor, IntermediateTensors]:
+
+        print(f"Gemma3Model : input_ids:{input_ids.shape if input_ids is not None else input_ids}, "
+              f"positions:{positions.shape}, inputs_embeds:{inputs_embeds.shape if inputs_embeds is not None else inputs_embeds}, "
+              f"intermediate_tensors:{intermediate_tensors.shape if intermediate_tensors is not None else intermediate_tensors}, "
+              f"kwargs{kwargs}")
+
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds

--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -569,28 +569,35 @@ class Gemma3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
         pixel_values = image_input["pixel_values"]
         num_patches = image_input["num_patches"]
 
-        image_features = self._image_pixels_to_features(
-            self.vision_tower,
-            pixel_values,
-        )
-
-        if is_hpu and len(self.graphed_multimodal_buckets) > 1:
+        if is_hpu:
             batch_breakdown = greedy_plan(pixel_values.shape[0], \
                     self.vision_buckets.multimodal_buckets)
             start_idx = 0
             image_embeds_multibatches = []
 
+            #print("batch_breakdown: ", batch_breakdown)
             for i in batch_breakdown:
                 end_idx = start_idx + i
                 indices = torch.arange(start_idx, end_idx)
-                batch_sliced_image_features = torch.index_select(
-                    image_features, dim=0, index=indices)
+                batch_sliced_pixel_values = torch.index_select(
+                    pixel_values, dim=0, index=indices)
+
+                #print("Input to VisionTower:", batch_sliced_pixel_values.shape)
+                image_features = self._image_pixels_to_features(
+                    self.vision_tower,
+                    batch_sliced_pixel_values,
+                )
+                #print("Input to MultiModal: ", image_features.shape)
                 image_embeds_multibatches += \
                             [self.multi_modal_projector(
-                                batch_sliced_image_features)]
+                                image_features)]
                 start_idx = end_idx
             image_embeds = torch.cat(image_embeds_multibatches, dim=0)
         else:
+            image_features = self._image_pixels_to_features(
+                    self.vision_tower,
+                    pixel_values,
+            )
             image_embeds = self.multi_modal_projector(image_features)
         return [
             e.flatten(0, 1) for e in image_embeds.split(num_patches.tolist())

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -476,6 +476,7 @@ class SiglipVisionModel(nn.Module):
         interpolate_pos_encoding: bool = False,
         feature_sample_layers: Optional[list[int]] = None,
     ) -> torch.Tensor:
+        print("Gemma3VisionTower : ", pixel_values.shape)
         return self.vision_model(
             pixel_values=pixel_values,
             interpolate_pos_encoding=interpolate_pos_encoding,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -371,7 +371,7 @@ class HpuModelAdapter(torch.nn.Module):
             if self.is_mm_optimized:
                 if hasattr(self.model, 'vision_tower'):
                     self.model.vision_tower = htorch.hpu.wrap_in_hpu_graph(
-                        self.model.vision_tower, disable_tensor_cache=True)
+                        self.model.vision_tower, disable_tensor_cache=False)
                 if hasattr(self.model, 'multi_modal_projector'):
                     self.model.multi_modal_projector = \
                             htorch.hpu.wrap_in_hpu_graph( \

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -622,11 +622,13 @@ class HpuModelAdapter(torch.nn.Module):
         inputs_embeds = self.model.get_input_embeddings(
             input_ids, vision_embeddings)
 
-        #TODO: In warmup, we need to warmup the model with dummy image data for
-        #multimodal model, here instead of generating a dummy image, we are just
-        #generating attn_mask for the images and pass with attn_metadata, so we
-        #can reuse HPU graph without running the whole vision tower.
-        if vision_embeddings is not None or warmup_mode:
+        # TODO: In warmup, we need to warmup the model with dummy image data for
+        # multimodal model for prompt, here instead of generating a dummy image,
+        # we are just generating attn_mask for the images and pass with
+        # attn_metadata, so we can reuse HPU graph without running
+        # the whole vision tower.
+        if vision_embeddings is not None or (
+            warmup_mode &  kwargs['attn_metadata'].is_prompt):
             input_ids = kwargs['input_ids']
             positions = kwargs['positions']
             kwargs = self.model.prepare_attn_masks(


### PR DESCRIPTION
Fixes HPU graph issues for gemma3 vision inputs

    -Text warmup to include mask info, so vision data can use the same
    graph for language model that's warmed up already.
    -Changing slicing to index_select for multimodal bucketing for HPU
    graph to work(otherwise hashkey is different)
