### PR TITLE
Remove conv1d weight cast in Qwen3-Next forward

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -144,9 +144,8 @@ def torch_chunk_gated_delta_rule(
 
     # for each chunk
     for i in range(0, tot_len // chunk_size):
-        q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
         v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
-        v_new = v_i - v_prime
+        v_new = value[:, :, i] - v_prime
         attn_inter = qg[:, :, i] @ last_recurrent_state
         core_attn_out[:, :, i] = attn_inter + attn[:, :, i] @ v_new
         last_recurrent_state = (

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -123,7 +123,7 @@ def torch_chunk_gated_delta_rule(
     for i in range(1, chunk_size):
         row = attn[..., i, :i].contiguous()
         sub = attn[..., :i, :]
-        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)[...,  :i]
+        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)[..., :i]
     attn = attn + eye_constant
     value = attn @ v_beta
     k_cumdecay = attn @ (k_beta * g_exp.unsqueeze(-1))
@@ -147,11 +147,11 @@ def torch_chunk_gated_delta_rule(
         q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
         v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
         v_new = v_i - v_prime
-        attn_inter = qg[:,:,i] @ last_recurrent_state
-        core_attn_out[:, :, i] = attn_inter + attn[:,:,i] @ v_new
+        attn_inter = qg[:, :, i] @ last_recurrent_state
+        core_attn_out[:, :, i] = attn_inter + attn[:, :, i] @ v_new
         last_recurrent_state = (
             last_recurrent_state * g_exp[:, :, i, -1, None, None] +
-            k_term[:,:,i].transpose(-1, -2) @ v_new)
+            k_term[:, :, i].transpose(-1, -2) @ v_new)
 
     if not output_final_state:
         last_recurrent_state = None

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -585,9 +585,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         mamba_cache_decode_indices = attn_metadata.mamba_cache_decode_indices
 
         if self.conv1d_weight is None:
-            self.conv1d_weight = self.conv1d.weight.squeeze(1).transpose(0,
-                1).flatten().reshape(self.conv_kernel_size,
-                    self.conv_dim // self.tp_size).float()
+            self.conv1d_weight = self.conv1d.weight.squeeze(1).transpose(
+                0, 1).flatten().reshape(self.conv_kernel_size,
+                                        self.conv_dim // self.tp_size).float()
             del self.conv1d.weight
 
         if attn_metadata.is_prompt:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -917,8 +917,8 @@ def FindMambaIndexForDecode(
     seq_list: List[int],
 ):
     diff = list(set(mamba_dict.keys()) - set(seq_list))
-    for idx in range(len(diff)):
-        mamba_dict.pop(diff[idx])
+    for idx in diff:
+        mamba_dict.pop(idx)
     return list(mamba_dict.values())
 
 
@@ -1705,7 +1705,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
             if self._is_fla_model():
                 mamba_cache_bs = self.max_num_seqs + \
-                    max(8, self.max_num_seqs) + 1
+                    max(8, self.max_num_seqs) + self.max_num_prefill_seqs
                 mamba_prefill_index = FindMambaIndexForPrefill(
                     self.mamba_cache_table, seq_id, mamba_cache_bs)
                 mamba_prefill_indices.append(mamba_prefill_index)


### PR DESCRIPTION
Conv1D's compute precision in Qwen3-Next in G2 should be kept as float, thus Conv1D weight should cast to fp32.

This PR removes the unnecessary bf16->fp32 cast in every forward call in flat linear attention. Instead it just calls the cast once in the first time (normally during the profile run), and then removes the original bf16 conv1d weight since it won't be used any more.