### PR TITLE
Fix Qwen3-Next crash issue when max-concurrency is not set in client

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -434,7 +434,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             })
 
         mamba_cache_bs = vllm_config.scheduler_config.max_num_seqs + \
-            max(8, vllm_config.scheduler_config.max_num_seqs)
+            max(8, vllm_config.scheduler_config.max_num_seqs) + 1
         conv_state_shape = (
             mamba_cache_bs,
             self.conv_kernel_size - 1,

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1695,7 +1695,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             seq_id = seq_ids[0]
 
             if self._is_fla_model():
-                mamba_cache_bs = self.max_num_seqs + max(8, self.max_num_seqs)
+                mamba_cache_bs = self.max_num_seqs + \
+                    max(8, self.max_num_seqs) + 1
                 mamba_prefill_index = FindMambaIndexForPrefill(
                     self.mamba_cache_table, seq_id, mamba_cache_bs)
                 mamba_prefill_indices.append(mamba_prefill_index)


### PR DESCRIPTION
No harm to the accuracy:
local-completions (model=/data/Qwen3-Next-80B-A3B-Instruct,max_length=16384,max_gen_toks=2048,base_url=http://127.0.0.1:30012/v1/completions), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9386|±  |0.0066|
|     |       |strict-match    |     5|exact_match|↑  |0.8908|±  |0.0086|

This PR increases the batch size of Mamba cache to 2*max_concurrency + 1 to avoid boundary issue of Qwen3-Next benchmark when max-concurrency is not set.