### PR TITLE
[DeepSeek R1] Gracefully shutdown mooncake store when exception for kill

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/mooncake_store_connector.py
@@ -92,7 +92,11 @@ class MooncakeStoreConnector(KVConnectorBase):
         Raises:
             NotImplementedError: This method must be implemented in subclasses.
         """
+        if self.kv_store is None:
+            return
+
         self.kv_store.close()
+        self.kv_store = None
 
     def send_kv_caches_and_hidden_states(
         self,

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
@@ -96,13 +96,20 @@ class MooncakeStore(KVLookupBufferBase):
             self.config = MooncakeStoreConfig.load_from_env()
             logger.info("Mooncake Configuration loaded successfully.")
 
-            self.store.setup(self.config.local_hostname,
-                             self.config.metadata_server,
-                             self.config.global_segment_size,
-                             self.config.local_buffer_size,
-                             self.config.protocol, self.config.device_name,
-                             self.config.master_server_address)
-
+            result = self.store.setup(
+                self.config.local_hostname,
+                self.config.metadata_server,
+                self.config.global_segment_size,
+                self.config.local_buffer_size,
+                self.config.protocol,
+                self.config.device_name,
+                self.config.master_server_address)
+            if result != 0:
+                error_msg = ("Failed to setup Mooncake store. "
+                             f"ErrorCode: {result}. "
+                             "Please make sure Mooncake master is "
+                             "running and check the configuration.")
+                raise RuntimeError(error_msg)
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
             raise

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py
@@ -134,9 +134,13 @@ class MooncakeStore(KVLookupBufferBase):
         raise NotImplementedError
 
     def close(self):
-        # MooncakeDistributedStore will automatically call the destructor, so
-        # it is unnecessary to close it manually.
-        pass
+        # MooncakeDistributedStore will close automatically in the following cases:
+        # 1. SIGINT, SIGTERM and SIGHUP are sent and there is no other signal handler
+        # 2. Normal exit
+        # If python process has another signal handler registered, the signal handler
+        # is responsible for calling to close
+        self.store.close()
+        logger.info("Mooncake store close successfully.")
 
     def put(
         self,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -416,6 +416,10 @@ class LLMEngine:
 
         self.seq_id_to_seq_group: Dict[str, SequenceGroupBase] = {}
 
+    def shutdown(self):
+        """Shutdown and cleanup engine resources."""
+        self.model_executor.shutdown()
+
     def _initialize_kv_caches(self) -> None:
         """Initialize the KV cache in the worker(s).
 

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -380,7 +380,15 @@ class MQLLMEngine:
         return self.engine.reset_prefix_cache()
 
 
+mp_engine_terminated = False
+
+
 def signal_handler(*_) -> None:
+    global mp_engine_terminated
+    if mp_engine_terminated:
+        logger.info("MQLLMEngine is already in progress of terminating.")
+        return
+    mp_engine_terminated = True
     raise KeyboardInterrupt("MQLLMEngine terminated")
 
 

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -148,6 +148,7 @@ class MQLLMEngine:
         """Cleanup zeromq state on shutdown."""
         # Closes all sockets and destroys context.
         self.ctx.destroy(linger=0)
+        self.engine.shutdown()
         del self.engine
 
     @contextmanager

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -9,6 +9,8 @@ import cloudpickle
 import zmq
 
 from vllm import AsyncEngineArgs, SamplingParams
+from vllm.distributed import (destroy_distributed_environment,
+                              destroy_model_parallel)
 from vllm.engine.llm_engine import LLMEngine
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -149,6 +151,12 @@ class MQLLMEngine:
         # Closes all sockets and destroys context.
         self.ctx.destroy(linger=0)
         self.engine.shutdown()
+
+        # Cleanup the pytorch distributed groups
+        logger.info("Cleanup parallel environments...")
+        destroy_model_parallel()
+        destroy_distributed_environment()
+
         del self.engine
 
     @contextmanager

--- a/vllm/executor/mp_distributed_executor.py
+++ b/vllm/executor/mp_distributed_executor.py
@@ -131,7 +131,7 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
 
     def shutdown(self):
         if getattr(self, 'shutdown_workers', False):
-            self._run_workers("shutdown")
+            self._run_workers("shutdown", ignore_error=True)
             self.shutdown_workers = False
         if (worker_monitor := getattr(self, "worker_monitor",
                                       None)) is not None:
@@ -153,6 +153,7 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
         *args,
         async_run_tensor_parallel_workers_only: bool = False,
         max_concurrent_workers: Optional[int] = None,
+        ignore_error: bool = False,
         **kwargs,
     ) -> List[Any]:
         """Runs the given method on all workers.
@@ -180,9 +181,19 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
                 for worker in self.non_driver_workers
             ]
 
+        def execute_method(worker):
+            if not ignore_error:
+                return worker.execute_method(sent_method, *args, **kwargs)
+
+            try:
+                return worker.execute_method(sent_method, *args, **kwargs)
+            except Exception as e:
+                logger.warning("Error on execute method on worker: %s", str(e))
+                return None
+
         # Start all remote workers first.
         worker_outputs = [
-            worker.execute_method(sent_method, *args, **kwargs)
+            execute_method(worker)
             for worker in self.workers
         ]
 
@@ -191,7 +202,7 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
 
         # Get the results of the workers.
         return [driver_worker_output
-                ] + [output.get() for output in worker_outputs]
+                ] + [output.get() if output else None for output in worker_outputs]
 
     def check_health(self) -> None:
         """Raises an error if engine is unhealthy."""

--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import sys
 import threading
+import time
 import uuid
 from dataclasses import dataclass
 from multiprocessing import Queue
@@ -126,6 +127,15 @@ class WorkerMonitor(threading.Thread):
                     logger.error("Worker %s pid %s died, exit code: %s",
                                  process.name, process.pid, process.exitcode)
             # Cleanup any remaining workers
+            # First try terminating for normal shutdown
+            if logger:
+                logger.info("Terminating local vLLM worker processes")
+            for worker in self.workers:
+                worker.terminate_worker()
+
+            # Wait for a few seconds to kill
+            time.sleep(3)
+
             if logger:
                 logger.info("Killing local vLLM worker processes")
             for worker in self.workers:
@@ -256,6 +266,9 @@ def _run_worker_process(
         logger.exception("Worker failed")
 
     logger.info("Worker exiting")
+
+    # Shut down the worker at process exiting
+    worker.shutdown()
 
 
 def _add_prefix(file: TextIO, worker_name: str, pid: int) -> None:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -2607,6 +2607,15 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 attn_backend=self.attn_backend,
             ))
 
+    def shutdown_kv_transfer(self):
+        if self.vllm_config.kv_transfer_config is None:
+            return
+
+        try:
+            get_kv_transfer_group().close()
+        except Exception as e:
+            logger.warning("Failed to close KV Transfer: %s", str(e))
+
     def need_recv_kv(self, model_input, kv_caches, warmup_mode) -> bool:
         """Check if we need to receive kv-cache from the other worker.
         We need to receive KV when

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -69,6 +69,7 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         self.rank = rank
         self.distributed_init_method = distributed_init_method
         self.is_driver_worker = is_driver_worker
+        self._shutdown = False
         if self.parallel_config and self.is_driver_worker:
             assert self.rank % self.parallel_config.tensor_parallel_size == 0, \
             "The driver worker must have TP rank 0."
@@ -520,7 +521,13 @@ class HPUWorker(LocalOrDistributedWorkerBase):
             "Prompt Adapter is not implemented for HPU backend.")
 
     def shutdown(self):
+        # Make sure we call shutdown only once
+        if self._shutdown:
+            return
+
         self.model_runner.shutdown_inc()
+        self.model_runner.shutdown_kv_transfer()
+        self._shutdown = True
 
     @property
     def max_model_len(self) -> int:

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -129,6 +129,10 @@ class WorkerBase:
         """Get vocabulary size from model configuration."""
         return self.model_config.get_vocab_size()
 
+    def shutdown(self) -> None:
+        """Clean up resources held by the worker."""
+        return
+
 
 class DelegateWorkerBase(WorkerBase):
     """
@@ -626,6 +630,10 @@ class WorkerWrapperBase:
 
     def __getattr__(self, attr):
         return getattr(self.worker, attr)
+
+    def shutdown(self) -> None:
+        if self.worker is not None:
+            self.worker.shutdown()
 
 
 def extract_previous_hidden_states(


### PR DESCRIPTION
This is to handle a lot of shutdown cases when any processes are killed or there are exceptions.
User can use "kill pid" to kill any process and the moon cake store shutdown gracefully. WARNING: if you use kill -9 to kill a process, the process is killed forcefully and there is no way to handle. You need to restart all the services for this case. It is suggest for you to gracefully shutdown a service by "kill" the pid of the api_server. This is enough to shutdown all distributed processes started as part of the api server.
When engine process shut down, it will cleanup the following:
1. Mooncake store: Unregister the global memory
2. The Parallel environments: PyTorch distributed groups