### PR TITLE
Fix xgrammar fallback for v0

### DIFF
--- a/vllm/model_executor/guided_decoding/utils.py
+++ b/vllm/model_executor/guided_decoding/utils.py
@@ -17,14 +17,12 @@ def has_xgrammar_unsupported_json_features(schema: dict) -> bool:
 
         # Check for array unsupported keywords
         if obj.get("type") == "array" and any(key in obj for key in [
-                "uniqueItems", "contains", "minContains", "maxContains",
-                "minItems", "maxItems"
+                "uniqueItems", "contains", "minContains", "maxContains"
         ]):
             return True
 
         # Unsupported keywords for strings
-        if obj.get("type") == "string" and any(
-                key in obj for key in ["minLength", "maxLength", "format"]):
+        if obj.get("type") == "string" and "format" in obj:
             return True
 
         # Unsupported keywords for objects

--- a/vllm/model_executor/guided_decoding/utils.py
+++ b/vllm/model_executor/guided_decoding/utils.py
@@ -16,9 +16,9 @@ def has_xgrammar_unsupported_json_features(schema: dict) -> bool:
             return True
 
         # Check for array unsupported keywords
-        if obj.get("type") == "array" and any(key in obj for key in [
-                "uniqueItems", "contains", "minContains", "maxContains"
-        ]):
+        if obj.get("type") == "array" and any(
+                key in obj for key in
+            ["uniqueItems", "contains", "minContains", "maxContains"]):
             return True
 
         # Unsupported keywords for strings


### PR DESCRIPTION
## Issue:

When using tool calling on V0, xgrammar is falling back to outlines, and we are unable to handle complex tool calling requests (used for Agentic AI) that are handled instead with Nvidia.

It is not a failure, we have:
```
WARNING 11-26 20:25:33 [__init__.py:34] xgrammar does not support advanced JSON schema features like string length, item limits, or property bounds. Falling back to use outlines instead.
```
but the service is not usable - wrong parser. 

I've adapted this solution:
https://github.com/vllm-project/vllm/blob/v0.9.0.1/vllm/v1/structured_output/backend_xgrammar.py#L198
to the `has_xgrammar_unsupported_json_features()` function used in V0.


