### PR TITLE
Fix: ensure prompt length matches requested length in RandomDataset

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -354,6 +354,14 @@ class RandomDataset(BenchmarkDataset):
             ]
             prompt = tokenizer.decode(re_encoded_sequence)
             total_input_len = prefix_len + int(input_lens[i])
+            # Ensure the final prompt length matches exactly what was requested
+            # by encoding with special tokens and truncating if necessary
+            final_encoded = tokenizer.encode(prompt, add_special_tokens=True)
+            if len(final_encoded) > total_input_len:
+                # Truncate and decode again to get exact length
+                final_encoded = final_encoded[:total_input_len]
+                prompt = tokenizer.decode(final_encoded)
+
             requests.append(
                 SampleRequest(
                     prompt=prompt,


### PR DESCRIPTION
- Add validation to ensure final prompt length matches the requested total_input_len
- Encode prompt with special tokens and truncate if necessary
- Decode again to get exact length as requested
- This prevents discrepancies between requested and actual prompt lengths

## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS ABOVE HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

<!--- pyml disable-next-line no-emphasis-as-heading -->
**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
