### PR TITLE
Fix precision issue when input multiple images at once

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -643,7 +643,7 @@ class Qwen3_VisionTransformerStaticShape(Qwen3_VisionTransformer):
                 htcore.mark_step()
 
                 post_embed_size = curr_img_size // self.spatial_merge_unit
-                results += [hidden_states[:post_embed_size, :]]
+                results += [hidden_states[:post_embed_size, :].clone()]
 
         results_cat = torch.concat(results)
         image_embeds = results_cat


### PR DESCRIPTION
When user inputs multiple image in one prompt, the result is wrong. Seems the output hidden_states is referenced to each other.
Adding clone() can fix it.

test commnd:
```
#server:
bash start_gaudi_vllm_server.sh -s -w Qwen/Qwen3-VL-30B-A3B-Instruct -m 7 -t 1 -b 1024 -i 4,3072 -o 4,2048 -a 127.0.0.1:8000
#client:
python openai_chat_completion_client_for_multimodal.py -c multi-image
```
If it is hard to download example images, you can modify  _run_multi_image()_  in _"openai_chat_completion_client_for_multimodal.py"_ and use local images.
