### PR TITLE
[SW-234412] [1.22] disable disable markstep with flag

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -107,6 +107,7 @@ if TYPE_CHECKING:
     VLLM_HPU_USE_DELAYED_SAMPLING: bool = False
     VLLM_HPU_FORCE_CHANNEL_FP8: bool = True
     VLLM_HPU_CONVERT_TO_FP8UZ: bool = True
+    VLLM_HPU_FORCE_MARK_STEP: bool = True
     VLLM_DP_RANK: int = 0
     VLLM_DP_RANK_LOCAL: int = -1
     VLLM_DP_SIZE: int = 1
@@ -738,6 +739,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # between each step.
     "VLLM_HPU_USE_DELAYED_SAMPLING":
     lambda: os.environ.get("VLLM_DELAYED_SAMPLING", "false").lower() in
+    ("1", "true"),
+
+    # Do mark_step for HPU to split hpu graph or prevent fused kernel
+    "VLLM_HPU_FORCE_MARK_STEP":
+    lambda: os.environ.get("VLLM_HPU_FORCE_MARK_STEP", "true").lower() in
     ("1", "true"),
 
     # Converts model weights to FP8UZ format.

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1034,6 +1034,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         ]  #TODO: Move to HPUBucketingContext
         self.graphed_multimodal_buckets: Set[Any] = set()
         self.use_contiguous_pa = envs.VLLM_USE_HPU_CONTIGUOUS_CACHE_FETCH
+        self.do_mark_step = envs.VLLM_HPU_FORCE_MARK_STEP
 
         # Data Parallel
         self.dp_size = vllm_config.parallel_config.data_parallel_size
@@ -1231,12 +1232,13 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             hidden_layer_markstep_interval = int(
                 os.getenv('VLLM_CONFIG_HIDDEN_LAYERS', '1'))
             model_config = getattr(self.model, "config", None)
-            modify_model_layers(
-                self.model,
-                get_target_layer_suffix_list(
-                    model_config.
-                    model_type if model_config is not None else None),
-                hidden_layer_markstep_interval)
+            if self.do_mark_step:
+                modify_model_layers(
+                    self.model,
+                    get_target_layer_suffix_list(
+                        model_config.
+                        model_type if model_config is not None else None),
+                    hidden_layer_markstep_interval)
             torch.hpu.synchronize()
 
             if self.is_pooler:
@@ -3976,7 +3978,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         sampling_metadata.selected_token_indices = None
                     logits = self.model.compute_logits(hidden_states,
                                                        sampling_metadata)
-                htorch.core.mark_step()
+                if self.do_mark_step:
+                    htorch.core.mark_step()
                 # Only perform sampling in the driver worker.
                 if not self.is_driver_worker:
                     continue
@@ -4010,7 +4013,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                                 output.deferred_sample_results_args,
                                 sampling_metadata, is_prompt))
                         self.cached_step_inputs.append(model_input)
-                htorch.core.mark_step()
+                if self.do_mark_step:
+                    htorch.core.mark_step()
                 if use_delayed_sampling \
                    and model_input.async_callback is not None:
                     model_input.async_callback()


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

add an env flag to mark_step between Embedding -> (mark_step) -> model_fwd ->(mark_step) -> LM_head
Before:
There are 3 seperate execute_cached_graph, and host time is 0.63ms
<img width="1676" height="390" alt="image" src="https://github.com/user-attachments/assets/39336a9b-78e0-4967-ae8d-ac4dd173ef82" />

With this PR:
Now we only do one execute_cached_graph, host time is 0.61ms
<img width="1407" height="376" alt="image" src="https://github.com/user-attachments/assets/856be900-e7d3-402c-9694-80a5c8df53ea" />



## Test Plan

## Test Result

<!--- pyml disable-next-line no-emphasis-as-heading -->
