### PR TITLE
[DeepSeek R1] P/D chunked prefill warmup with chunk size using context blocks

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -2086,8 +2086,8 @@ class Scheduler:
             if remaining_token_budget >= scheduler_config.prefill_chunk_size:
                 remaining_token_budget = scheduler_config.prefill_chunk_size
             else:
-                # If we cannot sequence has to be chunked, we make sure the
-                # context blocks are prefill_chunk_size
+                # If we sequence has to be chunked, we make sure the context
+                # blocks are multiple of prefill_chunk_size
                 if num_new_tokens > remaining_token_budget:
                     remaining_token_budget = 0
         num_new_tokens = min(num_new_tokens, remaining_token_budget)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -2083,8 +2083,13 @@ class Scheduler:
             # If prefill_chunk_size is specified, chunk with the specific size
             # The prefill_chunk_size must be dividable by the block size
             assert scheduler_config.prefill_chunk_size % block_size == 0
-            remaining_token_budget = min(
-                remaining_token_budget, scheduler_config.prefill_chunk_size)
+            if remaining_token_budget >= scheduler_config.prefill_chunk_size:
+                remaining_token_budget = scheduler_config.prefill_chunk_size
+            else:
+                # If we cannot sequence has to be chunked, we make sure the
+                # context blocks are prefill_chunk_size
+                if num_new_tokens > remaining_token_budget:
+                    remaining_token_budget = 0
         num_new_tokens = min(num_new_tokens, remaining_token_budget)
 
         return num_new_tokens

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1913,6 +1913,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             block_tables = None
             if context_blocks > 0:
                 context_len = context_blocks * self.block_size
+                # input length and num blocks needs to consider the context
+                input_len = seq_len + context_len
+                num_blocks = math.ceil(input_len / self.block_size)
                 block_tables = {group_id: [_PAD_BLOCK_ID] * num_blocks}
         else:
             input_len = seq_len - 1


### PR DESCRIPTION
Implement warmup for P/D chunked prefill when prefill chunk size is specified. This is a simpler warmup case for chunked prefill. When chunk size is not specified, the number of warmup cases will be increased by times of(max_seq_len / block_size) which is not realistic to implement.

This implement using the max_model_len and the chunk size to calculate the possible number of context chunks and warmup with this context chunks.