### PR TITLE
Fix large image bug on qwen3-vl

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -410,7 +410,10 @@ class Qwen2_5_VisionAttention(nn.Module):
                     q_i = q[:, start_idx:end_idx]
                     k_i = k[:, start_idx:end_idx]
                     v_i = v[:, start_idx:end_idx]
-                    a_i = attn_mask[start_idx:end_idx, start_idx:end_idx]
+                    if attn_mask is not None:
+                        a_i = attn_mask[start_idx:end_idx, start_idx:end_idx]
+                    else:
+                        a_i = None
                     q_i, k_i, v_i = (rearrange(x, "b s h d -> b h s d")
                                      for x in [q_i, k_i, v_i])
                     output_i = FusedSDPA.apply(q_i, k_i, v_i, a_i, 0.0, False,
@@ -426,10 +429,13 @@ class Qwen2_5_VisionAttention(nn.Module):
                 (batch_size, _, seq_len_N_t, _) = q1.shape
                 (batch_size, _, seq_len_N_s, _) = k1.shape
                 mask_shape = (batch_size, 1, seq_len_N_t, seq_len_N_s)
-                attn_mask = fullatt_block_attn_mask.reshape(
-                    batch_size, 1, seq_len_N_t, seq_len_N_s,
-                    -1)[:, :, :, :, 0]  # reshapes the mask to be Bx1xNxN
-                assert attn_mask.shape == mask_shape
+                if fullatt_block_attn_mask is not None:
+                    attn_mask = fullatt_block_attn_mask.reshape(
+                        batch_size, 1, seq_len_N_t, seq_len_N_s,
+                        -1)[:, :, :, :, 0]  # reshapes the mask to be Bx1xNxN
+                    assert attn_mask.shape == mask_shape
+                else:
+                    attn_mask = None
 
                 if q1.shape[2] <= 65536:  # need to investigate this crosspoint
                     fused_out = FusedSDPA.apply(q1, k1, v1, attn_mask, 0.0,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -629,8 +629,11 @@ class Qwen3_VisionTransformerStaticShape(Qwen3_VisionTransformer):
                     attention_mask.squeeze(1).unsqueeze(0) * attention_mask
 
                 extra_forward_kwargs = {}
+                padded_len = pixel_values_curr_img_padded.shape[0]
+                if padded_len == curr_img_size:
+                    # If there is no pad, attn_mask is not needed
+                    fullatt_block_attn_mask = None
                 if htorch.utils.internal.is_lazy():
-                    padded_len = pixel_values_curr_img_padded.shape[0]
                     use_graph = vision_buckets.use_graph(padded_len)
                     extra_forward_kwargs.update(
                         {"bypass_hpu_graphs": not use_graph})


### PR DESCRIPTION
When input attn_mask and seq_len is large, FusedSDPA fail.

Because large input image doesn't use pad, attn_mask is set to None for large input image to avoid this error.


example cmd:
`VLLM_SKIP_WARMUP=true VLLM_IMAGE_FETCH_TIMEOUT=60 VLLM_VIDEO_FETCH_TIMEOUT=60 VLLM_AUDIO_FETCH_TIMEOUT=60 VLLM_GRAPH_RESERVED_MEM=0.5 PT_HPU_LAZY_MODE=1 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct --port 6860 --host 0.0.0.0 --dtype bfloat16 --gpu-memory-utilization 0.7 --limit-mm-per-prompt '{"video":999, "image":999}' --tensor-parallel-size 2 --enable-expert-parallel --max-model-len 16384 --allowed-local-media-path /root/workspace/mm_resource/`
client:
modify _examples/online_serving/openai_chat_completion_client_for_multimodal_copy.py_ to use image with different resolution.
`python examples/online_serving/openai_chat_completion_client_for_multimodal_copy.py -c single-image`