### PR TITLE
[deepseek_r1]update decode benchmark code to generate N prompts.

### DIFF
--- a/examples/online_serving/disagg_examples/disagg_proxy_demo_benchmark.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_demo_benchmark.py
@@ -155,7 +155,7 @@ class Proxy:
             ])(self.custom_create_completion if self.
                custom_create_completion else self.create_completion)
         self.router.post(
-            "/v1/chat/completions",
+            "/v1/chat/prefill/completions",
             dependencies=[
                 Depends(self.validate_json_request)
             ])(self.custom_create_chat_completion if self.
@@ -170,6 +170,11 @@ class Proxy:
             dependencies=[
                 Depends(self.validate_json_request)
             ])(self.create_completion_decode)
+        self.router.post(
+            "/v1/chat/decode/completions",
+            dependencies=[
+                Depends(self.validate_json_request)
+            ])(self.create_chat_completion_decode)
 
     async def validate_json_request(self, raw_request: Request):
         content_type = raw_request.headers.get("content-type", "").lower()
@@ -360,6 +365,8 @@ class Proxy:
                 all(isinstance(x, int) for x in p) for p in prompt)):
                 # Already tokenized
                 return sum(len(p) for p in prompt)
+            elif all(isinstance(p, dict) and "text" in p for p in prompt):
+                return sum(len(self.tokenizer(p["text"])["input_ids"]) for p in prompt)
             else:
                 logger.error(
                     "Unsupported prompt format: %s / nested types. Value: %r",
@@ -405,6 +412,7 @@ class Proxy:
             if len(self.prefill_instances) > 0:
                 kv_prepare_request = request.copy()
                 kv_prepare_request["max_tokens"] = 1
+                kv_prepare_request["max_completion_tokens"] = 1
 
                 start_time = time.time()
                 prompt = kv_prepare_request.get("prompt")
@@ -450,6 +458,34 @@ class Proxy:
             print("Error occurred in disagg proxy server")
             print(exc_info)
 
+    async def create_chat_completion_decode(self, raw_request: Request):
+        try:
+            request = await raw_request.json()
+
+            prompt = request.get("prompt")
+            total_length = self.get_total_token_length(prompt)
+            decode_instance = self.schedule(self.decode_cycler,
+                                            is_prompt=False,
+                                            request_len=total_length)
+
+            try:
+                generator_d = self.forward_request(
+                    f"http://{decode_instance}/v1/chat/completions", request)
+            except HTTPException as http_exc:
+                self.remove_instance_endpoint("decode", decode_instance)
+                raise http_exc
+            final_generator = self.generator(generator_d,
+                                             self,
+                                             decode_instance,
+                                             req_len=total_length)
+            response = StreamingResponse(final_generator,
+                                         media_type="application/json")
+            return response
+        except Exception:
+            import sys
+            exc_info = sys.exc_info()
+            print(exc_info)
+
     async def create_chat_completion(self, raw_request: Request):
         try:
             request = await raw_request.json()
@@ -457,6 +493,7 @@ class Proxy:
             # add params to request
             kv_prepare_request = request.copy()
             kv_prepare_request["max_tokens"] = 1
+            kv_prepare_request["max_completion_tokens"] = 1
 
             start_time = time.time()
             # prefill stage
@@ -479,39 +516,24 @@ class Proxy:
                         f"http://{prefill_instance}/v1/chat/completions",
                         kv_prepare_request):
                     value += chunk
+                
+                value = value.strip().decode("utf-8").removesuffix(
+                "data: [DONE]").encode("utf-8")
+
+                async def streaming_response(value):
+                    if value:
+                        yield value
+                    else:
+                        yield b""
+                
+                generator_p = streaming_response(value)
+                response = StreamingResponse(generator_p,
+                                         media_type="application/json")
+                response.timeout = None
+                return response
             except HTTPException as http_exc:
                 self.remove_instance_endpoint("prefill", prefill_instance)
                 raise http_exc
-            # Perform kv recv and decoding stage
-            decode_instance = self.schedule(self.decode_cycler,
-                                            is_prompt=False,
-                                            request_len=total_length)
-            value = value.strip().decode("utf-8").removesuffix(
-                "data: [DONE]").encode("utf-8")
-
-            async def streaming_response(value):
-                if value:
-                    yield value
-                else:
-                    yield b""
-
-            generator_p = streaming_response(value)
-            try:
-                generator_d = self.forward_request(
-                    "http://" + decode_instance + "/v1/chat/completions",
-                    request)
-            except HTTPException as http_exc:
-                self.remove_instance_endpoint("decode", decode_instance)
-                raise http_exc
-            final_generator = self.generator(generator_p,
-                                             generator_d,
-                                             self,
-                                             prefill_instance,
-                                             decode_instance,
-                                             req_len=total_length)
-            response = StreamingResponse(final_generator,
-                                         media_type="application/json")
-            return response
         except Exception:
             exc_info = sys.exc_info()
             error_messages = [str(e) for e in exc_info if e]

--- a/pd_xpyd/xpyd_start_proxy.sh
+++ b/pd_xpyd/xpyd_start_proxy.sh
@@ -84,11 +84,7 @@ if [ "$BENCHMARK_MODE" == "1" ]; then
         --model $MODEL_PATH \
         --prefill $PREFILL_ARGS \
         --decode $DECODE_ARGS \
-        --port 8868 \
-        --repeat_p_request 1 \
-        --repeat_d_times 639 \
-        --benchmark_mode"
-
+        --port 8868"
 else
 
     CMD="python3 ./examples/online_serving/disagg_examples/disagg_proxy_demo.py \


### PR DESCRIPTION
Improve the deepseek_r1 benchmark to use N prompts, rather than 1 prompt, to test decode performance.

The prefill requests will be sent to dedicated endpoint to do prefill only, decode requests will be sent to dedicated decode endpoint to do decode.

Sample testing code:
```bash
MODEL_PATH="/mnt/disk2/hf_models/DeepSeek-R1-G2/"

SERVER_IP="localhost"
SERVER_PORT=8868

PREFILL_ENDPOINT='/v1/prefill/completions'
DECODE_ENDPOINT='/v1/decode/completions'
PROMPTS=256

# Get the output length from the first command-line argument
OUTPUT_LEN=$1

run_benchmark() {
    local output_length=$1
    local endpoint=$2

    python3 benchmarks/benchmark_serving.py \
        --backend vllm \
        --model "$MODEL_PATH" \
        --dataset-name sonnet \
        --request-rate inf \
        --host "$SERVER_IP" \
        --port "$SERVER_PORT" \
        --endpoint "$endpoint" \
        --sonnet-input-len 2000 \
        --sonnet-output-len "$output_length" \
        --sonnet-prefix-len 100 \
        --trust-remote-code \
        --max-concurrency "$PROMPTS" \
        --num-prompts "$PROMPTS" \
        --ignore-eos \
        --burstiness 1000 \
        --dataset-path benchmarks/sonnet.txt \
        --save-result
}

# Call the function with the provided output length
echo "Start Prefill Run."
run_benchmark 1 $PREFILL_ENDPOINT
echo "Start Decode Run, output_len: $OUTPUT_LEN"
run_benchmark "$OUTPUT_LEN" $DECODE_ENDPOINT

```