### PR TITLE
Fix Qwen2.5 omni bug

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -247,11 +247,20 @@ def uses_mrope(config: PretrainedConfig) -> bool:
     return _uses_mrope(config) or thinker_uses_mrope(config)
 
 
+def is_thinker(config: PretrainedConfig) -> bool:
+    model_type = getattr(config, "model_type", None)
+    if model_type is None:
+        return False
+
+    return "thinker" in model_type
+
+
 def thinker_uses_mrope(config: PretrainedConfig) -> bool:
     """Detect if the model contains a thinker config and it uses M-ROPE."""
-    thinker_text_config = getattr(config, "text_config", None)
-    if thinker_text_config is not None:
-        return uses_mrope(thinker_text_config)
+    if is_thinker(config):
+        thinker_text_config = getattr(config, "text_config", None)
+        if thinker_text_config is not None:
+            return uses_mrope(thinker_text_config)
 
     thinker_config = getattr(config, "thinker_config", None)
     if thinker_config is None:


### PR DESCRIPTION
Fix a bug that qwen2.5-omni is not detected as mrope model

test cmd:
`PT_HPU_LAZY_MODE=1 python examples/offline_inference/vision_language.py --modality image --model-type qwen2_5_omni`
