### PR TITLE
Enabled DeepSeek-Eagle on VLLM V0 for Gaudi

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -138,6 +138,9 @@ class SamplerOutput(
     # block/sync across workers, cpu-gpu sync time and sampling time.
     model_execute_time: Optional[float] = None
 
+    #  Optional for eagle proposer
+    all_hidden_states: Optional[torch.Tensor] = None
+
     def __getitem__(self, idx: int) -> CompletionSequenceGroupOutput:
         return self.outputs[idx]
 

--- a/vllm/model_executor/models/deepseek_eagle.py
+++ b/vllm/model_executor/models/deepseek_eagle.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader, maybe_remap_kv_scale_name)
+from vllm.model_executor.models.deepseek_v2 import (DeepseekV2DecoderLayer,
+                                                    DeepseekV3ForCausalLM)
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.sequence import IntermediateTensors
+
+from .utils import AutoWeightsLoader, maybe_prefix
+
+
+@support_torch_compile
+class DeepseekV2Model(nn.Module):
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        start_layer_id: int = 0,
+    ) -> None:
+        super().__init__()
+        self.config = vllm_config. \
+            speculative_config.draft_model_config.hf_config
+
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.vocab_size = self.config.vocab_size
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+
+        self.layers = nn.ModuleList([
+            DeepseekV2DecoderLayer(
+                self.config,
+                prefix=maybe_prefix(prefix, f"layers.{i + start_layer_id}"),
+                model_config=model_config,
+                cache_config=cache_config,
+                quant_config=quant_config,
+            ) for i in range(self.config.num_hidden_layers)
+        ])
+
+        self.fc = nn.Linear(
+            self.config.model.hidden_size * 2,
+            self.config.model.hidden_size,
+            bias=False,
+        )
+
+        self.enorm = RMSNorm(self.config.hidden_size,
+                             eps=self.config.rms_norm_eps)
+        self.hnorm = RMSNorm(self.config.hidden_size,
+                             eps=self.config.rms_norm_eps)
+        self.norm = RMSNorm(self.config.hidden_size,
+                            eps=self.config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        # ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
+        input_embeds = self.embed_tokens(input_ids)
+
+        inputs = torch.cat(
+            [self.enorm(input_embeds),
+             self.hnorm(hidden_states)], dim=-1)
+        hidden_states = self.fc(inputs)
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                residual,
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        # return hidden_states, hidden_states
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+            ("fused_qkv_a_proj", "q_a_proj", 0),
+            ("fused_qkv_a_proj", "kv_a_proj_with_mqa", 1),
+        ]
+
+        # Params for weights, fp8 weight scales, fp8 activation scales
+        # (param_name, weight_name, expert_id, shard_id)
+        expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts)
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                # Skip non-stacked layers and experts (experts handled below).
+                if weight_name not in name:
+                    continue
+                # We have mlp.experts[0].gate_proj in the checkpoint.
+                # Since we handle the experts below in expert_params_mapping,
+                # we need to skip here BEFORE we update the name, otherwise
+                # name will be updated to mlp.experts[0].gate_up_proj, which
+                # will then be updated below in expert_params_mapping
+                # for mlp.experts[0].gate_gate_up_proj, which breaks load.
+                if ("mlp.experts." in name) and name not in params_dict:
+                    continue
+                name_mapped = name.replace(weight_name, param_name)
+
+                # QKV fusion is optional, fall back to normal
+                # weight loading if it's not enabled
+                # if go with fusion option, then update name
+                if ((param_name == "fused_qkv_a_proj")
+                        and name_mapped not in params_dict):
+                    continue
+                else:
+                    name = name_mapped
+
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(
+                        param,
+                        loaded_weight,
+                        name,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                    )
+                    break
+                else:
+                    # if PP disabled then draft will share embed with target
+                    if get_pp_group().world_size == 1 and \
+                            "embed_tokens." in name:
+                        continue
+
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+
+                    # Remapping the name of FP8 kv-scale.
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader",
+                                            default_weight_loader)
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class EagleDeepseekV3ForCausalLM(DeepseekV3ForCausalLM):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        self.config = vllm_config. \
+            speculative_config.draft_model_config.hf_config
+        quant_config = vllm_config.quant_config
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config)
+        self.model = DeepseekV2Model(vllm_config=vllm_config,
+                                     prefix="model",
+                                     start_layer_id=target_layer_num)
+
+        self.lm_head = ParallelLMHead(self.config.vocab_size,
+                                      self.config.hidden_size,
+                                      quant_config=quant_config)
+
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.logits_processor = LogitsProcessor(self.config.vocab_size,
+                                                scale=logit_scale)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        # hidden_states: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        spec_step_index: int = 0,
+    ) -> torch.Tensor:
+        # ) -> tuple[torch.Tensor, torch.Tensor]:
+        if inputs_embeds is not None:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support multimodal inputs yet."
+            )
+        return self.model(input_ids, positions, previous_hidden_states)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[torch.Tensor]:
+        logits = self.logits_processor(self.lm_head, hidden_states,
+                                       sampling_metadata)
+        return logits
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+        )
+
+        model_weights = {}
+        for name, loaded_weight in weights:
+            if "lm_head" not in name:
+                name = "model." + name
+            model_weights[name] = loaded_weight
+        loader.load_weights(model_weights.items())

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -254,6 +254,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "EagleMiniCPMForCausalLM": ("minicpm_eagle", "EagleMiniCPMForCausalLM"),
     "Eagle3LlamaForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "DeepSeekMTPModel": ("deepseek_mtp", "DeepSeekMTP"),
+    "EagleDeepSeekMTPModel": ("deepseek_eagle", "EagleDeepseekV3ForCausalLM"),
     "Glm4MoeMTPModel": ("glm4_moe_mtp", "Glm4MoeMTP"),
     "MedusaModel": ("medusa", "Medusa"),
     "MLPSpeculatorPreTrainedModel": ("mlp_speculator", "MLPSpeculator"),

--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -413,21 +413,25 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
         new_output_token_ids = [*seq_data.get_output_token_ids(), *token_ids]
         mrope_position_delta = seq_data.mrope_position_delta
 
-        new_seq_data_dict = {
-            target_seq_id:
-            SequenceData(
-                prompt_token_ids,
-                _output_token_ids=array(VLLM_TOKEN_ID_ARRAY_TYPE,
-                                        new_output_token_ids),
-            ),
-        }
-        # This is a hack. Technically, spec decoding should compute
-        # num_lookahead slots at one shot, but instead, it expands the batch
-        # and evaluate one by one right now. context_len is seq_len - 1 because
-        # the kv cache is filled by a previous batch in the batch expansion.
-        for data in new_seq_data_dict.values():
-            data.update_num_computed_tokens(data.get_len() - 1)
-            data.mrope_position_delta = mrope_position_delta
+        if len(token_ids) == 0:
+            new_seq_data_dict = {target_seq_id: seq_data}
+        else:
+            new_seq_data_dict = {
+                target_seq_id:
+                SequenceData(
+                    prompt_token_ids,
+                    _output_token_ids=array(VLLM_TOKEN_ID_ARRAY_TYPE,
+                                            new_output_token_ids),
+                ),
+            }
+            # This is a hack. Technically, spec decoding should compute
+            # num_lookahead slots at one shot, but instead, it expands the
+            # batch and evaluate one by one right now. context_len is
+            # seq_len - 1 because the kv cache is filled by a previous
+            # batch in the batch expansion.
+            for data in new_seq_data_dict.values():
+                data.update_num_computed_tokens(data.get_len() - 1)
+                data.mrope_position_delta = mrope_position_delta
 
         return SequenceGroupMetadata(
             request_id=seq_group_metadata.request_id,

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -350,7 +350,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
             method == 'eagle':
             self.eagle_proposer = True
 
-        self.draft_seq_data_dict = {}
+        self.draft_seq_data_dict: dict[str, Any] = {}
 
     def init_device(self) -> None:
         """Initialize both scorer and proposer models.

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -24,7 +24,7 @@ from vllm.model_executor.layers.typical_acceptance_sampler import (
 from vllm.platforms import current_platform
 from vllm.sequence import (VLLM_INVALID_TOKEN_ID,
                            CompletionSequenceGroupOutput, ExecuteModelRequest,
-                           HiddenStates, SequenceGroupMetadata,
+                           HiddenStates, SequenceData, SequenceGroupMetadata,
                            get_all_seq_ids_and_request_ids)
 from vllm.spec_decode.batch_expansion import BatchExpansionTop1Scorer
 
@@ -193,11 +193,6 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                         draft_worker_kwargs[
                             "model_runner_cls"] = GeneralTP1DraftModelRunner
                 else:
-                    if draft_model_config.hf_config.model_type == "eagle":
-                        raise NotImplementedError(
-                            f"{draft_model_config.hf_config.model_type} "
-                            "does not support TP > 1 yet")
-
                     allow_zero_draft_token_step = False
 
                 # Load lm_head weight for eagle in init_device
@@ -347,6 +342,14 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         self._disable_log_stats = disable_log_stats
         self._num_spec_prefill_steps = num_spec_prefill_steps
 
+        if 'DeepseekV3ForCausalLM' in \
+            self.scorer_worker.model_runner.vllm_config.model_config. \
+            architectures and self.scorer_worker.model_runner. \
+            speculative_config is not None and \
+            self.scorer_worker.model_runner.speculative_config. \
+            method == 'eagle':
+            self.eagle_proposer = True
+
     def init_device(self) -> None:
         """Initialize both scorer and proposer models.
         """
@@ -360,15 +363,54 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         self.proposer_worker.load_model()
 
         if self._enable_lm_head_weight_load:
-            # NOTE(Shangming): gather lm_head weight when tp enabled
-            target_lm_head_weight: torch.Tensor = tensor_model_parallel_gather(
-                self.scorer_worker.model_runner.model_runner.model.lm_head.\
-                    weight.data,
-                    dim=0,
-            )
+            if self.eagle_proposer:
+                self.proposer_worker.model_runner.model.model.lm_head = \
+                    self.scorer_worker.model_runner.model_runner.model.lm_head
+            else:
+                # NOTE(Shangming): gather lm_head weight when tp enabled
+                target_lm_head_weight: torch.Tensor = \
+                    tensor_model_parallel_gather( \
+                    self.scorer_worker.model_runner.model_runner.model.lm_head.\
+                        weight.data,
+                        dim=0,
+                )
 
-            self.proposer_worker.maybe_load_lm_head_weight(
-                target_lm_head_weight)
+                self.proposer_worker.maybe_load_lm_head_weight(
+                    target_lm_head_weight)
+
+        if self.eagle_proposer:
+            # share embed_tokens with the target model if needed
+            target_embed_tokens_weight: torch.Tensor = \
+                self.scorer_worker.model_runner.model_runner.model.model.model.\
+                    embed_tokens.weight.data
+
+            if torch.distributed.get_world_size() == 1 \
+                and self.proposer_worker.model_runner.model.model. \
+                    model.embed_tokens. \
+                    weight.shape == target_embed_tokens_weight.shape:
+                logger.info(
+                    "Assuming the EAGLE head shares the same vocab embedding" \
+                    " with the target model."
+                )
+                del self.proposer_worker.model_runner.model.model. \
+                    model.embed_tokens.weight
+                self.proposer_worker.model_runner.model.model.model. \
+                    embed_tokens.weight = target_embed_tokens_weight
+            else:
+                if self.proposer_worker.model_runner.model.model.model.\
+                    embed_tokens.weight.shape == self.scorer_worker. \
+                    model_runner.model_runner.model.model.model.embed_tokens.\
+                    weight.shape:
+                    del self.proposer_worker.model_runner.model.model.\
+                        model.embed_tokens.weight
+                    self.proposer_worker.model_runner.model.model.model.\
+                        embed_tokens.weight = self.scorer_worker.model_runner.\
+                        model_runner.model.model.model.embed_tokens.\
+                        weight.data.clone()
+                    logger.info(
+                        "The EAGLE head's vocab embedding was loaded " \
+                        " separately from the target model."
+                        )
 
         self._metrics.init_tensors(self.rank, device_type=self.device)
         if model_parallel_is_initialized():
@@ -707,18 +749,55 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
             # We prepare the prefill hidden states here so that there no
             # additional complexity in worker for spec_decode vs non_spec_decode
             # flow and execute_model doesn't need additional modifications.
-            execute_model_req.previous_hidden_states = \
-                prepare_prefill_hidden_states(
-                    sampler_output.prefill_hidden_states)
+            if not self.eagle_proposer:
+                execute_model_req.previous_hidden_states = \
+                    prepare_prefill_hidden_states(
+                        sampler_output.prefill_hidden_states)
+            else:
+                execute_model_req.previous_hidden_states = \
+                    HiddenStates(sampler_output.all_hidden_states)
+            #adjust input of eagle proposer
+            if self.eagle_proposer:
+                draft_seq_group_metadata_list = []
+                for i, seq_group_meta in enumerate(
+                        execute_model_req.seq_group_metadata_list):
+                    key = list(seq_group_meta.seq_data.keys())[0]
+                    seq_data = seq_group_meta.seq_data[key]
+                    prompt_token_ids = seq_data.prompt_token_ids
+                    sample_token_ids = sampler_output.sampled_token_ids[i]
+                    input_len = len(prompt_token_ids)
+                    input_ids = [None] * input_len
+                    input_ids[:-1] = prompt_token_ids[1:]
+                    input_ids[-1] = sample_token_ids
+                    seq_data = {}
+                    seq_data[key] = SequenceData.from_seqs(input_ids)
+                    seq_group_meta_data = SequenceGroupMetadata(
+                        request_id=seq_group_meta.request_id,
+                        is_prompt=True,
+                        seq_data=seq_data,
+                        sampling_params=seq_group_meta.sampling_params,
+                        block_tables=seq_group_meta.block_tables,
+                        do_sample=seq_group_meta.do_sample,
+                        token_chunk_size=None,
+                        state=seq_group_meta.state,
+                        token_type_ids=seq_group_meta.token_type_ids,
+                    )
+                    draft_seq_group_metadata_list.append(seq_group_meta_data)
+                draft_execute_model_req = execute_model_req.clone(
+                    draft_seq_group_metadata_list)
             for i in range(self._num_spec_prefill_steps):
                 execute_model_req.spec_step_idx = i
-                self.proposer_worker.execute_model(execute_model_req)
+                if self.eagle_proposer:
+                    self.proposer_worker.execute_model(draft_execute_model_req)
+                    del draft_execute_model_req
+                else:
+                    self.proposer_worker.execute_model(execute_model_req)
 
         sampler_output_to_return = (self._serialize_sampler_output_no_logprobs(
             execute_model_req=execute_model_req, sampler_output=sampler_output)
                                     if self._disable_logprobs else
                                     [sampler_output])
-
+        del execute_model_req
         # Clear device tensors from sampler output. This reduces communication
         # overhead when the engine runs in a different process than the workers.
         sampler_output.sampled_token_probs = None
@@ -784,11 +863,50 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         # Pass last hidden states from target model to proposer
         execute_model_req.previous_hidden_states = self.previous_hidden_states
         self.previous_hidden_states = None
+        draft_execute_model_req = execute_model_req
+        #adjust input of eagle proposer
+        if self.eagle_proposer:
+            draft_seq_group_metadata_list = []
+            for i, seq_group_meta in enumerate(
+                    execute_model_req.seq_group_metadata_list):
+                key = list(seq_group_meta.seq_data.keys())[0]
+                seq_data = seq_group_meta.seq_data[key]
+                prompt_token_ids = seq_data.prompt_token_ids
+                output_token_ids = seq_data.get_output_token_ids()
+                input_len = len(prompt_token_ids)
+                input_ids = [None] * input_len
+                input_ids[:-1] = prompt_token_ids[1:]
+                input_ids[-1] = output_token_ids[0]
+
+                seq_data = {}
+                if len(output_token_ids) > 1:
+                    out_token_ids = output_token_ids[1:]
+                    seq_data[key] = SequenceData.from_seqs(
+                        input_ids, out_token_ids)
+                else:
+                    seq_data[key] = SequenceData.from_seqs(input_ids)
+
+                seq_group_meta_data = SequenceGroupMetadata(
+                    request_id=seq_group_meta.request_id,
+                    is_prompt=False,
+                    seq_data=seq_data,
+                    sampling_params=seq_group_meta.sampling_params,
+                    block_tables=seq_group_meta.block_tables,
+                    do_sample=seq_group_meta.do_sample,
+                    token_chunk_size=None,
+                    state=seq_group_meta.state,
+                    token_type_ids=seq_group_meta.token_type_ids,
+                )
+                draft_seq_group_metadata_list.append(seq_group_meta_data)
+            draft_execute_model_req = None
+            draft_execute_model_req = execute_model_req.clone(
+                draft_seq_group_metadata_list)
 
         with Timer() as proposal_timer:
             # Generate proposals using draft worker.
             proposals = self.proposer_worker.get_spec_proposals(
-                execute_model_req, self._seq_with_bonus_token_in_last_step)
+                draft_execute_model_req,
+                self._seq_with_bonus_token_in_last_step)
 
         if not self._allow_zero_draft_token_step and proposals.no_proposals:
             #TODO: Fix it #5814
@@ -1294,6 +1412,12 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
     def stop_profile(self):
         if isinstance(self.scorer_worker, WorkerBase):
             self.scorer_worker.stop_profile()
+
+    def shutdown(self):
+        if isinstance(self.scorer_worker, WorkerBase):
+            self.scorer_worker.shutdown()
+        if isinstance(self.proposer_worker, WorkerBase):
+            self.proposer_worker.shutdown()
 
 
 def split_num_cache_blocks_evenly(scorer_cache_block_size_bytes: int,

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -350,6 +350,8 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
             method == 'eagle':
             self.eagle_proposer = True
 
+        self.draft_seq_data_dict = {}
+
     def init_device(self) -> None:
         """Initialize both scorer and proposer models.
         """
@@ -783,6 +785,9 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                         token_type_ids=seq_group_meta.token_type_ids,
                     )
                     draft_seq_group_metadata_list.append(seq_group_meta_data)
+                    self.draft_seq_data_dict[key] = copy.deepcopy(
+                        seq_data[key])
+
                 draft_execute_model_req = execute_model_req.clone(
                     draft_seq_group_metadata_list)
             for i in range(self._num_spec_prefill_steps):
@@ -871,21 +876,12 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                     execute_model_req.seq_group_metadata_list):
                 key = list(seq_group_meta.seq_data.keys())[0]
                 seq_data = seq_group_meta.seq_data[key]
-                prompt_token_ids = seq_data.prompt_token_ids
                 output_token_ids = seq_data.get_output_token_ids()
-                input_len = len(prompt_token_ids)
-                input_ids = [None] * input_len
-                input_ids[:-1] = prompt_token_ids[1:]
-                input_ids[-1] = output_token_ids[0]
-
                 seq_data = {}
-                if len(output_token_ids) > 1:
-                    out_token_ids = output_token_ids[1:]
-                    seq_data[key] = SequenceData.from_seqs(
-                        input_ids, out_token_ids)
-                else:
-                    seq_data[key] = SequenceData.from_seqs(input_ids)
-
+                out_token_ids = output_token_ids[-1]
+                self.draft_seq_data_dict[key].append_token_id(
+                    out_token_ids, 0.0)
+                seq_data[key] = self.draft_seq_data_dict[key]
                 seq_group_meta_data = SequenceGroupMetadata(
                     request_id=seq_group_meta.request_id,
                     is_prompt=False,

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -44,7 +44,8 @@ class EAGLEConfig(PretrainedConfig):
             self.truncated_vocab_size = self.model.vocab_size if \
                 truncated_vocab_size is None else truncated_vocab_size
 
-        if 'DeepSeekMTPModel' in model.architectures and method == 'eagle':
+        if ('DeepSeekMTPModel' in self.model.architectures) \
+            and method == 'eagle':
             self.eagle_proposer = True
 
         if not envs.VLLM_USE_V1 and \

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -44,8 +44,21 @@ class EAGLEConfig(PretrainedConfig):
             self.truncated_vocab_size = self.model.vocab_size if \
                 truncated_vocab_size is None else truncated_vocab_size
 
-        if not envs.VLLM_USE_V1:
-            kwargs["architectures"] = ["EAGLEModel"]
+        if 'DeepSeekMTPModel' in model.architectures and method == 'eagle':
+            self.eagle_proposer = True
+
+        if not envs.VLLM_USE_V1 and \
+            ((self.model is None) or (self.model is not None \
+                and 'EagleDeepSeekMTPModel' not in self.model.architectures)):
+            if self.eagle_proposer:  #method == "eagle":
+                assert self.model is not None, \
+                    "model should not be None when method is eagle"
+                kwargs["architectures"] = [
+                    f"Eagle{arch}" if not arch.startswith("Eagle") \
+                        else arch for arch in self.model.architectures
+                ]
+            else:
+                kwargs["architectures"] = ["EAGLEModel"]
         else:
             # Eagle model name should follow naming convention of
             # LlamaForCausalLM -> EagleLlamaForCausalLM

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -44,7 +44,8 @@ class EAGLEConfig(PretrainedConfig):
             self.truncated_vocab_size = self.model.vocab_size if \
                 truncated_vocab_size is None else truncated_vocab_size
 
-        if ('DeepSeekMTPModel' in self.model.architectures) \
+        if self.model is not None and \
+            ('DeepSeekMTPModel' in self.model.architectures) \
             and method == 'eagle':
             self.eagle_proposer = True
 

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -450,6 +450,15 @@ class HpuModelAdapter(torch.nn.Module):
         self._rotary_embed_module = self._get_rotary_embedding_module(
             self.model)
         self._rotary_prepare_cos_sin = self._get_prepare_cos_sin()
+        ##enable eagle proposer
+        if vllm_config.speculative_config is not None:
+            archs = vllm_config.model_config.hf_config.architectures
+            print("archs ", archs)
+            if vllm_config.speculative_config.method=='eagle' and \
+                ('DeepseekV3ForCausalLM' in archs or \
+                  'EagleDeepSeekMTPModel' in archs
+                 ):
+                self.eagle_proposer = True
 
     def _get_rotary_embedding_module(self, model: torch.nn.Module):
         """
@@ -812,6 +821,8 @@ class HpuModelAdapter(torch.nn.Module):
                                  virtual_engine,
                                  dp_awared_padding=self.dp_awared_padding):
             hidden_states = self.model(*args, **kwargs)
+            if self.eagle_proposer:
+                all_hidden_states = hidden_states
             if self._rotary_prepare_cos_sin is not None and \
                 not self.model_is_mrope:
                 self._reset_rotary_cos_sin()
@@ -821,8 +832,10 @@ class HpuModelAdapter(torch.nn.Module):
             if selected_token_indices is not None:
                 hidden_states = hidden_states.index_select(
                     0, selected_token_indices)
-
-        return hidden_states
+        if self.eagle_proposer:
+            return hidden_states, all_hidden_states
+        else:
+            return hidden_states
 
     def compute_logits(self, *args, **kwargs):
         return self.model.compute_logits(*args, **kwargs)
@@ -1250,6 +1263,13 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                                     and not self.lora_config)
         self.use_delayed_sampling = get_config(
         ).use_delayed_sampling and can_use_delayed_sampling
+        ##enable eagle proposer
+        if vllm_config.speculative_config is not None:
+            archs = vllm_config.model_config.hf_config.architectures
+            if vllm_config.speculative_config.method=='eagle' and \
+                ('EagleDeepSeekMTPModel' in archs or \
+                 'DeepseekV3ForCausalLM' in archs):
+                self.eagle_proposer = True
 
     def _set_gc_threshold(self) -> None:
         """
@@ -1642,7 +1662,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     def _use_graphs(self, batch_size, seq_len, ctx_blocks=0):
         if self.enforce_eager:
             return False
-        if not self.skip_warmup:
+        if not self.skip_warmup or self.eagle_proposer:
             return batch_size * seq_len <= self.max_seq_len_to_capture
         bucket = (batch_size, seq_len, ctx_blocks)
         if seq_len > 1:
@@ -4323,8 +4343,26 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             if previous_hidden_states is not None:
                 # HPU will pad up to block_size,
                 # pad previous_hidden_states as well
-                previous_hidden_states = previous_hidden_states.unsqueeze(
-                    1).expand(-1, input_tokens.shape[-1], -1)
+                if self.eagle_proposer:
+                    #for eagle draft model (bs,padded_seq,hidden)
+                    if len(previous_hidden_states.shape
+                           ) == 3 and previous_hidden_states.shape[
+                               1] < input_tokens.shape[-1]:
+                        padding = torch.zeros(
+                            (previous_hidden_states.shape[0],
+                             input_tokens.shape[-1] -
+                             previous_hidden_states.shape[1],
+                             previous_hidden_states.shape[2]),
+                            dtype=previous_hidden_states.dtype,
+                            device=previous_hidden_states.device)
+                        previous_hidden_states = torch.cat(
+                            [previous_hidden_states, padding], dim=1)
+                    if len(previous_hidden_states.shape) < 3:
+                        previous_hidden_states = previous_hidden_states. \
+                        unsqueeze(1).expand(-1, input_tokens.shape[-1], -1)
+                else:
+                    previous_hidden_states = previous_hidden_states.unsqueeze(
+                        1).expand(-1, input_tokens.shape[-1], -1)
                 batch_size_padding = batch_size - previous_hidden_states.shape[
                     0]
                 if batch_size_padding > 0:
@@ -4449,10 +4487,16 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                     with self.profiler.record_event('internal',
                                                     model_event_name,
                                                     args=profiler_args):
-                        hidden_states = self.model.forward(
-                            **execute_model_kwargs,
-                            selected_token_indices=sampling_metadata.
-                            selected_token_indices)
+                        if self.eagle_proposer:
+                            hidden_states, all_hidden_states = self.model. \
+                            forward(**execute_model_kwargs,
+                                selected_token_indices=sampling_metadata.
+                                selected_token_indices)
+                        else:
+                            hidden_states = self.model.forward(
+                                **execute_model_kwargs,
+                                selected_token_indices=sampling_metadata.
+                                selected_token_indices)
                         if warmup_mode and not is_dummy_run:
                             torch.hpu.synchronize()
                             import torch.distributed as dist
@@ -4533,6 +4577,9 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                         logits=logits,
                         sampling_metadata=sampling_metadata,
                     )
+                    if self.eagle_proposer:
+                        output.all_hidden_states = all_hidden_states
+
                     if num_steps > 1:
                         output = output.sampled_token_ids
                         self.cached_step_outputs.append(


### PR DESCRIPTION
Enabled DeepSeek Eagle on VLLM V0 for Gaudi on multiple cards of 1 node and 2 nodes.

Example:
python3 -m vllm.entrypoints.openai.api_server --host $HOST_IP --port $PORT \
    --block-size 128 \
    --model $model_path \
    --device hpu \
    --dtype bfloat16 \
    --kv-cache-dtype fp8_inc \
    --tensor-parallel-size $TP \
    --trust-remote-code  \
    --max-model-len $max_model_len \
    --max-num-seqs $max_num_seqs \
    --max-num-batched-tokens $max_num_batched_tokens \
    --use-v2-block-manager \
    --distributed_executor_backend ray \
    --gpu_memory_utilization 0.93 \
    --trust_remote_code \
    --disable-log-requests \
    --enable-expert-parallel \
    --max_num_prefill_seqs 1 \
    --enable-reasoning \
    --reasoning-parser deepseek_r1 \
    --speculative_config '{"model": "/data/eagle618--eagle-deepseek-r1-2D", "method": "eagle", "num_speculative_tokens": 1, "trust-remote-code":true, "enable-expert-parallel":true}'
