### PR TITLE
[SW-235019] Fix for Invalid credentials in Authorization header, Qwen1.5-0.5B-Chat

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -64,7 +64,7 @@ def test_model_from_modelscope(monkeypatch: pytest.MonkeyPatch):
         m.setenv("VLLM_USE_MODELSCOPE", "True")
         # Don't use HF_TOKEN for ModelScope repos, otherwise it will fail
         # with 400 Client Error: Bad Request.
-        m.setenv("HF_TOKEN", "")
+        m.delenv("HF_TOKEN", raising=False)
         llm = LLM(model="qwen/Qwen1.5-0.5B-Chat")
 
         prompts = [


### PR DESCRIPTION
The error occurs when HF_TOKEN is set to an empty string "".
It does not occur when HF_TOKEN is None.
Using m.delenv("HF_TOKEN", raising=False) ensures that the HF_TOKEN value remains None.