### PR TITLE
[deepseek_r1]fix weight loading on 1.23

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -661,7 +661,8 @@ class FusedMoE(torch.nn.Module):
         param_data = param.data
 
         # Input scales can be loaded directly and should be equal.
-        param_data[expert_id] = loaded_weight
+        # Workaround: SW-233343
+        param_data[expert_id] = loaded_weight.cpu()
 
     def _load_g_idx(self, shard_id: str, expert_data: torch.Tensor,
                     shard_dim: int, loaded_weight: torch.Tensor, tp_rank: int):


### PR DESCRIPTION
## Purpose
Deepseek-R1 weight cannot load on 1.23. It was caused by SW-233343. PR is provided a workaround to fix the weight loading on 1.23.
