### PR TITLE
Fix the problem of bucket not warmup for pooling models

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -3254,10 +3254,13 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
     @torch.inference_mode()
     def warmup_model(self, kv_caches: List[torch.Tensor]) -> None:
-        prompt_buckets = len(self.bucketing_manager.prompt_buckets)
         if not self.is_pooler:
+            prompt_buckets = len(self.bucketing_manager.prompt_buckets)
             decode_buckets = len(self.bucketing_manager.decode_buckets)
         else:
+            # prompt buckets were not generated before this point when pooling
+            self.bucketing_manager.generate_prompt_buckets()
+            prompt_buckets = len(self.bucketing_manager.prompt_buckets)
             # When pooling we're not using decode phase
             decode_buckets = 0
 


### PR DESCRIPTION
This PR fixes the problem that prompt buckets are not warmed up for pooling models
