### PR TITLE
Option to abort request when kv cache miss

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1475,6 +1475,12 @@ class Scheduler:
 
     def _schedule(self) -> SchedulerOutputs:
         """Schedule queued requests."""
+        if not self.need_fetch_kv:
+            if self.scheduler_config.chunked_prefill_enabled:
+                return self._schedule_chunked_prefill()
+            else:
+                return self._schedule_default()
+
         # Processed requests which have done fetching KV cache
         # appending to the waiting queue
         aborted_seq_groups = self._process_fetching_done()
@@ -1482,7 +1488,6 @@ class Scheduler:
             scheduler_outputs = self._schedule_chunked_prefill()
         else:
             scheduler_outputs = self._schedule_default()
-
         scheduler_outputs.aborted_seq_groups = aborted_seq_groups
         return scheduler_outputs
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -603,6 +603,8 @@ class Scheduler:
             if self.abort_request_kv_cache_miss and not fetching_success:
                 self.abort_seq_group(seq_group.request_id)
                 aborted_seq_groups.append(seq_group)
+                logger.warning("KV cache miss for request: %s. Abort now.",
+                               seq_group.request_id)
 
         if len(self.waiting) == 0 and len(self.running) == 0 and len(
                 self.swapped) == 0 and len(self.fetching) != 0:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -49,7 +49,7 @@ from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.sequence import (ExecuteModelRequest, ParallelSampleSequenceGroup,
                            PoolingSequenceGroupOutput, Sequence, SequenceGroup,
                            SequenceGroupBase, SequenceGroupMetadata,
-                           SequenceGroupOutput, SequenceStatus, Logprob)
+                           SequenceGroupOutput, SequenceStatus)
 from vllm.tracing import (SpanAttributes, SpanKind, extract_trace_context,
                           init_tracer)
 from vllm.transformers_utils.detokenizer import Detokenizer
@@ -2090,10 +2090,6 @@ class LLMEngine:
     def _process_abort_seq_groups(self, ctx: SchedulerContext,
                                   aborted_seq_groups: List[SequenceGroup]):
         for aborted_seq_group in aborted_seq_groups:
-            # Append a dummy output token
-            seq = aborted_seq_group.first_seq
-            seq.append_token_id(-1, {-1: Logprob(0.0)})
-
             request_output = RequestOutputFactory.create(
                 aborted_seq_group,
                 self.seq_id_to_seq_group,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
     VLLM_DP_OPT: int = 4
     VLLM_USE_ASYNC_TRANSFER_IN_PD: bool = False
     VLLM_SKIP_PREFILL_SAMPLING: bool = False
+    VLLM_ABORT_REQUEST_KV_CACHE_MISS: bool = True
 
 
 def get_default_cache_root():
@@ -641,6 +642,8 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_USE_ASYNC_TRANSFER_IN_PD", "0"))),
     "VLLM_SKIP_PREFILL_SAMPLING":
     lambda: bool(int(os.getenv("VLLM_SKIP_PREFILL_SAMPLING", "0"))),
+    "VLLM_ABORT_REQUEST_KV_CACHE_MISS":
+    lambda: bool(int(os.getenv("VLLM_ABORT_REQUEST_KV_CACHE_MISS", "1"))),
 }
 
 # end-env-vars-definition

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3065,6 +3065,10 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     'real_seq_len': model_input.seq_lens,
                     'real_batch_size': real_batch_size
                 }
+                if self.dp_size > 1:
+                    # Need to align bypass among DP ranks
+                    bypass_model_exec = bool(align_dp_groups(
+                        bypass_model_exec, torch.distributed.ReduceOp.MAX))
                 if not bypass_model_exec:
                     with self.profiler.record_event('internal',
                                                     model_event_name,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3065,10 +3065,6 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     'real_seq_len': model_input.seq_lens,
                     'real_batch_size': real_batch_size
                 }
-                if self.dp_size > 1:
-                    # Need to align bypass among DP ranks
-                    bypass_model_exec = bool(align_dp_groups(
-                        bypass_model_exec, torch.distributed.ReduceOp.MAX))
                 if not bypass_model_exec:
                     with self.profiler.record_event('internal',
                                                     model_event_name,


### PR DESCRIPTION
## Purpose
The current DP implementation cannot handle the case of not bypass prefill model forward when KV cache miss.
This allows to abort the request when async KV cache fetching failure for the request, instead of adding the request to normal execution.
