### PR TITLE
PP Performance Optimizations

### DIFF
--- a/examples/online_serving/run_cluster.sh
+++ b/examples/online_serving/run_cluster.sh
@@ -1,17 +1,51 @@
 #!/bin/bash
 
 # Check for minimum number of required arguments
+Help() {
+    # Display Help
+    echo "Usage: $0 docker_image head_node_address --head|--worker path_to_hf_home"
+    echo "       [-h] [-d hpu|gpu] [-c true|false]  [-n CONTAINER_NAME] [-- additional_args..."]
+}
+
 if [ $# -lt 4 ]; then
-    echo "Usage: $0 docker_image head_node_address --head|--worker path_to_hf_home [additional_args...]"
+    Help
     exit 1
 fi
 
-# Assign the first three arguments and shift them away
+# Assign the first four arguments and shift them away
 DOCKER_IMAGE="$1"
 HEAD_NODE_ADDRESS="$2"
 NODE_TYPE="$3"  # Should be --head or --worker
 PATH_TO_HF_HOME="$4"
 shift 4
+
+PLATFORM="gpu"
+CLEANUP_ON_EXIT="true"
+CONTAINER_NAME="node"
+
+# Get the options
+while getopts hd:c:n: flag; do
+    case $flag in
+    h) # display Help
+        Help
+        exit
+        ;;
+    d) # get the device type
+        PLATFORM=$OPTARG ;;
+    c) # get exit cleanup option
+        CLEANUP_ON_EXIT=$OPTARG ;;
+    n) # get container name
+        CONTAINER_NAME=$OPTARG ;;
+    \?) # Invalid option
+        echo "Error: Invalid option"
+        Help
+        exit
+        ;;
+    esac
+done
+
+# Shift the processed options and their arguments
+shift $((OPTIND - 1))
 
 # Additional arguments are passed directly to the Docker command
 ADDITIONAL_ARGS=("$@")
@@ -24,26 +58,47 @@ fi
 
 # Define a function to cleanup on EXIT signal
 cleanup() {
-    docker stop node
-    docker rm node
+    docker stop $CONTAINER_NAME
+    docker rm $CONTAINER_NAME
 }
-trap cleanup EXIT
+if [[ "$CLEANUP_ON_EXIT" == "true" ]]; then
+    trap cleanup EXIT
+fi
 
 # Command setup for head or worker node
 RAY_START_CMD="ray start --block"
 if [ "${NODE_TYPE}" == "--head" ]; then
-    RAY_START_CMD+=" --head --port=6379"
+    RAY_START_CMD+=" --head --node-ip-address ${HEAD_NODE_ADDRESS} --port=6379"
 else
     RAY_START_CMD+=" --address=${HEAD_NODE_ADDRESS}:6379"
 fi
 
 # Run the docker command with the user specified parameters and additional arguments
-docker run \
-    --entrypoint /bin/bash \
-    --network host \
-    --name node \
-    --shm-size 10.24g \
-    --gpus all \
-    -v "${PATH_TO_HF_HOME}:/root/.cache/huggingface" \
-    "${ADDITIONAL_ARGS[@]}" \
-    "${DOCKER_IMAGE}" -c "${RAY_START_CMD}"
+if [[ "$PLATFORM" == "hpu" ]]; then
+    docker run \
+        -td \
+        --entrypoint /bin/bash \
+        --network host \
+        --ipc=host \
+        --name $CONTAINER_NAME \
+        -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
+        --cap-add SYS_NICE \
+        --privileged \
+        --runtime=habana \
+        -e HABANA_VISIBLE_DEVICES=all \
+        -e GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME} \
+        -e HCCL_SOCKET_IFNAME=${HCCL_SOCKET_IFNAME} \
+        -v "${PATH_TO_HF_HOME}:/root/.cache/huggingface" \
+        "${ADDITIONAL_ARGS[@]}" \
+        "${DOCKER_IMAGE}" -c "${RAY_START_CMD}"
+else
+    docker run \
+        --entrypoint /bin/bash \
+        --network host \
+        --name $CONTAINER_NAME \
+        --shm-size 10.24g \
+        --gpus all \
+        -v "${PATH_TO_HF_HOME}:/root/.cache/huggingface" \
+        "${ADDITIONAL_ARGS[@]}" \
+        "${DOCKER_IMAGE}" -c "${RAY_START_CMD}"
+fi

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -733,6 +733,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # limit will actually be zero-copy decoded.
     "VLLM_MSGPACK_ZERO_COPY_THRESHOLD":
     lambda: int(os.getenv("VLLM_MSGPACK_ZERO_COPY_THRESHOLD", "256")),
+
+    # If PP-group comms cannot use HCCL/NCCL/etc,
+    # set VLLM_PP_USE_CPU_COMS=1 to force PP comms over
+    # Gloo on CPU and avoid hangs (send/recv/broadcast).
+    "VLLM_PP_USE_CPU_COMS":
+    lambda: bool(int(os.getenv("VLLM_PP_USE_CPU_COMS", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm/executor/mp_distributed_executor.py
+++ b/vllm/executor/mp_distributed_executor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+from contextlib import nullcontext
 from typing import Any, Callable, List, Optional, Union
 
 import cloudpickle
@@ -126,7 +127,8 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
                           max_concurrent_workers=self.parallel_config.
                           max_parallel_loading_workers)
         self.driver_exec_model = make_async(self.driver_worker.execute_model)
-        self.pp_locks: Optional[List[asyncio.Lock]] = None
+        self.pp_locks: Optional[List[Union[asyncio.Lock,
+                                           nullcontext[Any]]]] = None
         self.shutdown_workers = True
 
     def shutdown(self):
@@ -217,10 +219,23 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
             # engines can't execute on the same stage at the same time
             # We create the locks here to avoid creating them in the constructor
             # which uses a different asyncio loop.
+            lock_type: Union[type[asyncio.Lock], type[nullcontext[Any]]]
+            from vllm.platforms import current_platform
+            if current_platform.is_hpu():
+                #NOTE(Tanner): HPU manages its own locks
+                # to maximize PP concurrency.
+                lock_type = nullcontext
+            else:
+                lock_type = asyncio.Lock
+
             self.pp_locks = [
-                asyncio.Lock()
+                lock_type()
                 for _ in range(self.parallel_config.pipeline_parallel_size)
             ]
+
+        if current_platform.is_hpu():
+            execute_model_req = self.prepare_execute_model_req_patch(
+                execute_model_req)
 
         tasks = [
             asyncio.create_task(

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -30,7 +30,8 @@ from vllm.attention import Attention
 from vllm.config import (LoadConfig, LoadFormat, ModelConfig, ParallelConfig,
                          VllmConfig, set_current_vllm_config)
 from vllm.distributed import (get_tensor_model_parallel_rank,
-                              get_tensor_model_parallel_world_size)
+                              get_tensor_model_parallel_world_size,
+                              get_tp_group)
 from vllm.envs import VLLM_USE_MODELSCOPE
 from vllm.logger import init_logger
 # yapf conflicts with isort for this block
@@ -178,6 +179,10 @@ def _process_weights_after_loading(model: nn.Module, model_config: ModelConfig,
             # parameters onto device for processing and back off after.
             with device_loading_context(module, target_device):
                 quant_method.process_weights_after_loading(module)
+            if current_platform.is_hpu():
+                torch.hpu.synchronize()
+                if torch.distributed.is_initialized():
+                    get_tp_group().barrier()
 
     # Currently only used by MLA.
     # NOTE: This intentionally happens after other modules so we can easily
@@ -188,6 +193,10 @@ def _process_weights_after_loading(model: nn.Module, model_config: ModelConfig,
             # TODO(lucas): see if there is a way to unify the signatures
             # of process_weights_after_loading
             module.process_weights_after_loading(model_config.dtype)
+            if current_platform.is_hpu():
+                torch.hpu.synchronize()
+                if torch.distributed.is_initialized():
+                    get_tp_group().barrier()
 
 
 class BaseModelLoader(ABC):

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -760,20 +760,6 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
                                        sampling_metadata)
         return logits
 
-    def make_empty_intermediate_tensors(
-            self, batch_size: int, dtype: torch.dtype,
-            device: torch.device) -> IntermediateTensors:
-        return IntermediateTensors({
-            "hidden_states":
-            torch.zeros((batch_size, self.config.hidden_size),
-                        dtype=dtype,
-                        device=device),
-            "residual":
-            torch.zeros((batch_size, self.config.hidden_size),
-                        dtype=dtype,
-                        device=device),
-        })
-
     def load_weights(self, weights: Iterable[Tuple[str,
                                                    torch.Tensor]]) -> Set[str]:
         stacked_params_mapping = [

--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -48,7 +48,8 @@ from vllm.sequence import IntermediateTensors
 
 from . import mixtral
 from .interfaces import SupportsLoRA, SupportsPP
-from .utils import AutoWeightsLoader, make_layers, maybe_prefix
+from .utils import (AutoWeightsLoader, make_empty_intermediate_tensors_factory,
+                    make_layers, maybe_prefix)
 
 
 class GraniteMoeMoE(nn.Module):
@@ -273,6 +274,10 @@ class GraniteMoeModel(nn.Module):
             prefix=f"{prefix}.layers")
 
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.make_empty_intermediate_tensors = (
+            make_empty_intermediate_tensors_factory(
+                ["hidden_states", "residual"], config.hidden_size))
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)


### PR DESCRIPTION
- Manual lock control in the worker for tighter VE overlap
- Split sampling from the forward pass. Allows for tighter VE overlap
- Async recv/send
- Use a caching method to decrease serialization/deserialization
- Validated on qwen3-32b

No impact on pure-TP workloads. Performance increase on PP workloads increases the higher the pipeline parallelism size is. At PP=8 observed a nearly 80% performance increase. Benefits will also likely extend to multi-node usage. No impacts to accuracy observed.

<img width="1747" height="408" alt="image" src="https://github.com/user-attachments/assets/9c23483a-d06b-43b9-b00e-bea67b8c3ed5" />

All TPS/DPS values are normalized against the aice/v1.21.0 baseline when that branch supports the exact configuration (columns show 1.00X entries). For configurations not supported by aice/v1.21.0 (shown as NA), results are normalized to the corresponding aice/v1.21.0 + Minimal PP configuration.

All pre-commit as well as functional tests (.jenkins/test_config.yaml) passed locally.