### PR TITLE
Fix Transformers to 4.55.4

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.55.4, < 4.58
+transformers == 4.55.4
 huggingface-hub[hf_xet] >= 0.32.0  # Required for Xet downloads.
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf # Required by LlamaTokenizer.


### PR DESCRIPTION
This PR aims to fix the conflict between Transformers>4.55.4 and INC for the following error:

`(VllmWorkerProcess pid=49855) ERROR 10-16 01:34:56 [multiproc_worker_utils.py:303]   File "/usr/local/lib/python3.10/dist-packages/neural_compressor/torch/__init__.py", line 15, in <module>
(VllmWorkerProcess pid=49855) ERROR 10-16 01:34:56 [multiproc_worker_utils.py:303]     from .utils import load_empty_model
(VllmWorkerProcess pid=49855) ERROR 10-16 01:34:56 [multiproc_worker_utils.py:303]   File "/usr/local/lib/python3.10/dist-packages/neural_compressor/torch/utils/__init__.py", line 18, in <module>
(VllmWorkerProcess pid=49855) ERROR 10-16 01:34:56 [multiproc_worker_utils.py:303]     from .utility import *
(VllmWorkerProcess pid=49855) ERROR 10-16 01:34:56 [multiproc_worker_utils.py:303]   File "/usr/local/lib/python3.10/dist-packages/neural_compressor/torch/utils/utility.py", line 41, in <module>
(VllmWorkerProcess pid=49855) ERROR 10-16 01:34:56 [multiproc_worker_utils.py:303]     SUPPORTED_LAYERS = [nn.Linear, transformers.modeling_utils.Conv1D]
(VllmWorkerProcess pid=49855) ERROR 10-16 01:34:56 [multiproc_worker_utils.py:303] AttributeError: module 'transformers.modeling_utils' has no attribute 'Conv1D'`

Transformers==4.55.4 works fine.