### PR TITLE
Clear the Mamba cache table if the running queue is empty

### DIFF
--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -249,6 +249,11 @@ class HPUWorker(LocalOrDistributedWorkerBase):
             'VLLM_HPU_LOG_STEP_CPU_FALLBACKS_ALL', '0') != '0'
         log_cpu_fallbacks = os.environ.get('VLLM_HPU_LOG_STEP_CPU_FALLBACKS',
                                            '0') != '0' or log_cpu_fallbacks_all
+
+        # Empty the Mamba cache table when all the requests are clear
+        if execute_model_req is None:
+            self.model_runner.mamba_cache_table.clear()
+
         if (log_graph_compilation or log_cpu_fallbacks) and \
             execute_model_req is not None:
             from habana_frameworks.torch.hpu.metrics import metric_localcontext


### PR DESCRIPTION
This PR fixed the corner case when all the sequences in the running queue are clear, the indices of Mamba cache table would be out of bound.
Hence it fixed the accuracy issue when bs > 256. Now with bs=512, the scores of gsm8k task are stable:

vllm (pretrained=/data/Qwen3-Next-80B-A3B-Instruct,trust_remote_code=True,enable_expert_parallel=True,tensor_parallel_size=4,distributed_executor_backend=mp,max_length=16384,max_gen_toks=2048,max_num_seqs=512,max_num_prefill_seqs=16), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 512
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9386|±  |0.0066|
|     |       |strict-match    |     5|exact_match|↑  |0.8878|±  |0.0087|
