### PR TITLE
Fix vllm ubi based image build

### DIFF
--- a/README_GAUDI.md
+++ b/README_GAUDI.md
@@ -30,7 +30,7 @@ Set up the container with the latest Intel Gaudi Software Suite release using th
 ### Ubuntu
 
 ```
-$ docker build -f Dockerfile.hpu -t vllm-hpu-env  .
+$ docker build -f docker/Dockerfile.hpu -t vllm-hpu-env  .
 $ docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --rm vllm-hpu-env
 ```
 
@@ -48,7 +48,7 @@ See [this repo](https://github.com/HabanaAI/Setup_and_Install/tree/main/dockerfi
 Additionally, the path to the Docker image must be updated in the Dockerfile.hpu.ubi file.
 
 ```
-$ docker build -f Dockerfile.hpu.ubi -t vllm-hpu-env  .
+$ docker build -f docker/Dockerfile.hpu.ubi -t vllm-hpu-env  .
 $ docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --rm vllm-hpu-env
 ```
 

--- a/docker/Dockerfile.hpu.ubi
+++ b/docker/Dockerfile.hpu.ubi
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ## Starting from the 1.22.x Intel Gaudi software version, we no longer provide RHEL Docker images.
-## These must be created manually, and the path below should be updated accordingly.
-ARG BASE_IMAGE=vault.habana.ai/gaudi-docker/1.21.4/rhel9.4/habanalabs/pytorch-installer-2.6.0:latest
+## These must be created manually, and the path below should be updated accordingly, for example:
+#ARG BASE_IMAGE=vault.habana.ai/gaudi-docker/1.21.4/rhel9.4/habanalabs/pytorch-installer-2.6.0:latest
+
+ARG
 
 FROM ${BASE_IMAGE} as habana-base
 
@@ -11,30 +13,17 @@ USER root
 
 ENV VLLM_TARGET_DEVICE="hpu"
 
-RUN dnf -y update --best --allowerasing --skip-broken && dnf clean all
+RUN dnf -y update --nobest --allowerasing --skip-broken && dnf clean all
 
 WORKDIR /workspace
 
-## Python Installer #################################################################
-FROM habana-base as python-install
-
-ARG PYTHON_VERSION=3.11
-
-ENV VIRTUAL_ENV=/opt/vllm
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN dnf install -y --setopt=install_weak_deps=0 --nodocs \
-    python${PYTHON_VERSION}-wheel && \
-    python${PYTHON_VERSION} -m venv $VIRTUAL_ENV --system-site-packages && pip install --no-cache -U pip wheel && dnf clean all
-
 ## Python Habana base #################################################################
-FROM python-install as python-habana-base
+FROM habana-base as python-habana-base
 
-ENV VIRTUAL_ENV=/opt/vllm
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install Habana Software and common dependencies
 RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,source=requirements-common.txt,target=requirements-common.txt \
+    --mount=type=bind,source=requirements,target=requirements \
     --mount=type=bind,source=requirements-hpu.txt,target=requirements-hpu.txt \
     pip install \
     -r requirements-hpu.txt
@@ -49,7 +38,7 @@ COPY csrc csrc
 COPY setup.py setup.py
 COPY cmake cmake
 COPY CMakeLists.txt CMakeLists.txt
-COPY requirements-common.txt requirements-common.txt
+COPY requirements requirements
 COPY requirements-hpu.txt requirements-hpu.txt
 COPY pyproject.toml pyproject.toml
 
@@ -73,12 +62,9 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
     python3 setup.py bdist_wheel --dist-dir=dist
 
 ## Release #####################################################################
-FROM python-install AS vllm-openai
+FROM build AS vllm-openai
 
 WORKDIR /workspace
-
-ENV VIRTUAL_ENV=/opt/vllm
-ENV PATH=$VIRTUAL_ENV/bin/:$PATH
 
 # Triton needs a CC compiler
 RUN dnf install -y --setopt=install_weak_deps=0 --nodocs gcc \
@@ -99,7 +85,7 @@ ENV HF_HUB_OFFLINE=1 \
 # set up a non-root user here.
 RUN umask 002 \
     && useradd --uid 2000 --gid 0 vllm \
-    && chmod g+rwx $HOME /usr/src /workspace
+    && chmod g+rwx $HOME /usr/src /workspace && chmod -R g+rwx /var/log/habana_logs
 
 COPY LICENSE /licenses/vllm.md
 


### PR DESCRIPTION
Add reference to instructions about building Gaudi UBI base image and fix outdated links in the docker file.

- [x] Test image on an Openshift cluster

<!--- pyml disable-next-line no-emphasis-as-heading -->



## Purpose

## Test Plan
Deployment of 8 inference instance using franite 8b on Openshift AI
run inference queries
## Test Result
Success
<!--- pyml disable-next-line no-emphasis-as-heading -->
