### PR TITLE
auto config parameters and ENVs for INC

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1216,7 +1216,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
                     disable_mark_scales_as_const = os.getenv(
                         "VLLM_DISABLE_MARK_SCALES_AS_CONST",
-                        "false") in ("1", "true")
+                        "true") in ("1", "true")
                     config = FP8Config.from_json_file(
                         os.getenv("QUANT_CONFIG", ""))
                     self._inc_preprocess()

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1210,6 +1210,21 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
             if self._is_quant_with_inc():
                 logger.info("Preparing model with INC..")
+
+                def move_all_params_to_hpu(model):
+                    model = model.to("hpu")
+                    # that does not handle the PatchedMoeFP8Matmul
+                    for _, module in model.named_modules():
+                        if hasattr(module, 'weight') \
+                            and module.weight.device.type == 'cpu':
+                            module.weight = module.weight.to('hpu')
+                        if hasattr(module, 'bias') \
+                            and module.bias is not None \
+                            and module.bias.device.type == 'cpu':
+                            module.bias.data = module.bias.data.to('hpu')
+                    torch.hpu.synchronize()
+                    return model
+
                 with HabanaMemoryProfiler() as m_inc:
                     from neural_compressor.torch.quantization import (
                         FP8Config, convert, prepare)
@@ -1221,6 +1236,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                         os.getenv("QUANT_CONFIG", ""))
                     self._inc_preprocess()
                     if config.measure:
+                        self.model = move_all_params_to_hpu(self.model)
                         self.model = prepare(self.model, config)
                     elif config.quantize:
                         self.model = convert(self.model, config)


### PR DESCRIPTION
INC is enabled by setting `QUANT_CONFIG`, and the relative parameters and ENVs are configured automatically:
1. Set `PT_HPU_WEIGHT_SHARING=0` if `QUANT_CONFIG` is set.
2. For a model with quantized weights: set `quantization=None` and vLLM will set it to the `quantization_config.quant_method` from the `config.json` of the model.
3. For a model with bf16/fp16 weights: set `quantization='inc'`.
3. Set `kv_cache_dtype='fp8_inc` if running in `quantize` mode and the KVCache is not blocked in the `blocklist` of `QUANT_CONFIG`, otherwise set `kv_cache_dtype='auto`.
4. Set `weights_load_device='cpu'` and `VLLM_HPU_CONVERT_TO_FP8UZ=true` on Gaudi2 to enable `fp8_e4m3fn->fp8_e4m3fnuz` conversion for models with quantized weights.
5. Set `VLLM_DISABLE_MARK_SCALES_AS_CONST=true` by default.
