### PR TITLE
Enable sleep mode by offload weights and delete kv cache

### DIFF
--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -121,3 +121,6 @@ class HpuPlatform(Platform):
     def supports_v1(cls, model_config: ModelConfig) -> bool:
         # V1 support on HPU is experimental
         return True
+
+    def is_sleep_mode_available(self) -> bool:
+        return True


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
This change is for verl GRPO training which requires vLLM to support sleep mode by default, the sleep mode can save device memory during training. The corresponding JIRA is REQ-843. By default, vLLM and MLM are co-located, during GRPO training, after vLLM done generation, it will enter sleep mode, and after MLM finish training, vLLM wakeup and to generation for next data batch.
 
## Test Plan
* Use UT (Qwen3-8B, TP8) to test accuracy across sleep/wakeup.
* Test verl Qwen3-8B GRPO training for loss curve and compare it with the curve which disabled sleep mode.

## Test Result
* UT (torch.compile mode) show correct result and memory reduction in logs
  prompt: 
  `Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May? Let's think step by step and output the final answer after "####".`
  1st response: 
  `<think>\nOkay, let's see here. Natalia sold clips to 48 friends in April. Then in May, she sold half as many as she did in April. The question is asking how many clips she sold altogether in April and May. \n\nFirst, I need to figure out how many clips she sold in May. Since it's half as many as April, I should take the number from April and divide it by 2. So April is 48 clips. Half of 48 would be 48 divided by 2. Let me do that calculation: 48 ÷ 2 equals 24. So in May, she sold 24 clips.\n\nNow, to find the total number of clips sold in both months, I need to add the number from April and the number from May. That would be 48 (April) plus 24 (May). Let me add those together. 48 + 24... Let's see, 40 + 20 is 60, and 8 + 4 is 12, so 60 + 12 is 72. So altogether, Natalia sold 72 clips in April and May.\n\nWait, let me double-check that. April is 48, May is half of that, so 24. Adding them together: 48 + 24. Yeah, that's 72. Hmm, seems right. I don't think I made a mistake there. So the answer should be 72 clips in total.\n</think>\n\nNatalia sold 48 clips in April. In May, she sold half as many, which is $ \\frac{48}{2} = 24 $ clips. Adding both months together: $ 48 + 24 = 72 $. \n\n#### 72<|im_end|>`
  after 3 sleep/wakeup: 
  `<think>\nOkay, so Natalia sold clips to her friends in April and May. Let me try to figure out how many clips she sold altogether. \n\nFirst, the problem says she sold clips to 48 friends in April. So that's straightforward—April sales are 48 clips. Then, in May, she sold half as many clips as she did in April. Wait, half as many as April? So April was 48, so half of that would be 48 divided by 2. Let me calculate that. 48 divided by 2 is 24. So in May, she sold 24 clips.\n\nNow, the question is asking for the total number of clips she sold in both April and May. So I need to add the number of clips sold in April and May together. That would be 48 (April) plus 24 (May). Let me add those numbers. 48 plus 24... 48 plus 20 is 68, and then plus 4 more is 72. So altogether, she sold 72 clips in April and May.\n\nWait, let me check my math again to make sure I didn't make a mistake. April is 48, May is half of that, so 48 divided by 2 is indeed 24. Then 48 plus 24... yes, 48 + 24 equals 72. Hmm, seems correct. \n\nAlternatively, maybe I can think of it as 48 plus (48 divided by 2). Which is the same as 48 times (1 + 1/2) which is 48 times 3/2. Let me compute that. 48 times 3 is 144, divided by 2 is 72. Yep, same answer. So that checks out. \n\nI don't think there's any trick here. The problem states she sold half as many in May as in April. So no, it's not half as many as she sold in total, but half as many as April. So the calculation seems right. \n\nTherefore, the total number of clips Natalia sold in April and May is 72.\n</think>\n\nNatalia sold 48 clips in April. In May, she sold half as many clips as in April, which is $ \\frac{48}{2} = 24 $ clips. To find the total number of clips sold in both months, we add the sales from April and May:\n\n$$\n48 + 24 = 72\n$$\n\n#### 72<|im_end|>`
  memory log:

```
(VllmWorkerProcess pid=185690) INFO 10-22 11:15:48 [hpu_worker.py:548] Moving model to CPU for sleep mode took -1.917 GiB of device memory (49.73 GiB/94.23 GiB used) and 14.77 GiB of host memory (106.3 GiB/1.
968 TiB used)                                                                                                                                                                                                   
(VllmWorkerProcess pid=185690) INFO 10-22 11:15:49 [hpu_worker.py:572] Clean up KV cache for sleep mode took -49.5 GiB of device memory (233.5 MiB/94.23 GiB used) and 780 KiB of host memory (106.3 GiB/1.968 T
iB used)                                                                                                                                                                                                        
(VllmWorkerProcess pid=185690) INFO 10-22 11:15:55 [hpu_worker.py:591]                                                                                                                                          
(VllmWorkerProcess pid=185690) INFO 10-22 11:15:56 [hpu_worker.py:601] Waking up worker: moving model back to HPU took 1.917 GiB of device memory (2.145 GiB/94.23 GiB used) and -1012 MiB of host memory (105.3
 GiB/1.968 TiB used)                                                                                                                                                                                            
(VllmWorkerProcess pid=185690) INFO 10-22 11:15:57 [hpu_worker.py:615] Waking up worker: initializing KV cache took 49.5 GiB of device memory (51.65 GiB/94.23 GiB used) and 1008 MiB of host memory (106.3 GiB/
1.968 TiB used)
```


* GRPO training reward loss curve align with the run not using sleep mode (vLLM in torch.compile mode). 
  
<img width="1275" height="771" alt="image" src="https://github.com/user-attachments/assets/7e1e302d-0c0f-47d3-9ff4-8deb96f047d6" />

  Memory log:
```
^[[36m(WorkerDict pid=591288)^[[0m INFO 10-22 11:41:26 [hpu_worker.py:548] Moving model to CPU for sleep mode took -1.922 GiB of device memory (55.27 GiB/94.62 GiB used) and 16.29 GiB of host memory (116.2 GiB/1.968 TiB used) 
^[[36m(WorkerDict pid=591288)^[[0m INFO 10-22 11:41:27 [hpu_worker.py:572] Clean up KV cache for sleep mode took -43.59 GiB of device memory (11.67 GiB/94.62 GiB used) and -559.3 MiB of host memory (115.7 GiB/1.968 TiB used)
^[[36m(WorkerDict pid=591288)^[[0m INFO 10-22 11:41:27 [executor_base.py:210] It took 2.493145 seconds to fall asleep.
^[[36m(WorkerDict pid=591288)^[[0m INFO 10-22 11:41:29 [hpu_worker.py:601] Waking up worker: moving model back to HPU took 1.922 GiB of device memory (13.6 GiB/94.62 GiB used) and -92.02 MiB of host memory (115.7 GiB/1.968 TiB used)
^[[36m(WorkerDict pid=591288)^[[0m INFO 10-22 11:41:29 [executor_base.py:226] It took 1.050677 seconds to wake up tags ['weights'].
^[[36m(WorkerDict pid=591288)^[[0m INFO 10-22 11:41:31 [hpu_worker.py:615] Waking up worker: initializing KV cache took 43.59 GiB of device memory (57.19 GiB/94.62 GiB used) and 559.2 MiB of host memory (116.3 GiB/1.968 TiB used)
^[[36m(WorkerDict pid=591288)^[[0m INFO 10-22 11:41:31 [executor_base.py:226] It took 1.160028 seconds to wake up tags ['kv_cache'].
```

<!--- pyml disable-next-line no-emphasis-as-heading -->

cc @czhu15 @Wei-Lin-Intel @yangulei

UT: [vllm_verl_ut.tar.gz](https://github.com/user-attachments/files/23111209/vllm_verl_ut.tar.gz)
