### PR TITLE
intervl:cache prompt_tokens and output_tokens for  penalty sampling

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -198,7 +198,8 @@ class Sampler(nn.Module):
         self.include_gpu_probs_tensor = False
         self.should_modify_greedy_probs_inplace = False
         # Add HPU cache class variables  
-        self._prompt_tokens_hpu_cache: Optional[torch.Tensor] = None  
+        self._prompt_tokens_hpu_cache: Optional[torch.Tensor] = None
+        self._output_tokens_hpu_cache: Optional[torch.Tensor] = None
         self._cached_seq_ids: Optional[set] = None
         
 
@@ -221,7 +222,8 @@ class Sampler(nn.Module):
         # Initialize new sampling tensors
         (sampling_tensors, do_penalties, do_top_p_top_k, do_min_p,
          top_k_scalar, top_p_scalar, current_seq_ids) = SamplingTensors.from_sampling_metadata(
-             sampling_metadata, vocab_size, logits.device, logits.dtype, self._prompt_tokens_hpu_cache, self._cached_seq_ids)
+            sampling_metadata, vocab_size, logits.device, logits.dtype, \
+            self._prompt_tokens_hpu_cache, self._output_tokens_hpu_cache, self._cached_seq_ids)
 
         self._sampling_tensors = sampling_tensors
         self._do_penalties = do_penalties
@@ -236,6 +238,7 @@ class Sampler(nn.Module):
         # After tensors are created, update cache
         if self._cached_seq_ids != current_seq_ids:
             self._prompt_tokens_hpu_cache = None
+            self._output_tokens_hpu_cache = None
             self._cached_seq_ids = current_seq_ids
 
             

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -271,7 +271,7 @@ class Sampler(nn.Module):
         """
         assert logits is not None
         _, vocab_size = logits.shape
-        #import remote_pdb;remote_pdb.set_trace()
+
         # Prepare sampling tensors with pinned memory to avoid blocking.
         if not sampling_metadata.reuse_sampling_tensors:
             self._init_sampling_tensors(logits, sampling_metadata)
@@ -290,15 +290,13 @@ class Sampler(nn.Module):
         do_min_p = self._do_min_p
 
         logits = _apply_min_tokens_penalty(logits, sampling_metadata)
-        #import remote_pdb;remote_pdb.set_trace()
         # Apply presence and frequency penalties.
         if do_penalties:
             logits = apply_penalties(logits, sampling_tensors.prompt_tokens,
                                      sampling_tensors.output_tokens,
                                      sampling_tensors.presence_penalties,
                                      sampling_tensors.frequency_penalties,
-                                     sampling_tensors.repetition_penalties,
-                                     self._prompt_mask_hpu_cache, self._last_prompt_mask)
+                                     sampling_tensors.repetition_penalties)
 
         # Use float32 to apply temperature scaling.
         # Use in-place division to avoid creating a new tensor.

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -199,9 +199,7 @@ class Sampler(nn.Module):
         self.should_modify_greedy_probs_inplace = False
         # Add HPU cache class variables  
         self._prompt_tokens_hpu_cache: Optional[torch.Tensor] = None  
-        self._prompt_mask_hpu_cache: Optional[torch.Tensor] = None  
         self._cached_seq_ids: Optional[set] = None
-        self._last_prompt_mask: Optional[torch.Tensor] = None
         
 
     def _init_sampling_tensors(
@@ -236,11 +234,9 @@ class Sampler(nn.Module):
         # Check if batch composition changed - if so, invalidate prompt cache
             
         # After tensors are created, update cache
-        logger.info(f"libin debug init_sampling {self._cached_seq_ids=} {current_seq_ids}")
         if self._cached_seq_ids != current_seq_ids:
             self._prompt_tokens_hpu_cache = None
             self._cached_seq_ids = current_seq_ids
-            self._prompt_mask_hpu_cache = None
 
             
 

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -197,6 +197,9 @@ class Sampler(nn.Module):
         # speculative decoding and when prompt embeddings are specified.
         self.include_gpu_probs_tensor = False
         self.should_modify_greedy_probs_inplace = False
+        # Add HPU cache class variables  
+        self._prompt_tokens_hpu_cache = None  
+        self._cached_seq_ids = None
 
     def _init_sampling_tensors(
         self,
@@ -216,8 +219,8 @@ class Sampler(nn.Module):
 
         # Initialize new sampling tensors
         (sampling_tensors, do_penalties, do_top_p_top_k, do_min_p,
-         top_k_scalar, top_p_scalar) = SamplingTensors.from_sampling_metadata(
-             sampling_metadata, vocab_size, logits.device, logits.dtype)
+         top_k_scalar, top_p_scalar, current_seq_ids) = SamplingTensors.from_sampling_metadata(
+             sampling_metadata, vocab_size, logits.device, logits.dtype, self._prompt_tokens_hpu_cache, self._cached_seq_ids)
 
         self._sampling_tensors = sampling_tensors
         self._do_penalties = do_penalties
@@ -227,6 +230,16 @@ class Sampler(nn.Module):
         self._top_p_scalar = top_p_scalar
 
         self._apply_top_k_top_p_opt = ApplyToppTopkScalar(5)
+        # Check if batch composition changed - if so, invalidate prompt cache
+            
+        # After tensors are created, update cache
+        logger.info(f"libin debug init_sampling {self._cached_seq_ids=} {current_seq_ids}")
+        if self._cached_seq_ids != current_seq_ids:
+            
+            self._prompt_tokens_hpu_cache = None
+            self._cached_seq_ids = current_seq_ids
+
+            
 
     def forward(
         self,

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -3,7 +3,7 @@
 """Utility methods for model layers."""
 from typing import Callable, Optional
 
-import torch,time
+import torch
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.platforms import current_platform
@@ -49,7 +49,6 @@ def apply_penalties(logits: torch.Tensor, prompt_tokens_tensor: torch.Tensor,
         output_tokens_tensor, vocab_size, num_seqs)
     # Apply repetition penalties as a custom op
     from vllm._custom_ops import apply_repetition_penalties
-
     apply_repetition_penalties(logits, prompt_mask, output_mask,
                                repetition_penalties)
 

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -8,7 +8,9 @@ import torch,time
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.platforms import current_platform
+from vllm.logger import init_logger
 
+logger = init_logger(__name__)
 
 def get_token_bin_counts_and_mask(
     tokens: torch.Tensor,
@@ -17,16 +19,12 @@ def get_token_bin_counts_and_mask(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # Compute the bin counts for the tokens.
     # vocab_size + 1 for padding.
-    #import pdb;pdb.set_trace()
-    t1 = time.perf_counter()
     bin_counts = torch.zeros((num_seqs, vocab_size + 1),
                              dtype=torch.long,
                              device=tokens.device)
     bin_counts.scatter_add_(1, tokens, torch.ones_like(tokens))
     bin_counts = bin_counts[:, :vocab_size]
     mask = bin_counts > 0
-    t2 = time.perf_counter()
-    print(f"libin debug get_token_bin_counts_and_mask time:{t2-t1} {tokens.device=} {num_seqs=} {vocab_size=}")
     return bin_counts, mask
 
 
@@ -34,7 +32,9 @@ def apply_penalties(logits: torch.Tensor, prompt_tokens_tensor: torch.Tensor,
                     output_tokens_tensor: torch.Tensor,
                     presence_penalties: torch.Tensor,
                     frequency_penalties: torch.Tensor,
-                    repetition_penalties: torch.Tensor) -> torch.Tensor:
+                    repetition_penalties: torch.Tensor,
+                    prompt_mask_hpu_cache: torch.Tensor,
+                    last_prompt_mask: torch.Tensor) -> torch.Tensor:
     """
     Applies penalties in place to the logits tensor
     logits : The input logits tensor of shape [num_seqs, vocab_size]
@@ -50,8 +50,16 @@ def apply_penalties(logits: torch.Tensor, prompt_tokens_tensor: torch.Tensor,
     """
     #import remote_pdb;remote_pdb.set_trace()
     num_seqs, vocab_size = logits.shape
-    _, prompt_mask = get_token_bin_counts_and_mask(prompt_tokens_tensor,
+    if prompt_mask_hpu_cache is None:
+        _, prompt_mask = get_token_bin_counts_and_mask(prompt_tokens_tensor,
                                                    vocab_size, num_seqs)
+    else:
+        prompt_mask = prompt_mask_hpu_cache
+    
+    last_prompt_mask = prompt_mask
+    #import remote_pdb;remote_pdb.set_trace()
+    logger.info(f"libin apply_penality found cache for prompt_mask {last_prompt_mask=}")
+
     output_bin_counts, output_mask = get_token_bin_counts_and_mask(
         output_tokens_tensor, vocab_size, num_seqs)
 

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -3,7 +3,7 @@
 """Utility methods for model layers."""
 from typing import Callable, Optional
 
-import torch
+import torch,time
 
 from vllm import _custom_ops as ops
 from vllm import envs
@@ -17,13 +17,16 @@ def get_token_bin_counts_and_mask(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # Compute the bin counts for the tokens.
     # vocab_size + 1 for padding.
+    #import pdb;pdb.set_trace()
+    t1 = time.perf_counter()
     bin_counts = torch.zeros((num_seqs, vocab_size + 1),
                              dtype=torch.long,
                              device=tokens.device)
     bin_counts.scatter_add_(1, tokens, torch.ones_like(tokens))
     bin_counts = bin_counts[:, :vocab_size]
     mask = bin_counts > 0
-
+    t2 = time.perf_counter()
+    print(f"libin debug get_token_bin_counts_and_mask time:{t2-t1} {tokens.device=} {num_seqs=} {vocab_size=}")
     return bin_counts, mask
 
 
@@ -45,6 +48,7 @@ def apply_penalties(logits: torch.Tensor, prompt_tokens_tensor: torch.Tensor,
     frequency_penalties: The frequency penalties of shape (num_seqs, )
     repetition_penalties: The repetition penalties of shape (num_seqs, )
     """
+    #import remote_pdb;remote_pdb.set_trace()
     num_seqs, vocab_size = logits.shape
     _, prompt_mask = get_token_bin_counts_and_mask(prompt_tokens_tensor,
                                                    vocab_size, num_seqs)

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -14,11 +14,7 @@ from vllm.sequence import (VLLM_TOKEN_ID_ARRAY_TYPE, SequenceData,
 from vllm.utils import (PyObjectCache, async_tensor_h2d,
                         is_pin_memory_available, make_tensor_with_pad,
                         make_tensor_with_pad_align)
-from vllm.logger import init_logger
 _SAMPLING_EPS = 1e-5
-
-logger = init_logger(__name__)
-
 pin_memory = is_pin_memory_available()
 is_hpu = current_platform.is_hpu()
 
@@ -416,7 +412,6 @@ class SamplingTensors:
     repetition_penalties: torch.Tensor
     prompt_tokens: torch.Tensor
     output_tokens: torch.Tensor
-
 
     @classmethod
     def from_sampling_metadata(

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -495,7 +495,6 @@ class SamplingTensors:
                 presence_penalties += [p] * sample_lens
                 frequency_penalties += [f] * sample_lens
                 repetition_penalties += [r] * sample_lens
-        prompt_tokens_cache_key = None
         if do_penalties:
             for seq_group in sampling_metadata.seq_groups:
                 seq_ids = seq_group.seq_ids
@@ -517,7 +516,7 @@ class SamplingTensors:
                         current_seq_ids.update(seq_ids)
             if current_seq_ids != past_seq_ids:
                 prompt_tokens_cache = None
-                logger.info(f"libin debug reset  prompt_tokens_cache as {current_seq_ids=} {past_seq_ids=}")
+                logger.info(f"libin debug from_sampling_metadata reset  prompt_tokens_cache as {current_seq_ids=} {past_seq_ids=}")
 
         top_k_scalar = top_ks[0] if do_top_p_top_k and all(
             k == top_ks[0] for k in top_ks) else None
@@ -539,6 +538,7 @@ class SamplingTensors:
             dtype,
             prompt_tokens_cache,
         )
+        logger.info(f"libin debug from_sampling_metadata {do_penalties=}")
         return (sampling_tensors, do_penalties, do_top_p_top_k, do_min_p,
                 top_k_scalar, top_p_scalar, current_seq_ids)
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3984,7 +3984,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     sampling_tensors = self.model.sampler._sampling_tensors  
                     if sampling_tensors.prompt_tokens.numel() > 0:  
                         # Cache the prompt_tokens tensor that's already on HPU  
-                        self.model.sampler._prompt_tokens_hpu_cache = sampling_tensors.prompt_tokens  
+                        self.model.sampler._prompt_tokens_hpu_cache = sampling_tensors.prompt_tokens
+                        self.model.sampler._prompt_mask_hpu_cache = self.model.sampler._last_prompt_mask
                         #logger.info(f"libin execute_mode assign hpu_cache {self.model.sampler._prompt_tokens_hpu_cache=}")
 
                 if use_delayed_sampling \

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3978,7 +3978,9 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 if self.do_mark_step:
                     htorch.core.mark_step()
 
-                if hasattr(self.model.sampler, '_sampling_tensors') and self.model.sampler._sampling_tensors is not None:
+                if hasattr(self.model.sampler, '_sampling_tensors') and \
+                    self.model.sampler._sampling_tensors is not None and \
+                    self.model.sampler._do_penalties:
                     sampling_tensors = self.model.sampler._sampling_tensors
                     if sampling_tensors.prompt_tokens.numel() > 0:
                         # Cache the prompt_tokens tensor that's already on HPU

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3986,7 +3986,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         # Cache the prompt_tokens tensor that's already on HPU  
                         self.model.sampler._prompt_tokens_hpu_cache = sampling_tensors.prompt_tokens
                         self.model.sampler._prompt_mask_hpu_cache = self.model.sampler._last_prompt_mask
-                        #logger.info(f"libin execute_mode assign hpu_cache {self.model.sampler._prompt_tokens_hpu_cache=}")
+                        
+                        #logger.info(f"libin execute_mode assign hpu_cache {self.model.sampler._last_prompt_mask =}")
 
                 if use_delayed_sampling \
                    and model_input.async_callback is not None:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3985,7 +3985,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     if sampling_tensors.prompt_tokens.numel() > 0:  
                         # Cache the prompt_tokens tensor that's already on HPU  
                         self.model.sampler._prompt_tokens_hpu_cache = sampling_tensors.prompt_tokens  
-                        logger.info(f"libin execute_mode assign hpu_cache {self.model.sampler._prompt_tokens_hpu_cache=}")
+                        #logger.info(f"libin execute_mode assign hpu_cache {self.model.sampler._prompt_tokens_hpu_cache=}")
 
                 if use_delayed_sampling \
                    and model_input.async_callback is not None:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3980,14 +3980,10 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     htorch.core.mark_step()
 
                 if hasattr(self.model.sampler, '_sampling_tensors') and self.model.sampler._sampling_tensors is not None:
-                    #import remote_pdb;remote_pdb.set_trace()
-                    sampling_tensors = self.model.sampler._sampling_tensors  
-                    if sampling_tensors.prompt_tokens.numel() > 0:  
-                        # Cache the prompt_tokens tensor that's already on HPU  
+                    sampling_tensors = self.model.sampler._sampling_tensors
+                    if sampling_tensors.prompt_tokens.numel() > 0:
+                        # Cache the prompt_tokens tensor that's already on HPU
                         self.model.sampler._prompt_tokens_hpu_cache = sampling_tensors.prompt_tokens
-                        self.model.sampler._prompt_mask_hpu_cache = self.model.sampler._last_prompt_mask
-                        
-                        #logger.info(f"libin execute_mode assign hpu_cache {self.model.sampler._last_prompt_mask =}")
 
                 if use_delayed_sampling \
                    and model_input.async_callback is not None:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1,4 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 ###############################################################################
@@ -3985,6 +3984,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     if sampling_tensors.prompt_tokens.numel() > 0:
                         # Cache the prompt_tokens tensor that's already on HPU
                         self.model.sampler._prompt_tokens_hpu_cache = sampling_tensors.prompt_tokens
+                    if sampling_tensors.output_tokens.numel() > 0:
+                        self.model.sampler._output_tokens_hpu_cache = sampling_tensors.output_tokens
 
                 if use_delayed_sampling \
                    and model_input.async_callback is not None:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3856,7 +3856,6 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         bool(model_input.multi_modal_kwargs and \
                        ('pixel_values')in model_input.multi_modal_kwargs))
                     execute_model_kwargs['attn_metadata'] = attn_metadata
-                logger.info(f"libin debug execute_model {execute_model_kwargs['input_ids'].shape=}")
                 if not bypass_model_exec:
                     if self.model_is_mrope or self.is_mm_optimized:
                         if ('pixel_values') in execute_model_kwargs and \


### PR DESCRIPTION
in sampling if do penalties, the prompt_tokens regenerates for each decode, that takes time. instead 
we can use cache it, and reset when requests set changes


## Purpose

## Test Plan

## Test Result

<!--- pyml disable-next-line no-emphasis-as-heading -->
