### PR TITLE
remove unnecessary redundant check for mrope

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1095,8 +1095,11 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     @property
     def model_is_mrope(self) -> bool:
-        config = self.model_config.hf_config
-        return uses_mrope(config)
+        self._model_is_mrope = getattr(self, '_model_is_mrope', None)
+        if self._model_is_mrope is None:
+            config = self.model_config.hf_config
+            self._model_is_mrope = uses_mrope(config)
+        return self._model_is_mrope
 
     def _is_quant_with_inc(self):
         quant_config = os.getenv("QUANT_CONFIG", None) is not None


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

Found current m_rope  check is always call transformer API, which leads to a deeper python stack and longer CPU time

Before:
thinker_uses_mrope is called 33 times => leads to model_is_mrope spent 0.097ms.
<img width="1682" height="573" alt="image" src="https://github.com/user-attachments/assets/f5de5586-8aa9-4028-b1ba-05b85dc6eaa1" />


With this PR:
we removed thinker_uses_mrope call (only call once to set local property) => leads to model_is_mrope only spends 0.006ms
<img width="1685" height="548" alt="image" src="https://github.com/user-attachments/assets/1b311199-e1a6-4dc5-b663-e2592fe18a57" />



## Test Plan

## Test Result

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
