### PR TITLE
Fix bug when video input for qwen2_5_vl

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -1450,10 +1450,6 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
             )
 
         if video_input is not None:
-            if is_hpu:
-                logger.warning("Video inputs have not been enabled yet, "
-                               "ignoring video inputs")
-                return inputs_embeds
             video_embeds = self._process_video_input(video_input)
             inputs_embeds = merge_multimodal_embeddings(
                 input_ids,


### PR DESCRIPTION
This PR fix the bug when the input of qwen2_5_vl is video.
Test：
python examples/offline_inference/vision_language.py --modality video --model-type qwen2_5_vl