### PR TITLE
Enable FSDPA Impl (prefill) in GPTOSS

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -7,7 +7,7 @@ ray
 triton==3.1.0
 setuptools>=77.0.3
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@f63577377f05a4ad84bbee225678450b489d3d54
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@refs/pull/339/head
 
 # Dependencies for HPU vllm docker image
 datasets

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -7,7 +7,7 @@ ray
 triton==3.1.0
 setuptools>=77.0.3
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@refs/pull/339/head
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@ce6bd4855a78863aff8312653a71925cb4be22ff
 
 # Dependencies for HPU vllm docker image
 datasets

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -471,10 +471,9 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         self.fused_scaled_dot_product_attention = (
             None if HPUFusedSDPA is None else ModuleFusedSDPA(HPUFusedSDPA)
         )
-        # self.prefill_impl = get_config().prompt_attn_impl
-        self.prefill_impl = 'naive_impl'
+        self.prefill_impl = get_config().prompt_attn_impl
         self.use_contiguous_pa = get_config().use_contiguous_pa
-        '''if alibi_slopes is not None:
+        if alibi_slopes is not None:
             assert (
                 self.prefill_impl != "flex_impl"
             ), "Prefill with Flex Attention not supported with alibi slopes!"
@@ -483,7 +482,7 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             ), "Prefill with FusedSDPA not supported with alibi slopes!"
             assert (
                 self.use_contiguous_pa
-            ), "Non-contiguous PA not supported with alibi slopes!"'''
+            ), "Non-contiguous PA not supported with alibi slopes!"
 
         self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
         self.sliding_window = sliding_window
@@ -657,14 +656,14 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                         attn_metadata.sliding_window_right,
                     )
                     common_args["window_size"] = window_size
-                    # TODO: Currently HPU doesn't support GQA for FusedSDPA
-                    # with causal + window, so repeat KV so QKV are all the
-                    # same shape.
-                    if query_shape != kv_shape:
-                        repeat_kv = self.num_heads // self.num_kv_heads
-                        key = key.repeat_interleave(repeat_kv, dim=1)
-                        value = value.repeat_interleave(repeat_kv, dim=1)
-                        kv_shape = query_shape
+            # TODO: Currently HPU doesn't support GQA for FusedSDPA
+            # with causal + window/sinks, so repeat KV so QKV are all the
+            # same shape.
+            if self.prefill_impl == "fsdpa_impl" and query_shape != kv_shape:
+                repeat_kv = self.num_heads // self.num_kv_heads
+                key = key.repeat_interleave(repeat_kv, dim=1)
+                value = value.repeat_interleave(repeat_kv, dim=1)
+                kv_shape = query_shape
 
             out = ops.prompt_attention(
                 impl=self.prefill_impl,

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -472,6 +472,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
             None if HPUFusedSDPA is None else ModuleFusedSDPA(HPUFusedSDPA)
         )
         self.prefill_impl = get_config().prompt_attn_impl
+        if not os.environ.get("VLLM_PROMPT_USE_FUSEDSDPA"):
+            self.prefill_impl = "naive_impl"
         self.use_contiguous_pa = get_config().use_contiguous_pa
         if alibi_slopes is not None:
             assert (


### PR DESCRIPTION
Command to run test_gpt_oss_offline.py script with Fused_SDPA Enabled:

`PT_HPU_QKV_SLICE_SEQ_LEN_THLD=128 PT_HPU_ENABLE_FUSED_SDPA_SINK=1 PT_HPU_SDPA_QKV_SLICE_MODE_FWD=1 VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 python test_gpt_oss_offline.py`

`PT_HPU_ENABLE_FUSED_SDPA_SINK=1` Enables sink
If `PT_HPU_QKV_SLICE_SEQ_LEN_THLD` is set to 128, `PT_HPU_SDPA_BC_FACTOR` and `PT_HPU_SDPA_BR_FACTOR` is set to 128. BC and BR Factors are window sizes (which is 128 for gptoss).

For more details on env variable usage please refer: https://jira.habana-labs.com/browse/SW-238114?focusedId=1093460&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1093460 
