### PR TITLE
fix the mismatch of ignored_layers for model.visual.blocks.x.attn.qkv in qwen2.5-vl

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -300,7 +300,7 @@ class Qwen2_5_VisionAttention(nn.Module):
             total_num_kv_heads=num_heads,
             bias=True,
             quant_config=quant_config,
-            prefix=f"{prefix}.qkv")
+            prefix=f"model.{prefix}.qkv")
         self.proj = RowParallelLinear(input_size=projection_size,
                                       output_size=embed_dim,
                                       quant_config=quant_config,


### PR DESCRIPTION
The `ignored_layers` in the [config.json](https://huggingface.co/Qwen/Qwen3-VL-30B-A3B-Instruct-FP8/blob/main/config.json#L85) does not match that in the modeling.