### PR TITLE
Optimized Bert based embedding model on HPU.

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -336,7 +336,8 @@ def get_target_layer_suffix_list(model_type) -> list[str]:
     }
 
     return [
-        decoder_layer_table.get(model_type, "DecoderLayer"), "EncoderLayer"
+        decoder_layer_table.get(model_type, "DecoderLayer"), "EncoderLayer",
+        "BertLayer"
     ]
 
 


### PR DESCRIPTION
1. Added config to add mark_step and optimize the hpu graph for BertLayer. 
The HPU graph of BERT was split into reusable graphs. The performance of Bert-based embed models, such as BAAI/bge-m3 was improved.
2. Optimized the position algorithm of RobertEmbedding and decreased host time.  
