### PR TITLE
disable select_token_indices adjust for decode

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2405,9 +2405,26 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             lora_requests = decode_lora_requests
             lora_ids = decode_lora_ids
 
+        if self.lora_config:
+            lora_mapping = LoRAMapping(
+                **dict(index_mapping=lora_index_mapping,
+                       prompt_mapping=lora_prompt_mapping,
+                       is_prefill=(num_prefills > 0)))
+        else:
+            lora_mapping = None
+
+        if (prefill_attn_metadata is not None
+                and decode_attn_metadata is not None):
+            batch_type = BatchType.MIXED
+            raise NotImplementedError("Mixed batch is not supported on HPU")
+        elif prefill_attn_metadata is not None:
+            batch_type = BatchType.PREFILL
+        else:
+            batch_type = BatchType.DECODE
+
         if self.is_pooler:
             sampling_metadata = None
-        elif not self.use_merged_prefill:
+        elif not self.use_merged_prefill and batch_type != BatchType.DECODE:
             # FIXME: We need to adjust selected_token_indices to accommodate
             # for padding
             max_len = input_tokens.size(1)
@@ -2428,23 +2445,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 dtype=sampling_metadata.selected_token_indices.dtype,
                 device=sampling_metadata.selected_token_indices.device)
             sampling_metadata.selected_token_indices.add_(paddings)
-
-        if self.lora_config:
-            lora_mapping = LoRAMapping(
-                **dict(index_mapping=lora_index_mapping,
-                       prompt_mapping=lora_prompt_mapping,
-                       is_prefill=(num_prefills > 0)))
-        else:
-            lora_mapping = None
-
-        if (prefill_attn_metadata is not None
-                and decode_attn_metadata is not None):
-            batch_type = BatchType.MIXED
-            raise NotImplementedError("Mixed batch is not supported on HPU")
-        elif prefill_attn_metadata is not None:
-            batch_type = BatchType.PREFILL
-        else:
-            batch_type = BatchType.DECODE
 
         metadata_dict = {
             "input_tokens": input_tokens,


### PR DESCRIPTION
# Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

This PR suggests to skip select_token_indices adjustment for decode batch
decode batch select_token_indices adjustment padding is always bs * [0], so seems the adjustment is not needed.

Verified gsm8k accuracy, no impact

From host overhead point of view

Before:
0.06ms will be in each step to prepare the padding and copy from H2D.
<img width="814" height="352" alt="image" src="https://github.com/user-attachments/assets/46460c73-0126-4f26-b3d4-0f990ee6160d" />

with this PR:
This 0.06ms will be removed
<img width="1120" height="472" alt="image" src="https://github.com/user-attachments/assets/bf4bdf68-d68e-44b2-8ab8-5b0c85e53cdd" />




## Test Plan

## Test Result

## (Optional) Documentation Update

