### PR TITLE
fix bug in merge_multimodal_embeddings on HPU

### DIFF
--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -458,7 +458,7 @@ def _merge_multimodal_embeddings(
             flattened = _flatten_embeddings(multimodal_embeddings)
             inputs_embeds[is_multimodal] = flattened
         inputs_embeds = inputs_embeds.reshape(batch_size, seq_length,
-                                                  hidden_size)
+                                              hidden_size)
 
         return inputs_embeds
     num_expected_tokens = is_multimodal.sum().item()


### PR DESCRIPTION
## Purpose
This PR is porting https://github.com/HabanaAI/vllm-fork/pull/1436 to 1.22.0 Without this PR, when PT_HPU_LAZY_MODE=1 ,QwenVL result is incorrect.

## Tested models
PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true python examples/offline_inference/vision_language.py -m glm4v
PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true python examples/offline_inference/vision_language.py -m qwen_vl
PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true python examples/offline_inference/vision_language.py -m qwen2_vl
PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true python examples/offline_inference/vision_language.py -m qwen2_5_vl
PT_HPU_LAZY_MODE=1 VLLM_SKIP_WARMUP=true python examples/offline_inference/vision_language.py -m qwen2_5_omni
