### PR TITLE
Move only the quantized model and tensors to HPU

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -250,6 +250,9 @@ bash calibrate_model.sh \
      -t 4 -u
 ```
 
+ [!TIP]
+> **To run fp8 inference with 4 HPUs using Qwen3-235B-A22B bfloat16 weights**: The weights have to be loaded to host memory first by adding `-e "--weights-load-device cpu"` to the `benchmark_serving_range.sh` and `benchmark_serving_sharegpt.sh` or by setting `weights_load_device='cpu'` for the LLM engine.
+
 ##### 3. Do the calibration for pipeline parallelism mode
 The `-x <TP_SIZE_WITH_PP>` must set to run the model with pipeline parallelism (PP), with the `TP_SIZE_WITH_PP` means the TP size when PP is enabled. Take GLM-4.5-FP8 with TP=4 and PP=2 as an example:
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1355,10 +1355,15 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 torch.hpu.synchronize()
                 return model
 
-            with HabanaMemoryProfiler() as m_to_hpu:
-                self.model = move_model_to_hpu(self.model)
-            logger.info("Moving model to HPU took %s",
-                        m_to_hpu.get_summary_string())
+            # Move quantized model and tensors to HPU to avoid deduplicated
+            # copies of MoE weights in w13/w2 weights and w13/12 list.
+            # Skip for unquantized model as INC will handle it layer-by-layer.
+            if self.model_config.quantization != 'inc' \
+                and self._is_quant_with_inc():
+                with HabanaMemoryProfiler() as m_to_hpu:
+                    self.model = move_model_to_hpu(self.model)
+                logger.info("Moving model to HPU took %s",
+                            m_to_hpu.get_summary_string())
 
             if self._is_quant_with_inc():
                 logger.info("Preparing model with INC..")

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1358,8 +1358,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             # Move quantized model and tensors to HPU to avoid deduplicated
             # copies of MoE weights in w13/w2 weights and w13/12 list.
             # Skip for unquantized model as INC will handle it layer-by-layer.
-            if self.model_config.quantization != 'inc' \
-                and self._is_quant_with_inc():
+            if self.model_config.quantization is not None \
+                and self.model_config.quantization != 'inc':
                 with HabanaMemoryProfiler() as m_to_hpu:
                     self.model = move_model_to_hpu(self.model)
                 logger.info("Moving model to HPU took %s",


### PR DESCRIPTION
- The non HPU tensor error for bf16 qwen3 models introduced in https://github.com/HabanaAI/vllm-fork/pull/2075 is fixed by https://github.com/HabanaAI/vllm-fork/pull/2090
- This PR moves the quantized model and tensors to HPU only to avoid OOM when the bf16 weights is loaded to CPU then quantized to fp8 with INC.