### PR TITLE
[P/D] Implement Non-blocking/Async D2H optimization for kv fetching a…

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
     VLLM_USE_ASYNC_TRANSFER_IN_PD: bool = False
     VLLM_SKIP_PREFILL_SAMPLING: bool = False
     VLLM_ABORT_REQUEST_KV_CACHE_MISS: bool = True
+    VLLM_FETCH_KV_USE_ASYNC_D2H: int = 0
 
 
 def get_default_cache_root():
@@ -644,6 +645,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: bool(int(os.getenv("VLLM_SKIP_PREFILL_SAMPLING", "0"))),
     "VLLM_ABORT_REQUEST_KV_CACHE_MISS":
     lambda: bool(int(os.getenv("VLLM_ABORT_REQUEST_KV_CACHE_MISS", "1"))),
+
+    # Controls the async device-to-host mode used when fetching KV caches.
+    # 0: Sync copy, 1: Non-blocking copy, 2: Async copy with event
+    "VLLM_FETCH_KV_USE_ASYNC_D2H":
+    lambda: int(os.getenv("VLLM_FETCH_KV_USE_ASYNC_D2H", "0")),
 }
 
 # end-env-vars-definition

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -809,7 +809,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         self.kv_conf = self.vllm_config.kv_transfer_config
 
         self.fetch_kv_use_async_d2h = AsyncD2HMode(
-            int(os.environ.get("VLLM_FETCH_KV_USE_ASYNC_D2H", "0")))
+            envs.VLLM_FETCH_KV_USE_ASYNC_D2H)
         logger.info(f"fetch_kv_use_async_d2h: {self.fetch_kv_use_async_d2h}")
 
     def _set_gc_threshold(self) -> None:


### PR DESCRIPTION
…t prefill

The NON_BLOCKING mode is functionally ready while the ASYNC mode has piece missing and is right now just for dev use

## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
This commit is to significantly reduce the kv fetching overhead at prefill
## Test Plan
Prefill-only test and E2E test

## Test Result
Tested on G3D with bs=8 from 287 ms to
97 ms (NON_BLOCKING mode)
0 ms (ASYNC mode)
And according to prefill-only test with a G3D P/D setup (1P2D, 3.5K/1), the NON_BLOCKING mode increase the prefill throughput for around 8%

<!--- pyml disable-next-line no-emphasis-as-heading -->
