### PR TITLE
First token from decode for non stream case

### DIFF
--- a/examples/online_serving/disagg_examples/disagg_proxy_demo.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_demo.py
@@ -407,12 +407,20 @@ class Proxy:
             except HTTPException as http_exc:
                 self.remove_instance_endpoint("decode", decode_instance)
                 raise http_exc
-            final_generator = self.generator(generator_p,
-                                             generator_d,
-                                             self,
-                                             prefill_instance,
-                                             decode_instance,
-                                             req_len=total_length)
+            if request.get("stream"):
+                final_generator = self.generator(generator_p,
+                                                 generator_d,
+                                                 self,
+                                                 prefill_instance,
+                                                 decode_instance,
+                                                 req_len=total_length)
+            else:
+                final_generator = D_first_token_generator(generator_p,
+                                                          generator_d,
+                                                          self,
+                                                          prefill_instance,
+                                                          decode_instance,
+                                                          req_len=total_length)
             response = StreamingResponse(final_generator,
                                          media_type="application/json")
             return response

--- a/examples/online_serving/disagg_examples/disagg_proxy_demo.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_demo.py
@@ -407,20 +407,18 @@ class Proxy:
             except HTTPException as http_exc:
                 self.remove_instance_endpoint("decode", decode_instance)
                 raise http_exc
-            if request.get("stream"):
-                final_generator = self.generator(generator_p,
-                                                 generator_d,
-                                                 self,
-                                                 prefill_instance,
-                                                 decode_instance,
-                                                 req_len=total_length)
+
+            if request.get("stream", False):
+                generator_class = self.generator
             else:
-                final_generator = D_first_token_generator(generator_p,
-                                                          generator_d,
-                                                          self,
-                                                          prefill_instance,
-                                                          decode_instance,
-                                                          req_len=total_length)
+                # For stream=False request, cannot use P first token
+                generator_class = D_first_token_generator
+            final_generator = generator_class(generator_p,
+                                              generator_d,
+                                              self,
+                                              prefill_instance,
+                                              decode_instance,
+                                              req_len=total_length)
             response = StreamingResponse(final_generator,
                                          media_type="application/json")
             return response
@@ -484,12 +482,18 @@ class Proxy:
             except HTTPException as http_exc:
                 self.remove_instance_endpoint("decode", decode_instance)
                 raise http_exc
-            final_generator = self.generator(generator_p,
-                                             generator_d,
-                                             self,
-                                             prefill_instance,
-                                             decode_instance,
-                                             req_len=total_length)
+
+            if request.get("stream", False):
+                generator_class = self.generator
+            else:
+                # For stream=False request, cannot use P first token
+                generator_class = D_first_token_generator
+            final_generator = generator_class(generator_p,
+                                              generator_d,
+                                              self,
+                                              prefill_instance,
+                                              decode_instance,
+                                              req_len=total_length)
             response = StreamingResponse(final_generator,
                                          media_type="application/json")
             return response

--- a/examples/online_serving/disagg_examples/disagg_proxy_demo_benchmark.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_demo_benchmark.py
@@ -425,8 +425,17 @@ class Proxy:
             except HTTPException as http_exc:
                 self.remove_instance_endpoint("decode", decode_instance)
                 raise http_exc
-            final_generator = self.generator(generator_p, generator_d, self,
-                                             prefill_instance, decode_instance)
+
+            if request.get("stream", False):
+                generator_class = self.generator
+            else:
+                # For stream=False request, cannot use P first token
+                generator_class = D_first_token_generator
+            final_generator = generator_class(generator_p,
+                                              generator_d,
+                                              self,
+                                              prefill_instance,
+                                              decode_instance)
             response = StreamingResponse(final_generator)
             return response
         except Exception:
@@ -481,8 +490,17 @@ class Proxy:
             except HTTPException as http_exc:
                 self.remove_instance_endpoint("decode", decode_instance)
                 raise http_exc
-            final_generator = self.generator(generator_p, generator_d, self,
-                                             prefill_instance, decode_instance)
+
+            if request.get("stream", False):
+                generator_class = self.generator
+            else:
+                # For stream=False request, cannot use P first token
+                generator_class = D_first_token_generator
+            final_generator = generator_class(generator_p,
+                                              generator_d,
+                                              self,
+                                              prefill_instance,
+                                              decode_instance)
             response = StreamingResponse(final_generator)
             return response
         except Exception:


### PR DESCRIPTION
## Purpose
For request with stream=False, the output will be incorrect if we use the first chunk from prefill and skipped the first trunk from decode. Because when stream=False,  each decode chunk possibly contains multiple tokens which result wrong output if skipped.

We should not use prefill output and skipped the first decode chunk for non-steam case.