### PR TITLE
fix variable name order in qwen3-next model

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -129,9 +129,9 @@ def torch_chunk_gated_delta_rule(
     attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
     value = attn @ v_beta
     k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
-    last_recurrent_state = (torch.zeros(batch_size, num_heads,
-                                        k_head_dim, v_head_dim).to(value) if
-                            initial_state is None else initial_state.to(value))
+    last_recurrent_state = (torch.zeros(batch_size, num_heads, k_head_dim,
+                                        v_head_dim).to(value) if initial_state
+                            is None else initial_state.to(value))
     core_attn_out = torch.zeros_like(value)
     mask = torch.triu(torch.ones(chunk_size,
                                  chunk_size,


### PR DESCRIPTION
…> num_heads)

The dimension variable names were swapped (sequence_len and num_heads), but this change only affects naming consistency and does not impact actual logic or tensor behavior.

## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
Correct the variable name of the dimension
## Test Plan
```bash
python3 examples/offline_inference/basic/basic.py --model    /workspace/ckpt/Qwen3-Next-80B-A3B-Instruct --enable-ep --tp-size 4
```
## Test Result
Passed.
<!--- pyml disable-next-line no-emphasis-as-heading -->
