### PR TITLE
fix logging bug in qwen2_vl

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -795,11 +795,8 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
         if padding_len <= 0:
             return pixel_values, image_grid_thw
 
-        logger_msg = "[Multimodal] Padding current number pixel " \
-            + str(pixel_values.shape[0]) \
-            + " to " \
-            + str(desired_number_of_pixels)
-        logger.debug(logger_msg)
+        logger.info("[MM_BUCKETING] Padding current number pixel %s to %s ",
+                    pixel_values.shape[0], desired_number_of_pixels)
 
         # needs to make sure padding_len is even
         assert padding_len % 4 == 0, \


### PR DESCRIPTION
This pr fix the logging bug in qwen2vl:
TypeError: not all arguments converted during string formatting
  File "/workspace/vllm-fork/vllm/model_executor/models/qwen2_vl.py", line 798, in pad_multimodal_data
    logger.info("[MM_BUCKETING] Padding current number pixel {} to {}",
Message: '[MM_BUCKETING] Padding current number pixel {} to {}'
Arguments: (4988, 6400)

Test:
VLLM_IMAGE_FETCH_TIMEOUT=60 VLLM_SKIP_WARMUP=true PT_HPU_LAZY_MODE=1 python  examples/offline_inference/vision_language.py --model-type qwen2_vl