### PR TITLE
link to the correct vllm-hpu-extention branch

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -7,4 +7,4 @@ ray
 triton==3.1.0
 setuptools>=77.0.3
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@b6d48ef
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@aice/v1.22.0


### PR DESCRIPTION
The vllm-fork aice/v1.22.0 branch will always use vllm-hpu-extention aice/v1.22.0 branch
