### PR TITLE
Sampler output transfer from prefill to decode

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/base.py
@@ -8,7 +8,7 @@ The class provides two primary abstract methods:
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import torch
 
@@ -16,6 +16,8 @@ from vllm.sequence import IntermediateTensors
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.model_executor import SamplingMetadata
+    from vllm.model_executor.layers.sampler import SamplerOutput
     from vllm.worker.hpu_model_runner import (
         ModelInputForHPUWithSamplingMetadata)
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
@@ -156,4 +158,15 @@ class KVConnectorBase(ABC):
         attn_metadata: object, kv_caches: List[torch.Tensor]
     ) -> Tuple[Union[torch.Tensor, IntermediateTensors], bool,
                "ModelInputForHPUWithSamplingMetadata"]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def send_sampler_output(self, sampling_metadata: "SamplingMetadata",
+                            output: "SamplerOutput") -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def recv_sampler_output(
+            self, sampling_metadata: "SamplingMetadata"
+    ) -> Optional["SamplerOutput"]:
         raise NotImplementedError

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -590,6 +590,8 @@ class MooncakeStoreConnector(KVConnectorBase):
         outputs: List[CompletionSequenceGroupOutput] = []
         for seq_group_to_sample in seq_groups_to_sample:
             if not seq_group_to_sample.seq_data:
+                logger.warning(
+                    "Sequence data of sequence group to sample is empty")
                 return None
             start_time = time.time()
             sampler_output_key = self.get_sampler_output_key(

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -531,17 +531,6 @@ class MooncakeStoreConnector(KVConnectorBase):
         hash_hex = hash_object.hexdigest()
         return int(hash_hex[:16], 16)
 
-    def wait_for_key(self, key, timeout_in_seconds):
-        if timeout_in_seconds is None:
-            # default to 10 minutes
-            timeout_in_seconds = 60 * 10
-        timeout = time.time() + timeout_in_seconds
-        while self.kv_store.is_exist(key) is False:
-            if time.time() > timeout:
-                return False
-            time.sleep(0.01)
-        return True
-
     def get_sampler_output_key(self, seq_group_to_sample):
         # Use first seq data for prompt tokens
         first_seq_data = next(iter(seq_group_to_sample.seq_data.values()))
@@ -596,7 +585,7 @@ class MooncakeStoreConnector(KVConnectorBase):
             start_time = time.time()
             sampler_output_key = self.get_sampler_output_key(
                 seq_group_to_sample)
-            if not self.wait_for_key(sampler_output_key, 10):
+            if not self._wait_for_key(sampler_output_key):
                 logger.warning(
                     "Sampler output with key: %s is not ready in 10 seconds",
                     sampler_output_key)

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
@@ -235,6 +235,25 @@ class MooncakeStore(KVLookupBufferBase):
             return tensor
         return None
 
+    def put_bytes(
+        self,
+        key: str,
+        value: bytes,
+    ) -> None:
+        """Put bytes data to Mooncake Store"""
+        try:
+            self.store.put(key, value)
+        except TypeError as err:
+            logger.error("Failed to put value into Mooncake Store: %s", err)
+            raise TypeError("Mooncake Store Put Type Error.") from err
+
+    def get_bytes(self, key: str) -> bytes:
+        try:
+            return self.store.get(key)
+        except TypeError as err:
+            logger.error("Failed to get value from Mooncake Store: %s", err)
+            raise TypeError("Mooncake Store Get Type Error.") from err
+
     def is_exist(self, key: str) -> bool:
         """Check if the key exists in the Mooncake Store"""
         return self.store.isExist(key) == 1

--- a/vllm/distributed/kv_transfer/kv_transfer_agent.py
+++ b/vllm/distributed/kv_transfer/kv_transfer_agent.py
@@ -5,9 +5,11 @@ This implementation is a shim wrapper on two APIs exposed by `kv_connector`:
 1. `send_kv_caches_and_hidden_states`
 2. `recv_kv_caches_and_hidden_states
 """
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 if TYPE_CHECKING:
+    from vllm.model_executor import SamplingMetadata
+    from vllm.model_executor.layers.sampler import SamplerOutput
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
     from vllm.worker.hpu_model_runner import \
         ModelInputForHPUWithSamplingMetadata
@@ -110,3 +112,12 @@ class KVTransferAgent:
                "ModelInputForHPUWithSamplingMetadata"]:
         return self.connector.recv_kv_caches_and_hidden_states_hpu(
             model_executable, model_input, attn_metadata, kv_caches)
+
+    def send_sampler_output(self, sampling_metadata: "SamplingMetadata",
+                            output: "SamplerOutput") -> None:
+        self.connector.send_sampler_output(sampling_metadata, output)
+
+    def recv_sampler_output(
+            self, sampling_metadata: "SamplingMetadata"
+    ) -> Optional["SamplerOutput"]:
+        return self.connector.recv_sampler_output(sampling_metadata)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -96,6 +96,7 @@ if TYPE_CHECKING:
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_USE_ASYNC_TRANSFER_IN_PD: bool = False
+    VLLM_USE_PREFILL_OUTPUT: bool = False
 
 
 def get_default_cache_root():
@@ -625,6 +626,8 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_PP_USE_CPU_COMS", "0"))),
     "VLLM_USE_ASYNC_TRANSFER_IN_PD":
     lambda: bool(int(os.getenv("VLLM_USE_ASYNC_TRANSFER_IN_PD", "0"))),
+    "VLLM_USE_PREFILL_OUTPUT":
+    lambda: bool(int(os.getenv("VLLM_USE_PREFILL_OUTPUT", "0"))),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
## Purpose
Currently both prefill and decode phase generate the first token for P/D disaggregation case. Ideally, we use the first token generate from the prefill phase and transfer the sampler output from prefill to decode so that we get the same output from both prefill and decode without sampling twice.

One note to the difference with KV cache transfer. KV cache is key on the prompt token ids only. The sampler output is more than depending on the prompt token ids, it also depends on the sampling params. It is possible that there are two requests with the same prompt token ids but with different sampling params which we expect different sample outputs. Due to this, the transfer of sample output cannot be combined directly into the KV cache logic.

Considering the sampler output is relatively small, we currently implement only the sync transfer.

## Test Plan
Run 1P and 1D instance with VLLM_USE_PREFILL_OUTPUT environment variable set to True.