### PR TITLE
Fix warmup error when pooling (embedding and clasification) is running (#1442)

### DIFF
--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -249,6 +249,7 @@ class PoolerHead(nn.Module):
         dimensions_list = [
             pooling_param.dimensions if pooling_param is not None else None
             for _, pooling_param in pooling_metadata.seq_groups
+            if pooling_param is not None
         ]
         if any(d is not None for d in dimensions_list):
             # change the output dimension


### PR DESCRIPTION
by checking if pooling_param is None

Please review @czhu15

```
========================================
       SMOKE TEST REPORT
========================================
Test Time:    Wed Sep 17 14:18:50 CST 2025
Target Text:  paris
Test Query:   The capital of France is?
========================================

Model:        DeepSeek-R1-Distill-Qwen-7B
Model Path:   /data/hf_models/DeepSeek-R1-Distill-Qwen-7B
HPU Cards:    1
Result:       PASS
Status:       SUCCESS
Response:     <think>

</think>

The capital of France is Paris.
----------------------------------------

Model:        Qwen3-32B
Model Path:   /data/hf_models/Qwen3-32B
HPU Cards:    1
Result:       PASS
Status:       SUCCESS
Response:     <think>
Okay, so the user is asking, "The capital of France is?" Hmm, I need to figure out the answer. Let me start by recalling what I know about France. France is a country in Europe, right? I remember that Paris is a major city there. Wait, isn't Paris known for the Eiffel Tower and the Louvre? Yeah, that's right. But is Paris the capital?

Wait, sometimes countries have their capital in a different city than the largest city. For example, the capital of the United States is Washington, D.C., not New York City. But in France's case,
----------------------------------------

Model:        Qwen3-30B-A3B
Model Path:   /data/hf_models/Qwen3-30B-A3B
HPU Cards:    2
Result:       PASS
Status:       SUCCESS
Response:     <think>
Okay, the user is asking, "The capital of France is?" Let me think about how to approach this.

First, I know that the capital of a country is the city where the government is located. For France, I'm pretty sure the capital is Paris. But I should double-check to make sure I'm not confusing it with another city. Sometimes people might mix up capitals with other major cities.

Wait, what's the capital of France again? Let me recall. I remember that Paris is the capital, but maybe there's a common mistake here. For example, some people might think it's Lyon or Marseille,
----------------------------------------

SUMMARY:
Total Models: 3
Passed:       3
Failed:       0
========================================
```