### PR TITLE
[aice/1.22.0] Improve ngram speculative decoding

### DIFF
--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -443,7 +443,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
 
     @staticmethod
     def _split_scoring_output_hpu(
-        sampler_output: SamplerOutput, 
+        sampler_output: SamplerOutput,
         num_scoring_tokens: int,
         non_spec_indices: List[int],
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor,


### PR DESCRIPTION
Porting from https://github.com/HabanaAI/vllm-fork/pull/1780, and test it in aice/v1.22.0 @czhu15 

Fix the accuracy issue.

1, Speculative decoding fails (low accuracy) when batch size exceeds 1 due to incorrect handling of mixed speculative and non-speculative sequences in the batch.
2, This PR corrects batch expansion ordering and accounts for padding sequences.
Implemented by Voas, Tanner [tanner.voas@intel.com](mailto:tanner.voas@intel.com).

Below is a reference to the original PR which explains why these changes are needed.

- Speculative decoding fails (low accuracy) when batch size exceeds 1 due to incorrect handling of mixed speculative and non-speculative sequences in the batch.
- This PR corrects batch expansion ordering and accounts for padding sequences.

Below is a reference to the line where we combine speculative and non-speculative. The order is clearly non-speculative first followed by speculative.
https://github.com/HabanaAI/vllm-fork/blob/4d91f3bf48381073e51deb0c03c19457c1ee5137/vllm/spec_decode/batch_expansion.py#L135

Below is a reference to the line where we pad the batch with dummy sequences. These also must be accounted for.
https://github.com/HabanaAI/vllm-fork/blob/4d91f3bf48381073e51deb0c03c19457c1ee5137/vllm/worker/hpu_model_runner.py#L1270-L1275

It should be noted that even with this fix performance and accuracy with ngram speculative decoding is below what is expected. We expect significant performance gains when using ngram speculative decoding (observed previously with llama-3.1-8B) with little to no accuracy loss. However when we tested this branch on QWQ-32B we observed lower performance and accuracy than the non-speculative case.