### PR TITLE
[HS-6971] Add speculative decoding metrics for hpu

### DIFF
--- a/vllm/spec_decode/metrics.py
+++ b/vllm/spec_decode/metrics.py
@@ -102,7 +102,7 @@ class AsyncMetricsCollector:
         if current_platform.Event is None:
             return None
 
-        if not current_platform.is_cuda_alike():
+        if not (current_platform.is_hpu() or current_platform.is_cuda_alike()):
             return None
 
         # If a copy was initiated in the previous call, collect and return.


### PR DESCRIPTION
## Purpose
Fixes #1921.

`is_cuda_alike()` was returning `None` when evaluated as `False`, which disabled speculative decoding metrics.
This PR ensures that `is_hpu()` is added `is_cuda_alike()` to return a correct boolean value, so speculative decoding metrics are properly enabled.
