### PR TITLE
Fix shutdown issue of inc during exit (#1485)

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -4316,7 +4316,6 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 CompletionSequenceGroupOutput(seq_outputs, None))
         return SamplerOutput(sampler_outputs)
 
-
     def _patch_prev_output(self):
         if self.has_patched_prev_output:
             return

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -4316,8 +4316,6 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 CompletionSequenceGroupOutput(seq_outputs, None))
         return SamplerOutput(sampler_outputs)
 
-    def __del__(self):
-        self.shutdown_inc()
 
     def _patch_prev_output(self):
         if self.has_patched_prev_output:


### PR DESCRIPTION
Please reveiw @czhu15 

Bug fix

- Fix bug during shuting down
Exception ignored in: <function HPUModelRunner.del at 0x7f02148c3880>
Traceback (most recent call last):
File
"/usr/local/lib/python3.10/dist-packages/vllm/worker/hpu_model_runner.py", line 3505, in del
File
"/usr/local/lib/python3.10/dist-packages/vllm/worker/hpu_model_runner.py", line 3492, in shutdown_inc
ImportError: sys.meta_path is None, Python is likely shutting down

When you use llm.llm_engine.model_executor.shutdown(), this inc shutdown will be called here:
https://github.com/HabanaAI/vllm-fork/blob/19701377009bc503b1be48418ceb90dd4919a869/vllm/worker/hpu_worker.py#L497

The __del__ method is invoked when an object is destroyed, but Python's garbage collection mechanism does not guarantee ​​when​​ the __del__ method will be executed, especially during program termination. Since __del__ is not reliable, I remove shoutdown_inc from it.
