### PR TITLE
Enable the graph mode and add the full warmup logic for Deepseek OCR model

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -531,7 +531,8 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
 
             if model_type in ("aya_vision", "chameleon", "deepseek_vl_v2",
                               "internvl_chat", "ovis", "skywork_chat",
-                              "NVLM_D", "h2ovl_chat", "idefics3", "smolvlm"):
+                              "NVLM_D", "h2ovl_chat", "idefics3", "smolvlm",
+                              "deepseek_ocr",):
                 return "<image>"
             if model_type in ("mllama", "llama4"):
                 return "<|image|>"

--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -387,20 +387,21 @@ class DeepseekOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         if images_spatial_crop is not None:
             assert batch_sz == images_spatial_crop.shape[0]
         if images_crop is not None:
-            assert batch_sz == images_crop.shape[0]
-            if images_crop.dtype != model_dtype:
-                images_crop = images_crop.to(model_dtype)
+            assert batch_sz == len(images_crop) \
+                if isinstance(images_crop, list) else \
+                    images_crop.shape
 
         ret_list = []
         have_image_data = False
         for i in range(batch_sz):
             base_size = self.vision_config.image_size
             if pixel_values[i] is not None:
+                images_crop_data = images_crop[i].to(model_dtype)
+
                 pixel_input = DeepseekOCRImagePixelInputs(
                     type="pixel_values",
                     data=pixel_values[i],
-                    images_crop=images_crop[i] if images_crop \
-                        is not None else None,
+                    images_crop=images_crop_data,
                     images_spatial_crop=images_spatial_crop[i] \
                         if images_spatial_crop is not None else None,
                     resolve_bindings={

--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -27,6 +27,7 @@ from vllm.multimodal.processing import (BaseMultiModalProcessor,
                                         BaseProcessingInfo, PromptReplacement,
                                         PromptUpdate)
 from vllm.multimodal.profiling import BaseDummyInputsBuilder
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.tensor_schema import TensorSchema, TensorShape
 from vllm.transformers_utils.configs.deepseek_vl2 import DeepseekVLV2Config
@@ -36,6 +37,11 @@ from vllm.transformers_utils.tokenizer import cached_tokenizer_from_config
 
 from .deepencoder import DeepCLIPVisionTransformer, build_sam_vit_b
 from .deepseek_vl2 import MlpProjector
+
+is_hpu = current_platform.is_hpu()
+
+if is_hpu:
+    import habana_frameworks.torch.core as htcore
 
 # The image token id may be various
 _IMAGE_TOKEN = "<image>"
@@ -266,6 +272,25 @@ class DeepseekOCRMultiModalProcessor(
         ]
 
 
+class DeepseekOCRVisual(nn.Module):
+
+    def __init__(
+        self,
+        sam_model,
+        vision_model,
+    ):
+        super().__init__()
+        self.sam_model = sam_model
+        self.vision_model = vision_model
+
+    def forward(self, image_tensor: torch.Tensor) -> torch.Tensor:
+        htcore.mark_step()
+        features_1 = self.sam_model(image_tensor)
+        htcore.mark_step()
+        features_2 = self.vision_model(image_tensor, features_1)
+        return features_1, features_2
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     DeepseekOCRMultiModalProcessor,
     info=DeepseekOCRProcessingInfo,
@@ -326,6 +351,8 @@ class DeepseekOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
             quant_config=quant_config,
             prefix=maybe_prefix(prefix, "vision_model"),
         )
+
+        self.visual = DeepseekOCRVisual(self.sam_model, self.vision_model)
 
         self.projector = MlpProjector(self.projector_config)
         self.tile_tag = config.tile_tag
@@ -420,8 +447,8 @@ class DeepseekOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
 
     def _encode_global_features(self,
                                 image_tensor: torch.Tensor) -> torch.Tensor:
-        global_features_1 = self.sam_model(image_tensor)
-        global_features_2 = self.vision_model(image_tensor, global_features_1)
+        global_features_1, global_features_2 = \
+            self.visual(image_tensor)
         features = torch.cat(
             (
                 global_features_2[:, 1:],
@@ -445,8 +472,7 @@ class DeepseekOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         if torch.sum(patches).item() == 0:
             return None
 
-        local_features_1 = self.sam_model(patches)
-        local_features_2 = self.vision_model(patches, local_features_1)
+        local_features_1, local_features_2 = self.visual(patches)
         features = torch.cat(
             (
                 local_features_2[:, 1:],

--- a/vllm/transformers_utils/configs/deepseek_vl2.py
+++ b/vllm/transformers_utils/configs/deepseek_vl2.py
@@ -214,3 +214,8 @@ class DeepseekVLV2Config(PretrainedConfig):
         self.global_view_pos = global_view_pos
         self.candidate_resolutions = candidate_resolutions
         self.vocab_size = self.text_config.vocab_size
+
+        # update model_type for OCR model
+        if "DeepseekOCRForCausalLM" in (self.architectures
+                                        or kwargs.get("architectures", [])):
+            self.model_type = "deepseek_ocr"

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -107,21 +107,27 @@ class VisionBuckets:
     This class is used to bucket image tokens
     '''
 
-    def __init__(self, is_batch_based):
+    def __init__(self,
+                 is_batch_based,
+                 sub_image_list: Optional[list[int]] = None):
         self.is_batch_based = is_batch_based
         envvar = os.environ.get('VLLM_MULTIMODAL_BUCKETS', "").lower()
         if envvar == 'none':
             self.multimodal_buckets = None
         else:
             if envvar == "":
-                if is_batch_based:
+                if sub_image_list is not None:
+                    assert isinstance(sub_image_list, list), \
+                        "sub_image_list must be a list"
+                    multimodal_buckets = sub_image_list
+                elif is_batch_based:
                     multimodal_buckets = [1, 2, 4, 8]  # batch sizes for gemma3
                 else:
                     multimodal_buckets = [1600, 3136, 4096, 6400]
             else:
                 multimodal_buckets = [int(i) for i in envvar.split(',')]
             self.multimodal_buckets = self._process_buckets(multimodal_buckets)
-        self.graphed_buckets = set()
+        self.graphed_buckets: Set[Any] = set()
         self.skip_warmup = os.environ.get('VLLM_SKIP_WARMUP',
                                           'false').lower() == 'true'
 
@@ -204,6 +210,14 @@ def is_mm_optimized(model):
         if hasattr(model, 'model') else \
         'Gemma3ForConditionalGeneration' in str(type(model)) or \
         'DeepseekOCRForCausalLM' in str(type(model))
+
+
+def fixed_sub_image_list(model):
+    # So far, in deepseek OCR model, the sub image mode only
+    # supports 0~6 excluding 1. 1 means the sub image is equal
+    # to global image, which is not allowed.
+    return [i for i in range(6+1) if i!=1] \
+        if model.config.model_type == 'deepseek_ocr' else None
 
 
 def pad_flat_tensor(tensor, desired_size):
@@ -408,9 +422,12 @@ class HpuModelAdapter(torch.nn.Module):
         # This is to ensure that we keeps
         # the static and dynamic parts distinct.
         if htorch.utils.internal.is_lazy():
-            if self.model_is_mrope and hasattr(self.model, 'visual') and \
-               model_config is not None and \
-               model_config.model_type not in ("glm4v_moe", "paddleocr_vl"):
+            if (self.model_is_mrope and hasattr(self.model, 'visual') and
+                model_config is not None
+                and model_config.model_type not in
+                ("glm4v_moe", "paddleocr_vl")) \
+               or (model_config is not None and
+                   model_config.model_type in ("deepseek_ocr")):
                 logger.info("[Multimodal] Wrapping Visual Model")
                 self.model.visual = htorch.hpu.wrap_in_hpu_graph(
                     self.model.visual, disable_tensor_cache=True)
@@ -1731,8 +1748,10 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     def add_vision_buckets_to_mrope_mm_optimized(self):
         model = self.get_model()
         self.is_mm_optimized = is_mm_optimized(model)
+        sub_image_list = fixed_sub_image_list(model)
         if self.model_is_mrope or self.is_mm_optimized:
-            model.vision_buckets = VisionBuckets(self.is_mm_optimized)
+            model.vision_buckets = \
+                VisionBuckets(self.is_mm_optimized, sub_image_list)
             model.vision_buckets.graphed_buckets = \
                 self.graphed_multimodal_buckets
             model.audio_buckets = AudioBuckets()
@@ -3023,6 +3042,16 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 "pixel_values": pixel_values,
                 "image_grid_thw": image_grid_thw,
             }
+        elif self.get_model().config.model_type == 'deepseek_ocr':
+            pixel_values = torch.randn(1, 3, 1024, 1024)
+            images_crop = torch.randn(img_args, 3, 640, 640)
+            images_spatial_crop = torch.tensor([[1, img_args]])
+            multi_modal_data = {
+                "pixel_values": pixel_values,
+                "images_crop": images_crop,
+                "images_spatial_crop": images_spatial_crop,
+            }
+            num_image_tokens = 1
         elif self.model_is_mrope:
             if not hasattr(self.get_model().config, "vision_config"):
                 raise ValueError("Expect mrope model to have vision_config")
@@ -3077,7 +3106,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
 
         if 'ernie4_5_moe_vl' in self.get_model().config.model_type:
             image_token_id = self.get_model().config.im_patch_id
-        elif 'deepseek_vl_v2' in self.get_model().config.model_type:
+        elif 'deepseek_ocr' in self.get_model().config.model_type:
             image_token_id = self.get_model().image_token_id
         else:
             image_token_id = self.get_model().config.image_token_id


### PR DESCRIPTION
The Deepseek OCR model uses fixed input tensor shape, so there is no need for padding.
Its input is different from the other MM models so a new fake data set is added to warm it up.

