### PR TITLE
fix error for non-MoE model and unquantized MoE model

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2829,7 +2829,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             logger_msg = "Multimodal bucket : " + str(self.multimodal_buckets)
             logger.info(logger_msg)
 
-        logger.info("Profile run with bs={}, seq_len={}", \
+        logger.info("Profile run with bs=%s, seq_len=%s", \
                     max_batch_size, max_seq_len)
 
         self.warmup_scenario(

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1216,7 +1216,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
                 # handle the PatchedMoeFP8Matmul
                 for _, module in model.named_modules():
-                    if isinstance(module, FusedMoE):
+                    if isinstance(module, FusedMoE) \
+                        and module.quant_config is not None:
                         module = hpu_ops.fp8_channel_moe_prepare_weights(
                             module)
                 torch.hpu.synchronize()


### PR DESCRIPTION
- [disable expert parallelism if it is enabled for a non-MoE model](https://github.com/HabanaAI/vllm-fork/commit/237ea4088c30d617aeece792b1ee82868cdddde9)
- [call fp8_channel_moe_prepare_weights for fp8 MoE model only](https://github.com/HabanaAI/vllm-fork/commit/db7630aeb72c7c38a5d5a4872e1379b70454eb1d)