### PR TITLE
Fix Qwen3-VL huge graph issue

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -118,7 +118,7 @@ class VisionBuckets:
                     multimodal_buckets = [1, 2, 4, 8]  # batch sizes for gemma3
                 else:
                     multimodal_buckets = [
-                        1600, 3136, 4096, 6400, 7744, 9216, 12544
+                        1600, 3136, 4096, 6400
                     ]
             else:
                 multimodal_buckets = [int(i) for i in envvar.split(',')]

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -117,9 +117,7 @@ class VisionBuckets:
                 if is_batch_based:
                     multimodal_buckets = [1, 2, 4, 8]  # batch sizes for gemma3
                 else:
-                    multimodal_buckets = [
-                        1600, 3136, 4096, 6400
-                    ]
+                    multimodal_buckets = [1600, 3136, 4096, 6400]
             else:
                 multimodal_buckets = [int(i) for i in envvar.split(',')]
             self.multimodal_buckets = self._process_buckets(multimodal_buckets)


### PR DESCRIPTION

<img width="2078" height="511" alt="image" src="https://github.com/user-attachments/assets/ecb4e5d3-a2a9-4b0f-b1df-bdbca23562f8" />
In Qwen3-VL-235B case, the graph may consume 4GB HBM memory, thus causing HCCL hang issue. This PR can fix such issue to avoid such huge HPU graph.