### PR TITLE
[Proxy Server] Add support for dict-based prompt items and unify token limit parameters

### DIFF
--- a/examples/online_serving/disagg_examples/disagg_proxy_advanced.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_advanced.py
@@ -573,11 +573,14 @@ class Proxy:
 
             kv_prepare_request = request.copy()
             kv_prepare_request["max_tokens"] = 1
+            kv_prepare_request["max_completion_tokens"] = 1
 
             start_time = time.time()
             prompt = kv_prepare_request.get("prompt")
             total_length = self.get_total_token_length(prompt)
-            max_tokens = request.get("max_tokens", 0)
+            max_tokens = request.get("max_completion_tokens", 0)
+            if max_tokens == 0:
+                max_tokens = request.get("max_tokens", 0)
             end_time = time.time()
             log_info_green(
                 f"create_completion -- prompt length: {total_length}, "
@@ -677,13 +680,17 @@ class Proxy:
             # add params to request
             kv_prepare_request = request.copy()
             kv_prepare_request["max_tokens"] = 1
+            kv_prepare_request["max_completion_tokens"] = 1
 
             start_time = time.time()
             # prefill stage
             total_length = sum(
                 self.get_total_token_length(msg['content'])
                 for msg in kv_prepare_request['messages'])
-            max_tokens = request.get("max_tokens", 0)
+            max_tokens = request.get("max_completion_tokens", 0)
+            if max_tokens == 0:
+                max_tokens = request.get("max_tokens", 0)
+
             end_time = time.time()
             log_info_green(
                 f"create_chat_completion -- prompt length: {total_length}, "

--- a/examples/online_serving/disagg_examples/disagg_proxy_advanced.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_advanced.py
@@ -575,14 +575,11 @@ class Proxy:
 
             kv_prepare_request = request.copy()
             kv_prepare_request["max_tokens"] = 1
-            kv_prepare_request["max_completion_tokens"] = 1
 
             start_time = time.time()
             prompt = kv_prepare_request.get("prompt")
             total_length = self.get_total_token_length(prompt)
-            max_tokens = request.get("max_completion_tokens", 0)
-            if max_tokens == 0:
-                max_tokens = request.get("max_tokens", 0)
+            max_tokens = request.get("max_tokens", 0)
             end_time = time.time()
             log_info_green(
                 f"create_completion -- prompt length: {total_length}, "

--- a/examples/online_serving/disagg_examples/disagg_proxy_advanced.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_advanced.py
@@ -541,6 +541,8 @@ class Proxy:
                 all(isinstance(x, int) for x in p) for p in prompt)):
                 # Already tokenized
                 return sum(len(p) for p in prompt)
+            elif all(isinstance(p, dict) and "text" in p for p in prompt):
+                return sum(len(self.tokenizer(p["text"])["input_ids"]) for p in prompt)
             else:
                 logger.error(
                     "Unsupported prompt format: %s / nested types. Value: %r",

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -846,6 +846,8 @@ class OpenAIServingChat(OpenAIServing):
 
         created_time = int(time.time())
         final_res: Optional[RequestOutput] = None
+        reasoning_content = None
+        content = None
 
         try:
             async for res in result_generator:


### PR DESCRIPTION
1. Support list[dict] prompt format by extracting "text" field in token length calculation
2. Set both max_tokens and max_completion_tokens to 1 to ensure compatibility