### PR TITLE
fix 2 bugs in hpu model runner

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2877,7 +2877,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 output_len = 0
                 block_tables = None
                 if ctx:
-                    block_tables = {group_id: [_PAD_BLOCK_ID] * seq_len}
+                    seq_block_nums = math.ceil(seq_len / self.block_size)
+                    block_tables = {group_id: [_PAD_BLOCK_ID] * seq_block_nums}
                     computed_block_nums = ([1] * ctx)
         else:
             input_len = seq_len - 1


### PR DESCRIPTION
1. Wrong ctx length was calculated. 
2. Wrong block table when ctx > 0