### PR TITLE
Fix no attr enable_server_load_tracking error

### DIFF
--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -28,7 +28,10 @@ async def listen_for_disconnect(request: Request) -> None:
     while True:
         message = await request.receive()
         if message["type"] == "http.disconnect":
-            if request.app.state.enable_server_load_tracking:
+            if getattr(request.app.state, "enable_server_load_tracking",
+                       False):
+                if not hasattr(request.app.state, "server_load_metrics"):
+                    request.app.state.server_load_metrics = 0
                 # on timeout/cancellation the BackgroundTask in load_aware_call
                 # cannot decrement the server load metrics.
                 # Must be decremented by with_cancellation instead.


### PR DESCRIPTION
Fix
`Task exception was never retrieved
future: <Task finished name='Task-438' coro=<listen_for_disconnect() done, defined at /workspace/vllm/vllm/entrypoints/utils.py:26> exception=AttributeError("'State' object has no attribute 'enable_server_load_tracking'")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/starlette/datastructures.py", line 686, in __getattr__
    return self._state[key]
KeyError: 'enable_server_load_tracking' `
