### PR TITLE
Aice/v1.22.0 qwen2vl

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -85,11 +85,12 @@ if is_hpu:
     import habana_frameworks.torch as htorch
     import habana_frameworks.torch.core as htcore
     from habana_frameworks.torch.hpex.kernels import FusedSDPA
-    
+
 # For profile run
 _MAX_FRAMES_PER_VIDEO = 16
 
 # === Vision Inputs === #
+
 
 class AttentionLongSequence:
 
@@ -137,6 +138,7 @@ def create_block_diagonal_attention_mask_outerprod(indices):
     else:
         res = torch.einsum('bi,bj->ij', range_indices, range_indices)
     return res.bool()
+
 
 class Qwen2VLImagePixelInputs(TypedDict):
     type: Literal["pixel_values"]
@@ -765,6 +767,7 @@ class Qwen2VisionTransformer(nn.Module):
             loaded_params.add(name)
         return loaded_params
 
+
 class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
     """
     Here we overwrite some of the methods of Qwen2_5_VisionTransformer
@@ -841,7 +844,6 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
 
         return hidden_states
 
-
     def get_image_embeds(
         self,
         pixel_values: torch.Tensor,
@@ -875,7 +877,7 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
                     (cu_seqlens)
             assert pixel_values_curr_img_padded.shape[0] == \
                 rot_pos_emb.shape[0]
-                
+
             extra_forward_kwargs = {}
             if htorch.utils.internal.is_lazy():
                 padded_len = pixel_values_curr_img_padded.shape[0]

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -82,6 +82,7 @@ logger = init_logger(__name__)
 is_hpu = current_platform.is_hpu()
 
 if is_hpu:
+    import habana_frameworks.torch as htorch
     import habana_frameworks.torch.core as htcore
     from habana_frameworks.torch.hpex.kernels import FusedSDPA
     
@@ -871,11 +872,19 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
                     (cu_seqlens)
             assert pixel_values_curr_img_padded.shape[0] == \
                 rot_pos_emb.shape[0]
+                
+            extra_forward_kwargs = {}
+            if htorch.utils.internal.is_lazy():
+                padded_len = pixel_values_curr_img_padded.shape[0]
+                use_graph = vision_buckets.use_graph(padded_len)
+                extra_forward_kwargs.update(
+                    {"bypass_hpu_graphs": not use_graph})
 
             htcore.mark_step()
             hidden_states = self.forward(pixel_values_curr_img_padded,
                                          rotary_pos_emb=rot_pos_emb,
-                                         fullattn_mask=fullatt_block_attn_mask)
+                                         fullattn_mask=fullatt_block_attn_mask,
+                                         **extra_forward_kwargs)
             htcore.mark_step()
 
             image_embeds = self.post_attn(hidden_states)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -24,6 +24,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only Qwen2-VL model compatible with HuggingFace weights."""
+import math
 from collections.abc import Iterable, Mapping, Sequence
 from functools import partial
 from typing import Any, Callable, Literal, Optional, TypedDict, Union
@@ -78,12 +79,63 @@ from .utils import (AutoWeightsLoader, WeightsMapper,
 from .vision import get_vit_attn_backend
 
 logger = init_logger(__name__)
+is_hpu = current_platform.is_hpu()
 
+if is_hpu:
+    import habana_frameworks.torch.core as htcore
+    from habana_frameworks.torch.hpex.kernels import FusedSDPA
+    
 # For profile run
 _MAX_FRAMES_PER_VIDEO = 16
 
 # === Vision Inputs === #
 
+class AttentionLongSequence:
+
+    @staticmethod
+    def forward(q, k, v, mask, q_block_size, softmax_mode):
+        """
+        Support long sequence at prompt phase
+        """
+        q_len = q.size(-2)
+        assert q_len % q_block_size == 0
+        q_tiles = (q_len //
+                   q_block_size) if (q_len % q_block_size == 0) else math.ceil(
+                       q_len / q_block_size)
+        attn_output = torch.zeros_like(q)
+
+        for i in range(q_tiles):
+            s, e = i * q_block_size, (i + 1) * q_block_size
+            row_q = q[:, :, s:e, :]
+            row_mask = mask[:, :, s:e, :]
+            attn_output[:, :,
+                        s:e, :] = FusedSDPA.apply(row_q, k, v, row_mask, 0.0,
+                                                  False, None, softmax_mode)
+            # TODO: markstep after a couple of iterations
+            # need to experiment the optimal number.
+            if i % 75 == 0:
+                htcore.mark_step()
+        return attn_output
+
+
+def create_block_diagonal_attention_mask_outerprod(indices):
+    maxsize = indices[-1]
+    range_to_max_for_each_img = torch.arange(
+        maxsize,
+        device=indices.device).unsqueeze(0).repeat(indices.shape[0] - 1, 1)
+    lesser = range_to_max_for_each_img < indices[1:].unsqueeze(1)
+    greater_eq = range_to_max_for_each_img >= indices[:-1].unsqueeze(1)
+    range_indices = torch.logical_and(lesser, greater_eq).float()
+    # can reduce sum externally or as batchmatmul
+    if range_indices.shape[-1] > 40000:
+        log_msg = "einsum running on CPU :" + str(range_indices.shape)
+        logger.info(log_msg)
+        range_indices = range_indices.to("cpu")
+        res = torch.einsum('bi,bj->ij', range_indices, range_indices)
+        res = res.to("hpu")
+    else:
+        res = torch.einsum('bi,bj->ij', range_indices, range_indices)
+    return res.bool()
 
 class Qwen2VLImagePixelInputs(TypedDict):
     type: Literal["pixel_values"]
@@ -343,6 +395,26 @@ class Qwen2VisionAttention(nn.Module):
             context_layer = rearrange(output,
                                       "(b s) ... -> b s ...",
                                       b=batch_size)
+        elif self.attn_backend == _Backend.TORCH_SDPA and is_hpu:
+            # performs full attention using the previous computed mask
+            fullatt_block_attn_mask = cu_seqlens
+            q1, k1, v1 = (rearrange(x, "b s h d -> b h s d")
+                          for x in [q, k, v])
+            (batch_size, _, seq_len_N_t, _) = q1.shape
+            (batch_size, _, seq_len_N_s, _) = k1.shape
+            mask_shape = (batch_size, 1, seq_len_N_t, seq_len_N_s)
+            attn_mask = fullatt_block_attn_mask.reshape(
+                batch_size, 1, seq_len_N_t, seq_len_N_s,
+                -1)[:, :, :, :, 0]  # reshapes the mask to be Bx1xNxN
+            assert attn_mask.shape == mask_shape
+
+            if q1.shape[2] <= 65536:  # need to investigate this crosspoint
+                fused_out = FusedSDPA.apply(q1, k1, v1, attn_mask, 0.0, False,
+                                            None)
+            else:
+                fused_out = AttentionLongSequence.forward(
+                    q1, k1, v1, attn_mask, 64)
+            context_layer = rearrange(fused_out, "b h s d -> b s h d ")
         elif self.attn_backend == _Backend.TORCH_SDPA:
             # Execute attention entry by entry for speed & less VRAM.
             outputs = []
@@ -552,6 +624,7 @@ class Qwen2VisionTransformer(nn.Module):
         self.spatial_merge_size = spatial_merge_size
         self.num_heads = num_heads
         self.embed_dim = embed_dim
+        self.spatial_merge_unit = self.spatial_merge_size**2
 
         self.patch_embed = Qwen2VisionPatchEmbed(
             patch_size=patch_size,
@@ -690,6 +763,128 @@ class Qwen2VisionTransformer(nn.Module):
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params
+
+class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
+    """
+    Here we overwrite some of the methods of Qwen2_5_VisionTransformer
+    to make the model more friendly to static shapes. Specifically,
+    we split the forward  method into:
+      - pre_attn (dynamic)
+      - forward (static shape) 
+      - post_attn (dynamic)
+    and we should call get_image_embeds instead of forward, allowing
+    the forward method ro run with HPU_Graphs, whereas the 
+    pre_attn and post_attn methods are allow to be dynamic.
+    """
+
+    def pad_multimodal_data(self, pixel_values, image_grid_thw,
+                            vision_buckets):
+        assert pixel_values.shape[0] % 4 == 0, 'needs 64 aligned resolution'
+
+        desired_number_of_pixels = vision_buckets.get_multimodal_bucket(
+            pixel_values.shape[0])
+        padding_len = desired_number_of_pixels - pixel_values.shape[0]
+        if padding_len <= 0:
+            return pixel_values, image_grid_thw
+
+        logger.info(
+            f"[MM_BUCKETING] Padding current number pixel {pixel_values.shape[0]} to {desired_number_of_pixels}"
+        )
+        constant_value = -100
+        pixel_values = torch.cat([
+            pixel_values,
+            torch.ones((padding_len, pixel_values.shape[1]), \
+                device=pixel_values.device) * constant_value
+        ])
+
+        image_grid_thw = torch.cat([
+            image_grid_thw,
+            torch.tensor([[1, 2, padding_len // 2]],
+                         device=image_grid_thw.device)
+        ])
+
+        assert image_grid_thw.prod(-1).sum() == desired_number_of_pixels
+        return pixel_values, image_grid_thw
+
+    def pre_attn(self, x: torch.Tensor, grid_thw: torch.Tensor):
+        # patchify
+        hidden_states = x.to(device=self.device, dtype=self.dtype)
+        hidden_states = self.patch_embed(hidden_states)
+
+        # compute position embedding
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+
+        cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2],
+                                             grid_thw[:, 0]).cumsum(
+                                                 dim=0, dtype=torch.int32)
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), "constant", 0)
+        return hidden_states, rotary_pos_emb, cu_seqlens
+
+    def forward(self, x: torch.Tensor, fullattn_mask: Optional[torch.Tensor],
+                rotary_pos_emb: torch.Tensor) -> torch.Tensor:
+
+        hidden_states = x.unsqueeze(1)
+        for layer_num, blk in enumerate(self.blocks):
+            htcore.mark_step()
+            hidden_states = blk(hidden_states,
+                                cu_seqlens=fullattn_mask,
+                                rotary_pos_emb=rotary_pos_emb)
+        return hidden_states
+
+    def post_attn(self, hidden_states: torch.Tensor):
+        # adapter
+        hidden_states = self.merger(hidden_states)
+
+        return hidden_states
+
+
+    def get_image_embeds(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+        vision_buckets,
+    ) -> torch.Tensor:
+
+        offset = 0
+        results = []
+        # process each image one by one
+        for img_idx in range(grid_thw.shape[0]):
+            img_shape = grid_thw[img_idx, :].unsqueeze(0)
+            curr_img_size = img_shape.prod()
+
+            pixel_values_curr_img = pixel_values[offset:offset +
+                                                 curr_img_size, :]
+
+            offset += curr_img_size
+            pixel_values_curr_img_padded, img_shape_padded = \
+                self.pad_multimodal_data(pixel_values_curr_img, \
+                    img_shape, vision_buckets=vision_buckets)
+
+            pixel_values_curr_img_padded, rot_pos_emb, \
+                cu_seqlens = self.pre_attn(
+            pixel_values_curr_img_padded, img_shape_padded)
+
+            # Create full attention block mask
+            # before VisionTransformer to save memory/time
+            fullatt_block_attn_mask = \
+                create_block_diagonal_attention_mask_outerprod \
+                    (cu_seqlens)
+            assert pixel_values_curr_img_padded.shape[0] == \
+                rot_pos_emb.shape[0]
+
+            htcore.mark_step()
+            hidden_states = self.forward(pixel_values_curr_img_padded,
+                                         rotary_pos_emb=rot_pos_emb,
+                                         fullattn_mask=fullatt_block_attn_mask)
+            htcore.mark_step()
+
+            image_embeds = self.post_attn(hidden_states)
+            # slice image_embeds to remove the padded parts
+            pad_index = img_shape_padded[0].prod() // self.spatial_merge_unit
+            results += [image_embeds[:pad_index, :]]
+        results_cat = torch.concat(results)
+        image_embeds = results_cat
+        return image_embeds
 
 
 def _qwen2vl_field_config(hf_inputs: Mapping[str, torch.Tensor]):
@@ -1091,7 +1286,11 @@ class Qwen2VLForConditionalGeneration(nn.Module, SupportsMultiModal,
         self.config = config
         self.multimodal_config = multimodal_config
 
-        self.visual = Qwen2VisionTransformer(
+        if is_hpu:
+            qwen2_visionTransformer = Qwen2VisionTransformerStaticShape
+        else:
+            qwen2_visionTransformer = Qwen2VisionTransformer
+        self.visual = qwen2_visionTransformer(
             config.vision_config,
             norm_eps=getattr(config, "rms_norm_eps", 1e-6),
             quant_config=self._maybe_ignore_quant_config(quant_config),
@@ -1211,7 +1410,16 @@ class Qwen2VLForConditionalGeneration(nn.Module, SupportsMultiModal,
             image_embeds = image_input["image_embeds"].type(self.visual.dtype)
         else:
             pixel_values = image_input["pixel_values"].type(self.visual.dtype)
-            image_embeds = self.visual(pixel_values, grid_thw=grid_thw)
+            if is_hpu:
+                assert isinstance(self.visual,
+                                  Qwen2VisionTransformerStaticShape)
+                image_embeds = self.visual.get_image_embeds(
+                    pixel_values,
+                    grid_thw=grid_thw,
+                    vision_buckets=self.vision_buckets,
+                )
+            else:
+                image_embeds = self.visual(pixel_values, grid_thw=grid_thw)
 
         # Split concatenated embeddings for each image item.
         merge_size = self.visual.spatial_merge_size
@@ -1230,7 +1438,17 @@ class Qwen2VLForConditionalGeneration(nn.Module, SupportsMultiModal,
         else:
             pixel_values_videos = video_input["pixel_values_videos"].type(
                 self.visual.dtype)
-            video_embeds = self.visual(pixel_values_videos, grid_thw=grid_thw)
+            if is_hpu:
+                assert isinstance(self.visual,
+                                  Qwen2VisionTransformerStaticShape)
+                video_embeds = self.visual.get_image_embeds(
+                    pixel_values_videos,
+                    grid_thw=grid_thw,
+                    vision_buckets=self.vision_buckets,
+                )
+            else:
+                video_embeds = self.visual(pixel_values_videos,
+                                           grid_thw=grid_thw)
 
         # Split concatenated embeddings for each video item.
         merge_size = self.visual.spatial_merge_size

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -93,7 +93,7 @@ _MAX_FRAMES_PER_VIDEO = 16
 class AttentionLongSequence:
 
     @staticmethod
-    def forward(q, k, v, mask, q_block_size, softmax_mode):
+    def forward(q, k, v, mask, q_block_size):
         """
         Support long sequence at prompt phase
         """
@@ -110,7 +110,7 @@ class AttentionLongSequence:
             row_mask = mask[:, :, s:e, :]
             attn_output[:, :,
                         s:e, :] = FusedSDPA.apply(row_q, k, v, row_mask, 0.0,
-                                                  False, None, softmax_mode)
+                                                  False, None)
             # TODO: markstep after a couple of iterations
             # need to experiment the optimal number.
             if i % 75 == 0:

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -788,9 +788,12 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
         if padding_len <= 0:
             return pixel_values, image_grid_thw
 
-        logger.info(
-            f"[MM_BUCKETING] Padding current number pixel {pixel_values.shape[0]} to {desired_number_of_pixels}"
-        )
+        logger_msg = "Padding current number pixel " \
+            + str(pixel_values.shape[0]) \
+            + " to " \
+            + str(desired_number_of_pixels)
+        logger.debug(logger_msg)
+
         constant_value = -100
         pixel_values = torch.cat([
             pixel_values,


### PR DESCRIPTION
## Purpose
This  PR is porting https://github.com/HabanaAI/vllm-fork/pull/1379 to v1.22.0 to enable qwen2vl.
## Test
PT_HPU_LAZY_MODE=1 python examples/offline_inference/vision_language.py --modality video --model-type qwen2_vl
PT_HPU_LAZY_MODE=1 python examples/offline_inference/vision_language.py --modality image --model-type qwen2_vl