### PR TITLE
fix finding bucket for context length

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -4586,6 +4586,14 @@ class VllmConfig:
                            "but the scheduler is configured to publish them."
                            "Modify KVEventsConfig.enable_kv_cache_events"
                            "to True to enable.")
+        if (current_platform.is_hpu()
+                and self.cache_config.enable_prefix_caching
+                and self.scheduler_config.max_num_prefill_seqs is not None
+                and self.scheduler_config.max_num_prefill_seqs > 1):
+            logger.warning(
+                "Prefix caching with bs > 1 is not supported on HPU."
+                " Setting max_num_prefill_seqs to 1.")
+            self.scheduler_config.max_num_prefill_seqs = 1
         current_platform.check_and_update_config(self)
 
         if not self.instance_id:

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -1084,8 +1084,8 @@ class ComputedBlocksTracker:
             seq_len = seq.get_len() - num_cached_blocks * self._block_size
             _, _, bkt_cached_blocks = hpu_bucketing_manager.find_prompt_bucket(
                 1, seq_len, num_cached_blocks, False)
-            logger.info("HPU bucketing adjusted cached blocks from %d to %d",
-                        num_cached_blocks, bkt_cached_blocks)
+            logger.debug("HPU bucketing adjusted cached blocks from %d to %d",
+                         num_cached_blocks, bkt_cached_blocks)
             num_cached_blocks = bkt_cached_blocks
         num_cached_tokens = num_cached_blocks * self._block_size
         self._seq_id_to_num_tokens_computed[seq.seq_id] = num_cached_tokens

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1959,6 +1959,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         if any(context_lens):
             assert not self.scheduler_config.chunked_prefill_enabled
+            assert self.scheduler_config.max_num_prefill_seqs == 1
+            assert bs == 1, (
+                "Prefix caching with multiple sequences is not supported yet.")
             # prefix caching
 
             max_num_block = max(len(bt) for bt in prefix_block_tables)

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1962,8 +1962,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             # prefix caching
 
             max_num_block = max(len(bt) for bt in prefix_block_tables)
-            max_num_block = self.bucketing_manager.find_prompt_bucket(
-                bs, target_query_len, max_num_block)[2]
             prefix_block_list = list(
                 itertools.chain.from_iterable(
                     bt if len(bt) == max_num_block else bt +

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1962,6 +1962,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             # prefix caching
 
             max_num_block = max(len(bt) for bt in prefix_block_tables)
+            max_num_block = self.bucketing_manager.find_prompt_bucket(
+                bs, target_query_len, max_num_block)[2]
             prefix_block_list = list(
                 itertools.chain.from_iterable(
                     bt if len(bt) == max_num_block else bt +

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1929,43 +1929,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         bs = len(seq_group_metadata_list)
         if bs > 1 and self.use_merged_prefill:
             bs = 1
-
-        if any(context_lens):
-            assert not self.scheduler_config.chunked_prefill_enabled
-
-            max_num_block = max(len(bt) for bt in prefix_block_tables)
-            padded_num_block = self.bucketing_manager.find_prompt_bucket(
-                bs, target_query_len, max_num_block)[2]
-            ctx = padded_num_block
-
-            for i in range(len(seq_lens)):
-                seq_lens[i] += (len(prefix_block_tables[i]) -
-                                padded_num_block) * self.block_size
-            prefix_block_list = list(
-                itertools.chain.from_iterable(
-                    bt[:padded_num_block] if len(bt) >=
-                    padded_num_block else bt + ([_PAD_BLOCK_ID] *
-                                                (padded_num_block - len(bt)))
-                    for bt in prefix_block_tables))
-
-            pad_len = len(prefix_block_list)
-            prefix_block_list = pad_list(prefix_block_list, pad_len,
-                                         _PAD_BLOCK_ID)
-
-            prefix_block_list_tensor = torch.tensor(prefix_block_list,
-                                                    dtype=torch.long,
-                                                    device=self.device)
-        else:
-            ctx = 0
-            prefix_block_list_tensor = None
-
-        target_query_len = sum(query_lens) if self.use_merged_prefill else max(
-            query_lens)
-
-        _, pad_seq_len, pad_ctx = self.bucketing_manager.find_prompt_bucket(
-            bs, target_query_len, ctx)
-        assert pad_ctx == ctx and pad_seq_len >= target_query_len
-        max_prompt_len = max(pad_seq_len, self.block_size)
+        max_prompt_len = max(
+            self.bucketing_manager.find_prompt_bucket(bs, target_query_len,
+                                                      ctx)[1], self.block_size)
 
         if self.dp_awared_padding and\
             self.vllm_config.kv_transfer_config is None:
@@ -1990,6 +1956,29 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 [lora_id] *
                 (max_prompt_len if seq_group_metadata.sampling_params and
                  seq_group_metadata.sampling_params.prompt_logprobs else 1))
+
+        if any(context_lens):
+            assert not self.scheduler_config.chunked_prefill_enabled
+            # prefix caching
+
+            max_num_block = max(len(bt) for bt in prefix_block_tables)
+            max_num_block = self.bucketing_manager.find_prompt_bucket(
+                bs, target_query_len, max_num_block)[2]
+            prefix_block_list = list(
+                itertools.chain.from_iterable(
+                    bt if len(bt) == max_num_block else bt +
+                    ([_PAD_BLOCK_ID] * (max_num_block - len(bt)))
+                    for bt in prefix_block_tables))
+
+            pad_len = len(prefix_block_list)
+            prefix_block_list = pad_list(prefix_block_list, pad_len,
+                                         _PAD_BLOCK_ID)
+
+            prefix_block_list_tensor = torch.tensor(prefix_block_list,
+                                                    dtype=torch.long,
+                                                    device=self.device)
+        else:
+            prefix_block_list_tensor = None
 
         input_tokens_tensor = make_cpu_tensor(input_tokens,
                                               max_len=max_prompt_len,


### PR DESCRIPTION
- Works with https://github.com/HabanaAI/vllm-hpu-extension/pull/385 to enable padding ratio limit for the context length bucketing to reduce the number of buckets.
- Truncate the context length based on the bucketing in the APC block manager.
- Add assertion for `max_num_prefill_seqs==` when APC is enabled.