### PR TITLE
[DeepSeek R1] Optimize the serial fetching with responsive fetching

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -473,8 +473,7 @@ class Scheduler:
         self.fetching: Deque[SequenceGroup] = deque()
         self.abort_request_kv_cache_miss = \
             envs.VLLM_ABORT_REQUEST_KV_CACHE_MISS
-        # TODO: read from env
-        self.wait_for_key_timeout = 10
+        self.wait_for_key_timeout = envs.VLLM_KV_CACHE_WAIT_TIMEOUT
         self.fetching_thread = threading.Thread(target=self._fetch_kv_thread, )
         if self.need_fetch_kv:
             from vllm_hpu_extension.profiler import HabanaHighLevelProfiler

--- a/vllm/distributed/kv_transfer/kv_connector/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/base.py
@@ -157,3 +157,7 @@ class KVConnectorBase(ABC):
     ) -> Tuple[Union[torch.Tensor, IntermediateTensors], bool,
                "ModelInputForHPUWithSamplingMetadata"]:
         raise NotImplementedError
+
+    @abstractmethod
+    def is_key_exist(self, prefix: str) -> bool:
+        raise NotImplementedError

--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -254,6 +254,10 @@ class MooncakeStoreConnector(KVConnectorBase):
             self.kv_store.put_unsafe(store_kvcache_key,
                                      kv_caches_send_list[idx])
             self.kv_store.put_unsafe(store_hidden_key, hidden_states_list[idx])
+            # Put a separate signal key to avoid duplicated GC problem
+            # caused by is_exist and get call on the same key
+            # Not needed when we move to pure eviction solution
+            self.kv_store.put_bytes(str(store_key_prefix), b'OK')
         logger.info("[rank %d]: KV send DONE. send %d, takes %f s", self.rank,
                     len(input_tokens_list),
                     time.time() - start_time)
@@ -475,15 +479,11 @@ class MooncakeStoreConnector(KVConnectorBase):
 
         load_kvcache_key = f"{prefix}_0"
         load_hidden_key = f"{prefix}_hidden_0"
-        remote_kv = None
-        if self._wait_for_key(load_kvcache_key):
-            remote_kv = self.kv_store.get_unsafe(load_kvcache_key,
-                                                 shape=None,
-                                                 dtype=self.dtype)
+        remote_kv = self.kv_store.get_unsafe(load_kvcache_key,
+                                             shape=None,
+                                             dtype=self.dtype)
         # hidden_states always use bf16.
-        hidden = None
-        if self._wait_for_key(load_hidden_key):
-            hidden = self.kv_store.get_unsafe(load_hidden_key, shape=(1, 7168))
+        hidden = self.kv_store.get_unsafe(load_hidden_key, shape=(1, 7168))
 
         if remote_kv is None or hidden is None:
             # didn't find any match.
@@ -503,6 +503,9 @@ class MooncakeStoreConnector(KVConnectorBase):
                 return False
             time.sleep(0.01)
         return True
+
+    def is_key_exist(self, prefix: str) -> bool:
+        return self.kv_store.is_exist(prefix)
 
     @staticmethod
     def tensor_hash(tensor: torch.Tensor) -> int:

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
@@ -240,6 +240,21 @@ class MooncakeStore(KVLookupBufferBase):
             return tensor
         return None
 
+    def put_bytes(self, key: str, value: bytes,) -> None:
+        """Put bytes data to Mooncake Store"""
+        try:
+            self.store.put(key, value)
+        except TypeError as err:
+            logger.error("Failed to put value into Mooncake Store: %s", err)
+            raise TypeError("Mooncake Store Put Type Error.") from err
+
+    def get_bytes(self, key: str) -> bytes:
+        try:
+            return self.store.get(key)
+        except TypeError as err:
+            logger.error("Failed to get value from Mooncake Store: %s", err)
+            raise TypeError("Mooncake Store Get Type Error.") from err
+
     def is_exist(self, key: str) -> bool:
         """Check if the key exists in the Mooncake Store"""
         return self.store.isExist(key) == 1

--- a/vllm/distributed/kv_transfer/kv_transfer_agent.py
+++ b/vllm/distributed/kv_transfer/kv_transfer_agent.py
@@ -110,3 +110,6 @@ class KVTransferAgent:
                "ModelInputForHPUWithSamplingMetadata"]:
         return self.connector.recv_kv_caches_and_hidden_states_hpu(
             model_executable, model_input, attn_metadata, kv_caches)
+
+    def is_key_exist(self, prefix: str) -> bool:
+        return self.connector.is_key_exist(prefix)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
     VLLM_USE_ASYNC_TRANSFER_IN_PD: bool = False
     VLLM_SKIP_PREFILL_SAMPLING: bool = False
     VLLM_ABORT_REQUEST_KV_CACHE_MISS: bool = True
+    VLLM_KV_CACHE_WAIT_TIMEOUT: float = 10.0
 
 
 def get_default_cache_root():
@@ -644,6 +645,10 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_SKIP_PREFILL_SAMPLING", "0"))),
     "VLLM_ABORT_REQUEST_KV_CACHE_MISS":
     lambda: bool(int(os.getenv("VLLM_ABORT_REQUEST_KV_CACHE_MISS", "1"))),
+    # The longest time in seconds waiting for KV cache available.
+    # Default to 10 seconds.
+    "VLLM_KV_CACHE_WAIT_TIMEOUT":
+    lambda: float(os.getenv("VLLM_KV_CACHE_WAIT_TIMEOUT", "10.0")),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
## Purpose
The current async fetching is done in the following way:
get request -> wait key -> fetch data -> get request -> wait key -> fetch data -> ...
This poses a serious problem when there is a key is unavailable and the whole process will wait on the key until timeout happens. During the wait period, no more new quest queued can be processed and will not response to these new request even the whole process is idle but wait for the current key to be available.

We need to improve the serial fetching to a more responsive fetching. 

This PR implement a solution that we will wait on a list of keys and any key available will be dispatched to fetching. And during the wait period, we will also make sure the new requests for fetching and join to the wait list so that the whole process will not be blocked by previous key(s)  is not available.

We also optimized the kv cache key use a signal key to mitigate the troubling GC issue.