### PR TITLE
Delay prefix cache calculation to find longest common prefix

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2185,6 +2185,14 @@ class SchedulerConfig:
     like full attention and sliding window attention.
     """
 
+    delayed_prefix_caching_calculation: bool = False
+    """
+    When enabled (True) with APC and padding-aware scheduling active,
+    forces immediate exit from the prefill scheduling loop upon
+    reaching `max_num_prefill_seqs`. This optimization enables
+    identification of the longest contiguous sequence prefix available.
+    """
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1305,6 +1305,14 @@ class Scheduler:
                 budget.add_prefill_seqs(seq_group.request_id, num_new_seqs,
                                         max_prefill_seq_len)
 
+                # break early if we have reached the max number of prefill seqs
+                # otherwise it could not be able to get longest prefix
+                if current_platform.is_hpu() \
+                    and self.cache_config.enable_prefix_caching \
+                    and budget.num_curr_prefill_seqs >= \
+                        self.scheduler_config.max_num_prefill_seqs:
+                    break
+
         # Queue requests that couldn't be scheduled.
         waiting_queue.extendleft(leftover_waiting_sequences)
         if len(seq_groups) > 0:

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1308,6 +1308,8 @@ class Scheduler:
                 # break early if we have reached the max number of prefill seqs
                 # otherwise it could not be able to get longest prefix
                 if current_platform.is_hpu() \
+                    and self.scheduler_config \
+                        .delayed_prefix_caching_calculation \
                     and self.cache_config.enable_prefix_caching \
                     and budget.num_curr_prefill_seqs >= \
                         self.scheduler_config.max_num_prefill_seqs:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1232,6 +1232,8 @@ class EngineArgs:
             long_prefill_token_threshold=self.long_prefill_token_threshold,
             disable_hybrid_kv_cache_manager=self.
             disable_hybrid_kv_cache_manager,
+            delayed_prefix_caching_calculation=envs.
+            VLLM_SCHED_DELAYED_PREFIX_CACHING_CALCULATION,
         )
 
         lora_config = LoRAConfig(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -127,6 +127,7 @@ if TYPE_CHECKING:
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
     VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS: int = 1
     VLLM_SLEEP_WHEN_IDLE: bool = False
+    VLLM_SCHED_DELAYED_PREFIX_CACHING_CALCULATION: bool = False
 
 
 def get_default_cache_root():
@@ -872,6 +873,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # latency penalty when a request eventually comes.
     "VLLM_SLEEP_WHEN_IDLE":
     lambda: bool(int(os.getenv("VLLM_SLEEP_WHEN_IDLE", "0"))),
+
+    # When enabled (True) with APC and padding-aware scheduling active,
+    # forces immediate exit from the prefill scheduling loop upon
+    # reaching `max_num_prefill_seqs`. This optimization enables
+    # identification of the longest contiguous sequence prefix available.
+    "VLLM_SCHED_DELAYED_PREFIX_CACHING_CALCULATION":
+    lambda: os.environ.get("VLLM_SCHED_DELAYED_PREFIX_CACHING_CALCULATION",
+                           "false").lower() in ("1", "true"),
 }
 
 # --8<-- [end:env-vars-definition]


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results


## Purpose
We found when running test with a dataset with prefix, and there're pending requests, the prefix is not longest and wasted computation, which is caused by scheduler caching the prefix but reach max prefill num of seqs, in this case, it can miss the longest prefix.

## Test Plan
Run with customer dataset with prefix and compare with the option on and off.

## Test Result
TTFT is improved from 4085.28ms to 3373.49ms. 

<!--- pyml disable-next-line no-emphasis-as-heading -->
