### PR TITLE
Add random image option to benchmark_servering.py

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -6,6 +6,7 @@ datasets. Each dataset subclass of BenchmarkDataset must implement sample
 generation. Supported dataset types include:
   - ShareGPT
   - Random (synthetic)
+  - Random Image(synthetic)
   - Sonnet
   - BurstGPT
   - HuggingFace
@@ -363,7 +364,97 @@ class RandomDataset(BenchmarkDataset):
             )
         return requests
 
+# -----------------------------------------------------------------------------
+# Random Image Dataset Implementation (Synthetic Data)
+# -----------------------------------------------------------------------------
+class RandomImageDataset(BenchmarkDataset):
+    """
+    Random Image Dataset.
+    """
+    DEFAULT_INPUT_LEN = 1024
+    DEFAULT_OUTPUT_LEN = 128
+    DEFAULT_RANGE_RATIO = 0.0
+    IS_MULTIMODAL = True
+    
+    def sample(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        num_requests: int,
+        input_len: int = DEFAULT_INPUT_LEN,
+        output_len: int = DEFAULT_OUTPUT_LEN,
+        range_ratio: float = DEFAULT_RANGE_RATIO,
+        enable_multimodal_chat: bool = False,
+        width = 1280,
+        height = 720,
+        img_path = None,
+        **kwargs,
+    ) -> list:
 
+        sampled_requests = []
+         
+        if img_path is not None:
+            print("random data using image path:",img_path)
+            image = Image.open(img_path).convert("RGB")
+            prompt = "Describe this image."
+            print("prompt=",prompt) 
+        else:
+            arr = (np.random.rand(height, width, 3) * 255).astype(np.uint8)
+            image = Image.fromarray(arr, mode="RGB")
+            print("random image height=",height)
+            print("random image width=",width)
+
+            vocab_size = tokenizer.vocab_size
+            num_special_tokens = tokenizer.num_special_tokens_to_add()
+            real_input_len = input_len - num_special_tokens
+
+            prefix_token_ids = []
+
+            # New sampling logic: [X * (1 - b), X * (1 + b)]
+            input_low = int(real_input_len * (1 - range_ratio))
+            input_high = int(real_input_len * (1 + range_ratio))
+            output_low = int(output_len * (1 - range_ratio))
+            output_high = int(output_len * (1 + range_ratio))
+
+            # Add logging for debugging
+            logger.info("Sampling input_len from [%s, %s]", input_low, input_high)
+            logger.info("Sampling output_len from [%s, %s]", output_low,
+                        output_high)
+
+            input_lens = np.random.randint(input_low,
+                                        input_high + 1,
+                                        size=num_requests)
+            output_lens = np.random.randint(output_low,
+                                            output_high + 1,
+                                            size=num_requests)
+            offsets = np.random.randint(0, vocab_size, size=num_requests)
+                                        
+        for i in range(num_requests):
+            if img_path is None:
+                inner_seq = ((offsets[i] + i + np.arange(input_lens[i])) %
+                            vocab_size).tolist()
+                token_sequence = prefix_token_ids + inner_seq
+                prompt = tokenizer.decode(token_sequence) 
+                output_len = int(output_lens[i]) 
+                              
+            mm_content = process_image(image)
+            prompt_len = len(tokenizer(prompt).input_ids)
+
+            if enable_multimodal_chat:
+                # Note: when chat is enabled the request prompt_len is no longer
+                # accurate and we will be using request output to count the
+                # actual prompt len
+                prompt = self.apply_multimodal_chat_transformation(
+                    prompt, mm_content)            
+            sampled_requests.append(
+                SampleRequest(
+                    prompt=prompt,
+                    prompt_len=prompt_len,
+                    expected_output_len=output_len,
+                    multi_modal_data=mm_content,
+                ))
+        self.maybe_oversample_requests(sampled_requests, num_requests)
+        return sampled_requests
+    
 # -----------------------------------------------------------------------------
 # ShareGPT Dataset Implementation
 # -----------------------------------------------------------------------------

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -919,7 +919,8 @@ if __name__ == "__main__":
         "--dataset-name",
         type=str,
         default="sharegpt",
-        choices=["sharegpt", "burstgpt", "sonnet", "random", "hf", "custom","random_image"],
+        choices=["sharegpt", "burstgpt", "sonnet", "random", "hf", 
+                 "custom","random_image"],
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument(

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -722,8 +722,8 @@ def main(args: argparse.Namespace):
             tokenizer=tokenizer,
             output_len=args.hf_output_len,
         )
-        
-    elif args.dataset_name == "random_image":       
+
+    elif args.dataset_name == "random_image":
         input_requests = RandomImageDataset(
             dataset_path=args.dataset_path,
             random_seed=args.seed,
@@ -733,11 +733,11 @@ def main(args: argparse.Namespace):
             input_len=args.random_input_len,
             output_len=args.random_output_len,
             range_ratio=args.random_range_ratio,
-            img_path = args.bench_single_image_path,
-            width = args.random_image_width,
-            height = args.random_image_height,            
+            img_path=args.bench_single_image_path,
+            width=args.random_image_width,
+            height=args.random_image_height,
         )
-            
+
     else:
         # For datasets that follow a similar structure, use a mapping.
         dataset_mapping = {
@@ -919,8 +919,15 @@ if __name__ == "__main__":
         "--dataset-name",
         type=str,
         default="sharegpt",
-        choices=["sharegpt", "burstgpt", "sonnet", "random", "hf", 
-                 "custom","random_image"],
+        choices=[
+            "sharegpt",
+            "burstgpt",
+            "sonnet",
+            "random",
+            "hf",
+            "custom",
+            "random_image",
+        ],
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument(
@@ -1167,7 +1174,7 @@ if __name__ == "__main__":
             "input_len * (1 + range_ratio)]."
         ),
     )
-    
+
     random_image_group = parser.add_argument_group("random_image dataset options")
     random_image_group.add_argument(
         "--random-image-width",
@@ -1175,7 +1182,7 @@ if __name__ == "__main__":
         default=1280,
         help="Image width, used only for random-image sampling."
         "If bench-single-image-path is not None,"
-        "--random-image-width/--random-image-height will be ignored."
+        "--random-image-width/--random-image-height will be ignored.",
     )
     random_image_group.add_argument(
         "--random-image-height",
@@ -1183,17 +1190,17 @@ if __name__ == "__main__":
         default=720,
         help="Image height, used only for random-image sampling."
         "If bench-single-image-path is not None,"
-        "--random-image-width/--random-image-height will be ignored."
+        "--random-image-width/--random-image-height will be ignored.",
     )
     random_image_group.add_argument(
         "--bench-single-image-path",
         type=str,
         default=None,
         help="Repeat using one image to do the benchmark in random-image sampling."
-             "If bench-single-image-path is not None,"
-             "--random-image-width/--random-image-height will be ignored."
+        "If bench-single-image-path is not None,"
+        "--random-image-width/--random-image-height will be ignored.",
     )
-    
+
     hf_group = parser.add_argument_group("hf dataset options")
     hf_group.add_argument(
         "--hf-subset", type=str, default=None, help="Subset of the HF dataset."


### PR DESCRIPTION
This PR is to port (https://github.com/HabanaAI/vllm-fork/pull/1897) to aice/v1.22.0.
It added random image test for multi-modal models in benchmark_serving.py

This PR support using one single image or fix image resolution to do the
benchmark_serving for multimodal images.

Add random_image dataset options:
  --random-image-height RANDOM_IMAGE_HEIGHT
Image height, used only for random-image sampling.If bench-single-image-path
is not None, --random-image-width/--random-image-height will be ignored.
(default: 720)
  --random-image-width RANDOM_IMAGE_WIDTH
Image width, used only for random-image sampling.If bench-single-image-path is
not None, --random-image-width/--random-image-height will be ignored.
(default: 1280)
  --bench-single-image-path SINGLE_IMAGE_PATH
Repeat using one image to do the benchmark in random-image sampling. If
bench-single-image-path is not None,
--random-image-width/--random-image-height will be ignored. (default:
None)

Example1: Using cherry_blossom.jpg to do the benchmark
python3 benchmark_serving.py --model Qwen/Qwen2.5-VL-3B-Instruct/
--backend openai-chat --endpoint /v1/chat/completions \
--dataset-name random_image   \
--num-prompts 10   \
--bench-single-image-path ./cherry_blossom.jpg 

Example2: Using random image with fix width(1280) and height(720).
python3 benchmark_serving.py --model Qwen/Qwen2.5-VL-3B-Instruct/
--backend openai-chat --endpoint /v1/chat/completions \
--dataset-name random_image   \
--random-image-width 1280   \
--random-image-height 720   \
--random-input-len 2048   \
--random-output-len 128   \
--max-concurrency 16   \
--num-prompts 10   \
