### PR TITLE
compose small seqlen sdpa for qwen2vl and qwen2.5vl

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -161,7 +161,7 @@ class Qwen2VLImageEmbeddingInputs(TypedDict):
         Each tensor holds an image's features.
     - `torch.Tensor`: A tensor holding all images' features
         (concatenation of all images' feature tensors).
-    
+
     Tensor shape: `(num_image_features, hidden_size)`
     - `num_image_features` varies based on
         the number and resolution of the images.
@@ -201,9 +201,9 @@ class Qwen2VLVideoEmbeddingInputs(TypedDict):
         Each tensor holds an video's features.
     - `torch.Tensor`: A tensor holding all videos' features
         (concatenation of all videos' feature tensors).
-    
+
     Tensor shape: `(num_image_features, hidden_size)`
-    - `num_image_features` varies based on 
+    - `num_image_features` varies based on
         the number and resolution of the videos.
     - `hidden_size` must match the hidden size of language model backbone.
     """
@@ -399,17 +399,12 @@ class Qwen2VisionAttention(nn.Module):
                                       "(b s) ... -> b s ...",
                                       b=batch_size)
         elif self.attn_backend == _Backend.TORCH_SDPA and is_hpu:
-            # performs full attention using the previous computed mask
-            fullatt_block_attn_mask = cu_seqlens
+
             q1, k1, v1 = (rearrange(x, "b s h d -> b h s d")
                           for x in [q, k, v])
             (batch_size, _, seq_len_N_t, _) = q1.shape
             (batch_size, _, seq_len_N_s, _) = k1.shape
-            mask_shape = (batch_size, 1, seq_len_N_t, seq_len_N_s)
-            attn_mask = fullatt_block_attn_mask.reshape(
-                batch_size, 1, seq_len_N_t, seq_len_N_s,
-                -1)[:, :, :, :, 0]  # reshapes the mask to be Bx1xNxN
-            assert attn_mask.shape == mask_shape
+            attn_mask = cu_seqlens if cu_seqlens is not None else None
 
             if q1.shape[2] <= 65536:  # need to investigate this crosspoint
                 fused_out = FusedSDPA.apply(q1, k1, v1, attn_mask, 0.0, False,
@@ -774,15 +769,18 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
     to make the model more friendly to static shapes. Specifically,
     we split the forward  method into:
       - pre_attn (dynamic)
-      - forward (static shape) 
+      - forward (static shape)
       - post_attn (dynamic)
     and we should call get_image_embeds instead of forward, allowing
-    the forward method ro run with HPU_Graphs, whereas the 
+    the forward method ro run with HPU_Graphs, whereas the
     pre_attn and post_attn methods are allow to be dynamic.
     """
 
-    def pad_multimodal_data(self, pixel_values, image_grid_thw,
-                            vision_buckets):
+    def pad_multimodal_data(self,
+                            pixel_values,
+                            image_grid_thw,
+                            vision_buckets,
+                            constant_value=0):
         assert pixel_values.shape[0] % 4 == 0, 'needs 64 aligned resolution'
 
         desired_number_of_pixels = vision_buckets.get_multimodal_bucket(
@@ -797,7 +795,6 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
             + str(desired_number_of_pixels)
         logger.debug(logger_msg)
 
-        constant_value = -100
         pixel_values = torch.cat([
             pixel_values,
             torch.ones((padding_len, pixel_values.shape[1]), \
@@ -810,7 +807,6 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
                          device=image_grid_thw.device)
         ])
 
-        assert image_grid_thw.prod(-1).sum() == desired_number_of_pixels
         return pixel_values, image_grid_thw
 
     def pre_attn(self, x: torch.Tensor, grid_thw: torch.Tensor):
@@ -829,7 +825,6 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
 
     def forward(self, x: torch.Tensor, fullattn_mask: Optional[torch.Tensor],
                 rotary_pos_emb: torch.Tensor) -> torch.Tensor:
-
         hidden_states = x.unsqueeze(1)
         for layer_num, blk in enumerate(self.blocks):
             htcore.mark_step()
@@ -853,10 +848,45 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
 
         offset = 0
         results = []
+        calc_img_size = 0
+        calc_img_len_list = []
+        calc_grid_thw_list = []
+        #compose small images SDPA into one bigger SDPA with mask
+        compose_seq_len = 1024
         # process each image one by one
         for img_idx in range(grid_thw.shape[0]):
             img_shape = grid_thw[img_idx, :].unsqueeze(0)
             curr_img_size = img_shape.prod()
+            attn_mask = None
+            next_img_size = 100000
+            if img_idx < grid_thw.shape[0] - 1:
+                img_shape_next = grid_thw[img_idx + 1, :].unsqueeze(0)
+                next_img_size = img_shape_next.prod()
+
+            calc_img_size += curr_img_size
+            calc_img_len_list.append(curr_img_size)
+            calc_grid_thw_list.append(img_shape)
+            if calc_img_size + next_img_size < compose_seq_len:
+                continue
+            else:
+                curr_img_size = calc_img_size
+                calc_img_size = 0
+                if len(calc_img_len_list) > 1:
+                    bucket_img_size = vision_buckets.get_multimodal_bucket(
+                        curr_img_size)
+                    attn_mask = torch.zeros(bucket_img_size,
+                                            bucket_img_size).bool()
+                    img_start = 0
+                    for img_len in calc_img_len_list:
+                        img_end = img_start + img_len
+                        attn_mask[img_start:img_end, img_start:img_end] = True
+                        img_start = img_end
+
+                    img_shape = torch.cat(calc_grid_thw_list)
+
+                    attn_mask = attn_mask.to(device=self.device)
+                calc_img_len_list = []
+                calc_grid_thw_list = []
 
             pixel_values_curr_img = pixel_values[offset:offset +
                                                  curr_img_size, :]
@@ -864,17 +894,12 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
             offset += curr_img_size
             pixel_values_curr_img_padded, img_shape_padded = \
                 self.pad_multimodal_data(pixel_values_curr_img, \
-                    img_shape, vision_buckets=vision_buckets)
+                    img_shape, vision_buckets=vision_buckets,constant_value=0)
 
             pixel_values_curr_img_padded, rot_pos_emb, \
                 cu_seqlens = self.pre_attn(
             pixel_values_curr_img_padded, img_shape_padded)
 
-            # Create full attention block mask
-            # before VisionTransformer to save memory/time
-            fullatt_block_attn_mask = \
-                create_block_diagonal_attention_mask_outerprod \
-                    (cu_seqlens)
             assert pixel_values_curr_img_padded.shape[0] == \
                 rot_pos_emb.shape[0]
 
@@ -888,15 +913,18 @@ class Qwen2VisionTransformerStaticShape(Qwen2VisionTransformer):
             htcore.mark_step()
             hidden_states = self.forward(pixel_values_curr_img_padded,
                                          rotary_pos_emb=rot_pos_emb,
-                                         fullattn_mask=fullatt_block_attn_mask,
+                                         fullattn_mask=attn_mask,
                                          **extra_forward_kwargs)
             htcore.mark_step()
 
             image_embeds = self.post_attn(hidden_states)
+
             # slice image_embeds to remove the padded parts
-            pad_index = img_shape_padded[0].prod() // self.spatial_merge_unit
+            pad_index = curr_img_size // self.spatial_merge_unit
             results += [image_embeds[:pad_index, :]]
+
         results_cat = torch.concat(results)
+
         image_embeds = results_cat
         return image_embeds
 


### PR DESCRIPTION
## Purpose
This is a perf. improvement for 
1) Mineru application with vllm backend which called qwen2vl in vllm.
2) Window attention Qwen2.5vl

It is found that SDPA is not efficient for small seqlen. Compose small seqlen into bigger one with mask will get performance gain.
<img width="212" height="161" alt="image" src="https://github.com/user-attachments/assets/590faa4e-dfdd-4a56-9eb1-c23c1b1d7e2b" />

In qwen2.5vl the window attention seqlen=64 , so it is composed to 1024 with mask. 
In Mineru vllm backend, it will call qwen2vl. As in pdf Parsing application, some layout images boxes are very small, which is the input of qwen2vl. So in qwen2vl small image seqlen is composed to 1024 with mask.


## Test Result
With this PR, qwen2.5vl got 5% throughput performance boost and TTFT time reduced by 4% .
For mineru 2.5.4, pdf with small page layout boxes can get 5% performance gain.
