### PR TITLE
Introduce VLLM_WARMUP_WITH_PENALTY

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2775,11 +2775,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                         img_args=None,
                                         temperature=0,
                                         presence_penalty=0.0,
+                                        top_p=1.0,
                                         ctx=0):
         if self.is_pooler:
             sampling_params = None
         else:
-            sampling_params = SamplingParams(temperature=temperature, presence_penalty=presence_penalty)
+            sampling_params = SamplingParams(temperature=temperature,
+                                             presence_penalty=presence_penalty,
+                                             top_p=top_p)
         num_blocks = math.ceil(seq_len / self.block_size)
         seq_len = max(seq_len, 1)
         computed_block_nums = None
@@ -2936,6 +2939,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.profiler.start('internal', scenario_name)
         times = num_iters if use_graphs or is_pt_profiler_run else 1
         presence_penalty = 1.0 if os.getenv('VLLM_WARMUP_WITH_PENALTY', '0') == '1' else 0.0
+        top_p = 0.1 if os.getenv('VLLM_WARMUP_WITH_PENALTY', '0') == '1' else 1.0
+        temperature = 1.0 if os.getenv('VLLM_WARMUP_WITH_PENALTY', '0') == '1' else 0.0
         if is_prompt:
             seqs = [
                 self.create_dummy_seq_group_metadata(
@@ -2947,6 +2952,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                     img_args=img_args,
                     temperature=temperature,
                     presence_penalty=presence_penalty,
+                    top_p=top_p,
                     ctx=ctx) for i in range(batch_size)
             ]
         else:
@@ -2961,6 +2967,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                     if dummy_lora_requests_per_seq else None,
                     temperature=temperature,
                     presence_penalty=presence_penalty,
+                    top_p=top_p,
                     ctx=ctx) for i, b in enumerate(blocks)
             ]
         if not is_dummy_run:


### PR DESCRIPTION
Introduce VLLM_WARMUP_WITH_PENALTY to call apply penalty code in sampler during warmup also.

https://github.com/HabanaAI/vllm-fork/blob/libint/intervl_bucket/vllm/model_executor/layers/sampler.py#L280 is not called during warmup.
And it causes extra graph compile during runtime as it sets to True for real run.


## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose

## Test Plan

## Test Result

<!--- pyml disable-next-line no-emphasis-as-heading -->
