### PR TITLE
Revert "Add sleep 5s between init test run and 1st formal run (#1164)"

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -602,7 +602,7 @@ async def benchmark(
             f"are correctly specified. Error: {test_output.error}")
     else:
         print("Initial test run completed. Starting main benchmark run...")
-    time.sleep(5)
+
     if lora_modules:
         # For each input request, choose a LoRA module at random.
         lora_modules = iter(
@@ -623,7 +623,6 @@ async def benchmark(
         profile_output = await request_func(request_func_input=profile_input)
         if profile_output.success:
             print("Profiler started")
-        time.sleep(5)
 
     if burstiness == 1.0:
         distribution = "Poisson process"


### PR DESCRIPTION
w/a not needed anymore with mooncake gc issue being fixed by upgrading