### PR TITLE
KV transfer robustness improvements

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -350,8 +350,6 @@ class MooncakeStoreConnector(KVConnectorBase):
             self.block_size - 1 ) // self.block_size
 
         hidden_or_intermediate_states_for_one_req = []
-        input_tokens_list = []
-        num_computed_tokens_list = []
         start_block_idx = 0
 
         # For each sequence in the batch, we patch kv tensor together,
@@ -413,12 +411,9 @@ class MooncakeStoreConnector(KVConnectorBase):
                 logger.warning("Didn't find any match, key_prefix: %s",
                                load_kvcache_key)
                 bypass_model_exec = False
+                # We need to increment the start_block_idx to continue
+                start_block_idx += padded_num_blocks
                 continue
-
-            # collecting data for rebuilding the input
-            input_tokens_list.append(current_tokens)
-            num_computed_tokens = current_tokens.shape[0]
-            num_computed_tokens_list.append(num_computed_tokens)
 
             # it's padded to block size now.
             # key_values = remote_kv.to("hpu")

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -493,14 +493,6 @@ class MooncakeStoreConnector(KVConnectorBase):
 
         return remote_kv, hidden
 
-    @staticmethod
-    def tensor_hash(tensor: torch.Tensor) -> int:
-        """Calculate the hash value of the tensor."""
-        tensor_bytes = tensor.clone().detach().cpu().numpy().tobytes()
-        hash_object = hashlib.blake2b(tensor_bytes)
-        hash_hex = hash_object.hexdigest()
-        return int(hash_hex[:16], 16)
-
     def _wait_for_key(self, key, timeout_in_seconds=None):
         if timeout_in_seconds is None:
             # default to 10 seconds
@@ -511,3 +503,11 @@ class MooncakeStoreConnector(KVConnectorBase):
                 return False
             time.sleep(0.01)
         return True
+
+    @staticmethod
+    def tensor_hash(tensor: torch.Tensor) -> int:
+        """Calculate the hash value of the tensor."""
+        tensor_bytes = tensor.clone().detach().cpu().numpy().tobytes()
+        hash_object = hashlib.blake2b(tensor_bytes)
+        hash_hex = hash_object.hexdigest()
+        return int(hash_hex[:16], 16)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3034,7 +3034,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                                 torch.distributed.get_rank())
                             hidden_states = None
                         else:
-                            hidden_states = torch.cat(hidden_states_list, dim=0)
+                            hidden_states = torch.cat(hidden_states_list,
+                                                      dim=0)
                             htorch.core.mark_step()
                         return hidden_states, bypass_model_exec
 


### PR DESCRIPTION
## Purpose
The current async KV transfer has a few robustness issues.
1. If a key put was failed, the decode side will enter a forever wait which put the decode instance to dead status
2. If there is any problem in fetching, we need be able to continue the normal forwarding. The current async logic doesn't allow this and once if there is any problem in fetching, the decode instance will go dead with exception.

This PR handles this exceptional cases to improve its robustness. 
1. Wait for the key with a timeout (10 seconds for now)
2. Handle properly when the kv cache is not successfully fetched. The tricky part is to broadcast the kv cache status if tensor parallel is in use.