### PR TITLE
Check whether second_per_grid_ts is None

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -1281,7 +1281,7 @@ class MRotaryEmbedding(RotaryEmbedding):
                     video_grid_thw[video_index][2],
                 )
                 video_second_per_grid_t = 1.0
-                if second_per_grid_ts:
+                if second_per_grid_ts is not None:
                     video_second_per_grid_t = second_per_grid_ts[video_index]
                 video_index += 1
                 remain_videos -= 1


### PR DESCRIPTION
Without this fix, the code will fail with a runtimeError below when the list contains multi-element Tensors that are evaluated in a boolean context.

ERROR 08-26 01:36:36 [engine.py:160]   File "/workspace/aicse.vllm-habana.demo/vllm/worker/hpu_model_runner.py", line 3006, in prepare_model_input
ERROR 08-26 01:36:36 [engine.py:160]     model_input, sampling_metadata = self.prepare_input_tensors(
ERROR 08-26 01:36:36 [engine.py:160]   File "/workspace/aicse.vllm-habana.demo/vllm/worker/hpu_model_runner.py", line 1925, in prepare_input_tensors
ERROR 08-26 01:36:36 [engine.py:160]     ) = self._prepare_prompt(prefill_reqs)
ERROR 08-26 01:36:36 [engine.py:160]   File "/workspace/aicse.vllm-habana.demo/vllm/worker/hpu_model_runner.py", line 1389, in _prepare_prompt
ERROR 08-26 01:36:36 [engine.py:160]     self._get_mrope_positions_and_delta(
ERROR 08-26 01:36:36 [engine.py:160]   File "/workspace/aicse.vllm-habana.demo/vllm/worker/hpu_model_runner.py", line 1213, in _get_mrope_positions_and_delta
ERROR 08-26 01:36:36 [engine.py:160]     MRotaryEmbedding.get_input_positions(
ERROR 08-26 01:36:36 [engine.py:160]   File "/workspace/aicse.vllm-habana.demo/vllm/model_executor/layers/rotary_embedding.py", line 1174, in get_input_positions
ERROR 08-26 01:36:36 [engine.py:160]     cls.get_input_positions_tensor(
ERROR 08-26 01:36:36 [engine.py:160]   File "/workspace/aicse.vllm-habana.demo/vllm/model_executor/layers/rotary_embedding.py", line 1216, in get_input_positions_tensor
ERROR 08-26 01:36:36 [engine.py:160]     return cls._vl_get_input_positions_tensor(
ERROR 08-26 01:36:36 [engine.py:160]   File "/workspace/aicse.vllm-habana.demo/vllm/model_executor/layers/rotary_embedding.py", line 1284, in _vl_get_input_positions_tensor
ERROR 08-26 01:36:36 [engine.py:160]     if second_per_grid_ts:
ERROR 08-26 01:36:36 [engine.py:160] RuntimeError: Boolean value of Tensor with more than one value is ambiguous
