### PR TITLE
fix indexing error and patching of EOS token in delayed-sampling

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3483,11 +3483,11 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     seq_data.output_token_ids_array[-1] = real_out
                     seq_data._cached_all_token_ids[-1] = real_out
                 else:
-                    logger.debug('Last token {} is not patched by {}',
+                    logger.debug('Last token %s is not patched by %s',
                                  last_token, real_out)
                 assert seq_data.output_token_ids_array[-1] != DUMMY_TOKEN_ID
                 assert seq_data._cached_all_token_ids[-1] != DUMMY_TOKEN_ID
             else:
-                logger.debug('Skip patching with {} as last token is empty',
+                logger.debug('Skip patching with %s as last token is empty',
                              real_out)
         self.has_patched_prev_output = True

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3475,6 +3475,19 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             seq_data = list(sg.seq_data.values())[0]
             # This is a hack. Assigning output_token_ids triggers
             # a cache recomputation and we only need to update the last token
-            seq_data.output_token_ids_array[-1] = real_out
-            seq_data._cached_all_token_ids[-1] = real_out
+            if seq_data.output_token_ids_array \
+                and seq_data._cached_all_token_ids:
+                last_token = seq_data.output_token_ids_array[-1]
+                assert last_token == seq_data._cached_all_token_ids[-1]
+                if last_token == DUMMY_TOKEN_ID:
+                    seq_data.output_token_ids_array[-1] = real_out
+                    seq_data._cached_all_token_ids[-1] = real_out
+                else:
+                    logger.debug('Last token {} is not patched by {}',
+                                 last_token, real_out)
+                assert seq_data.output_token_ids_array[-1] != DUMMY_TOKEN_ID
+                assert seq_data._cached_all_token_ids[-1] != DUMMY_TOKEN_ID
+            else:
+                logger.debug('Skip patching with {} as last token is empty',
+                             real_out)
         self.has_patched_prev_output = True


### PR DESCRIPTION
- [add check to avoid array assignment index out of range error](https://github.com/HabanaAI/vllm-fork/pull/1730)
- [patch the DUMMY_TOKEN_ID only to avoid patching the EOS token](https://github.com/HabanaAI/vllm-fork/pull/1762)