### PR TITLE
Workaround for Assertion error when embedding with bge-m3 in lazy mode

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1579,7 +1579,18 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             input_tokens.append(prompt_tokens)
             # NOTE(woosuk): Here we assume that the first token in the prompt
             # is always the first token in the sequence.
-            input_positions.append(list(range(context_len, seq_len)))
+            if "RobertaEmbeddingModel" in str(type(self.model.model)):
+                padding_idx = getattr(self.model.model.model.embeddings, "padding_idx", 1)
+                tokens_cpu = torch.tensor(prompt_tokens, dtype=torch.long, device="cpu").clone().contiguous()
+                mask = tokens_cpu.ne(padding_idx).to(torch.int32)
+                incremental_indices = (torch.cumsum(mask, dim=0).to(torch.int32) * mask)
+                pos_cpu = incremental_indices.to(torch.int64) + padding_idx
+                if seq_len < pos_cpu.numel():
+                    pos_cpu[seq_len:] = 0
+                pos_hpu = pos_cpu.to("hpu", non_blocking=False)
+                input_positions.append(pos_hpu.tolist())
+            else:
+                input_positions.append(list(range(context_len, seq_len)))
 
             seq_data_mrope_positions: Optional[List[List[int]]] = None
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1580,10 +1580,14 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             # NOTE(woosuk): Here we assume that the first token in the prompt
             # is always the first token in the sequence.
             if "RobertaEmbeddingModel" in str(type(self.model.model)):
-                padding_idx = getattr(self.model.model.model.embeddings, "padding_idx", 1)
-                tokens_cpu = torch.tensor(prompt_tokens, dtype=torch.long, device="cpu").clone().contiguous()
+                padding_idx = getattr(self.model.model.model.embeddings,
+                                      "padding_idx", 1)
+                tokens_cpu = torch.tensor(prompt_tokens,
+                                          dtype=torch.long,
+                                          device="cpu").clone().contiguous()
                 mask = tokens_cpu.ne(padding_idx).to(torch.int32)
-                incremental_indices = (torch.cumsum(mask, dim=0).to(torch.int32) * mask)
+                incremental_indices = (
+                    torch.cumsum(mask, dim=0).to(torch.int32) * mask)
                 pos_cpu = incremental_indices.to(torch.int64) + padding_idx
                 if seq_len < pos_cpu.numel():
                     pos_cpu[seq_len:] = 0


### PR DESCRIPTION
Added Workaround for Assertion error when embedding with bge-m3 in lazy mode. 

For RoBERTa models, the position_ids are recalculated using the function create_position_ids_from_input_ids_hpu().
However, due to a known issue on HPU where modifying an already allocated tensor in-place can lead to invalid or corrupted values, this workaround precomputes position_ids on the CPU using the corresponding input_ids.
The computed position_ids are then transferred to the HPU within hpu_model_runner to ensure correctness and avoid in-place modification issues.
