### PR TITLE
[SW-240003] Prevent max_batch from being zero

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2800,8 +2800,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             self.vllm_config.compilation_config.static_forward_context,
             [kv_caches] * self.parallel_config.pipeline_parallel_size)
         max_seq_len = self.bucketing_manager.get_max_prompt_shape()
-        max_batch_size = min(self.max_num_seqs,
-                             self.max_num_batched_tokens // max_seq_len)
+        max_batch_size = max(min(self.max_num_seqs,
+                             self.max_num_batched_tokens // max_seq_len), 1)
 
         if self.model_is_mrope or self.is_mm_optimized:
             # Using batch_size 1 is profile multimodal models


### PR DESCRIPTION
## Purpose
Used max(1, min(a, b)) to ensure max_batch is always at least 1, avoiding potential issues with invalid batch sizes.

## Test Result
The test was previously failing because max_batch became 0 when the arguments were set as self.max_num_seqs=256, self.max_num_batched_tokens=2048, and max_seq_len=32768. While this might be an invalid use case, we've added a safeguard to ensure that max_batch_size never returns 0."

`pytest -v -s prefix_caching  -k' (test_disable_sliding_window[model_len_len1] or test_disable_sliding_window[model_len_len2])'`