### PR TITLE
fix bug that VLLM_SKIP_WARMUP=1 is not recognized in vision_bucket

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -130,8 +130,7 @@ class VisionBuckets:
         self.graphed_buckets = set()
 
         self.skip_warmup = 1 if os.environ.get(
-            'VLLM_SKIP_WARMUP', 'false').lower() in ['true', '1'
-                                                             ] else 0
+            'VLLM_SKIP_WARMUP', 'false').lower() in ['true', '1'] else 0
 
     def _process_buckets(self, buckets):
         if not self.is_batch_based:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -128,8 +128,10 @@ class VisionBuckets:
                 multimodal_buckets = [int(i) for i in envvar.split(',')]
             self.multimodal_buckets = self._process_buckets(multimodal_buckets)
         self.graphed_buckets = set()
-        self.skip_warmup = os.environ.get('VLLM_SKIP_WARMUP',
-                                          'false').lower() == 'true'
+
+        self.skip_warmup = 1 if os.environ.get(
+            'VLLM_SKIP_WARMUP', 'false').lower() in ['true', '1'
+                                                             ] else 0
 
     def _process_buckets(self, buckets):
         if not self.is_batch_based:


### PR DESCRIPTION
Original code in vision_bucket for checking graph usage only can recognize VLLM_SKIP_WARMUP=True/true only. If using VLLM_SKIP_WARMUP=1,  it will not using graph. This PR is aimed to fix this bug.