### PR TITLE
don't overwrite padding-aware scheduler when chunked prefill is disabled

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -5,6 +5,7 @@ import copy
 import enum
 import hashlib
 import json
+import os
 import sys
 import warnings
 from contextlib import contextmanager
@@ -1687,8 +1688,13 @@ class SchedulerConfig:
             raise ValueError("max_num_prefill_seqs can be only "
                              "used with padding-aware-scheduling. ")
         if self.use_padding_aware_scheduling and self.chunked_prefill_enabled:
-            raise ValueError("Padding-aware scheduling currently "
-                             "does not work with chunked prefill ")
+            if os.getenv("VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL", "false").lower() in ("1", "true") :
+                logger.warning("Padding-aware scheduling with chunked prefill "
+                               "is experimental and may lead to unexpected "
+                               "behaviors.")
+            else:
+                raise ValueError("Padding-aware scheduling currently "
+                                "does not work with chunked prefill ")
 
     @property
     def is_multi_step(self) -> bool:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1693,8 +1693,12 @@ class SchedulerConfig:
                                "is experimental and may lead to unexpected "
                                "behaviors.")
             else:
-                raise ValueError("Padding-aware scheduling currently "
-                                "does not work with chunked prefill ")
+                self.use_padding_aware_scheduling = False
+                logger.warning("Disabling padding-aware scheduling since "
+                               "chunked prefill is enabled. To enable "
+                               "padding-aware scheduling with chunked prefill, "
+                               "set the environment variable "
+                               "VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL=true")
 
     @property
     def is_multi_step(self) -> bool:

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -447,15 +447,6 @@ class Scheduler:
     ) -> None:
         self.scheduler_config = scheduler_config
 
-        overwrite = self.scheduler_config.enable_chunked_prefill and \
-            os.getenv("VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL", "false").lower() in ("1", "true") 
-        if overwrite != self.scheduler_config.use_padding_aware_scheduling:
-            self.scheduler_config.use_padding_aware_scheduling = overwrite
-            logger.warning(
-                "<scheduler> use_padding_aware_scheduling is overwrited to %s",
-                " by the VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL env var."
-                self.scheduler_config.use_padding_aware_scheduling)
-
         self.cache_config = cache_config
         # Note for LoRA scheduling: the current policy is extremely
         # simple and NOT fair. It can lead to starvation of some

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -447,13 +447,13 @@ class Scheduler:
     ) -> None:
         self.scheduler_config = scheduler_config
 
-        overwrite = bool(
-            int(os.environ.get("VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL", 0))
-        )
+        overwrite = self.scheduler_config.enable_chunked_prefill and \
+            os.getenv("VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL", "false").lower() in ("1", "true") 
         if overwrite != self.scheduler_config.use_padding_aware_scheduling:
             self.scheduler_config.use_padding_aware_scheduling = overwrite
             logger.warning(
                 "<scheduler> use_padding_aware_scheduling is overwrited to %s",
+                " by the VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL env var."
                 self.scheduler_config.use_padding_aware_scheduling)
 
         self.cache_config = cache_config


### PR DESCRIPTION
The padding-aware scheduler is expected to be **enabled** by default, but it will be disabled as the `VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL` is set to `False` by default. This PR makes the `VLLM_PADDING_AWARE_IN_CHUNKED_PREFILL` takes effects when the chunked prefill is enabled only.