### PR TITLE
Fix pooling (classify or embed) model returns nan when dtype is float16 (or downcasted to float16) (#1441)

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -514,6 +514,8 @@ class HpuModelAdapter(torch.nn.Module):
             len_mask_v = len_mask.view(batch_size, 1, seq_len, 1)
             mask = attn_mask.logical_or(len_mask).logical_or(len_mask_v)
             off_value = -3E38  #small number, avoid nan and overflow
+            if dtype == torch.float16:
+                off_value = -63000  # a small value close to float16.min
         else:
             mask = attn_mask.logical_or(
                 len_mask)  #no need for len_mask_v as decode overwrites it


### PR DESCRIPTION
Please review @czhu15 

```
========================================
       SMOKE TEST REPORT
========================================
Test Time:    Wed Sep 17 13:46:16 CST 2025
Target Text:  paris
Test Query:   The capital of France is?
========================================

Model:        DeepSeek-R1-Distill-Qwen-7B
Model Path:   /data/hf_models/DeepSeek-R1-Distill-Qwen-7B
HPU Cards:    1
Result:       PASS
Status:       SUCCESS
Response:     <think>

</think>

The capital of France is Paris.
----------------------------------------

Model:        Qwen3-32B
Model Path:   /data/hf_models/Qwen3-32B
HPU Cards:    1
Result:       PASS
Status:       SUCCESS
Response:     <think>
Okay, so the user is asking, "The capital of France is?" Hmm, I need to figure out the answer. Let me start by recalling what I know about France. France is a country in Europe, right? I remember that Paris is a major city there. Wait, isn't Paris known for the Eiffel Tower and the Louvre? Yeah, that's right. But is Paris the capital?

Wait, sometimes countries have their capital in a different city than the largest city. For example, the capital of the United States is Washington, D.C., not New York City. But in France's case,
----------------------------------------

Model:        Qwen3-30B-A3B
Model Path:   /data/hf_models/Qwen3-30B-A3B
HPU Cards:    2
Result:       PASS
Status:       SUCCESS
Response:     <think>
Okay, the user is asking, "The capital of France is?" Let me think about how to approach this.

First, I know that the capital of a country is the city where the government is located. For France, I'm pretty sure the capital is Paris. But I should double-check to make sure I'm not confusing it with another city. Sometimes people might mix up capitals with other major cities.

Wait, what's the capital of France again? Let me recall. I remember that Paris is the capital, but maybe there's a common mistake here. For example, some people might think it's Lyon or Marseille,
----------------------------------------

SUMMARY:
Total Models: 3
Passed:       3
Failed:       0
========================================
```