### PR TITLE
Fix audio bug for omni.

### DIFF
--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -648,8 +648,8 @@ class Qwen2_5OmniAudioEncoderStaticShape(Qwen2_5OmniAudioEncoder):
     ):
         offset = 0
         audio_outputs = []
-        for feature_len in audio_feature_lengths:
-            input_feature = input_features[offset:offset + feature_len]
+        for i, feature_len in enumerate(audio_feature_lengths):
+            input_feature = input_features[:, offset:offset + feature_len]
             offset = offset + feature_len
             padded_feature, padded_mask, padded_mask_after_cnn, \
               padded_aftercnn_lens, attention_mask = \
@@ -661,7 +661,7 @@ class Qwen2_5OmniAudioEncoderStaticShape(Qwen2_5OmniAudioEncoder):
                                           attention_mask)
             audio_features = self.post_attn(audio_features,
                                             padded_aftercnn_lens,
-                                            audio_feat_lengths)
+                                            audio_feat_lengths[i:i + 1])
             audio_outputs.append(audio_features)
         return torch.cat(audio_outputs, dim=0)
 


### PR DESCRIPTION
Fix bug that the qwen2.5-omni cannot process more than one audio

example command:
'python examples/offline_inference/audio_language.py --model-type qwen2_5_omni --num-audios 2'
