### PR TITLE
Port: Fix not cleared globals in runtime config (#1983)

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -7,7 +7,7 @@ ray<2.49.0
 triton==3.1.0
 setuptools>=77.0.3
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@048015b
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@7717587
 
 # Dependencies for HPU vllm docker image
 datasets

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -36,7 +36,8 @@ from vllm_hpu_extension.profiler import (HabanaHighLevelProfiler,
                                          HabanaMemoryProfiler,
                                          HabanaProfilerCounterHelper,
                                          format_bytes)
-from vllm_hpu_extension.runtime import finalize_config, get_config
+from vllm_hpu_extension.runtime import (clear_config, finalize_config,
+                                        get_config)
 
 import vllm.envs as envs
 from vllm.attention import AttentionMetadata, get_attn_backend
@@ -4122,6 +4123,7 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         return SamplerOutput(sampler_outputs)
 
     def __del__(self):
+        clear_config()
         self.shutdown_inc()
 
     def _patch_prev_output(self):


### PR DESCRIPTION
Related change in extension:
https://github.com/HabanaAI/vllm-hpu-extension/pull/370

The PR fixes case when we run vllm multiple times in the same process, e.g. running some pytest scenarios.

Cherry-pick from v1.23.0: https://github.com/HabanaAI/vllm-fork/pull/1983