### PR TITLE
Support Tool Calling and Configure 32K Context for Two-node HPU Setup

### DIFF
--- a/scripts/quickstart/README.md
+++ b/scripts/quickstart/README.md
@@ -407,14 +407,11 @@ export GLOO_SOCKET_IFNAME=enx6c1ff7012f87
 #### Adjust environment variables if required. Make sure the head node and worker node to have the same configuration except for VLLM_HOST_IP, GLOO_SOCKER_IFNAME and HCCL_SOCKET_IFNAME. 
 ```bash
 # warmup cache folder
-export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k_1k_20k_16k,false,32768
+export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k,false,32768
 
 # vllm parameters
-max_num_batched_tokens=32768
-max_num_seqs=512
-input_min=768
-input_max=20480
-output_max=16896
+export max_num_batched_tokens=32768
+export max_num_seqs=512
 ```
 
 #### INC FP8 Quantization

--- a/scripts/quickstart/README.md
+++ b/scripts/quickstart/README.md
@@ -41,6 +41,7 @@ Verified models:
     - [Install lm\_eval](#install-lm_eval)
     - [Set Proxy or HF Mirror if Required](#set-proxy-or-hf-mirror-if-required)
     - [Run lm\_eval](#run-lm_eval)
+  - [Tool Calling Support](#tool-calling-support)
 
 ## Hardware Requirements
 
@@ -610,4 +611,43 @@ Change the model path, vLLM IP address or port in the command below if required.
 lm_eval --model local-completions --tasks gsm8k --model_args model=/data/hf_models/DeepSeek-R1-G2,max_gen_toks=4096,max_length=16384,base_url=http://127.0.0.1:8688/v1/completions --batch_size 16 --log_samples --output_path ./lm_eval_output
 ```
 
+## Tool Calling Support
+vLLM supports calling user-defined functions. 
 
+Tool calling is incompatible with reasoning outputs. To enable this feature, you must **remove** any reasoning parameters (--enable-reasoning --reasoning-parser deepseek_r1) and **add** the model-specific arguments shown below.
+
+### DeepSeek-V3 Models (`deepseek_v3`)
+Supported models:
+
+* `deepseek-ai/DeepSeek-V3-0324` (use with [examples/tool_chat_template_deepseekv3.jinja](../../examples/tool_chat_template_deepseekv3.jinja))
+* `deepseek-ai/DeepSeek-R1-0528` (use with [examples/tool_chat_template_deepseekr1.jinja](../../examples/tool_chat_template_deepseekr1.jinja))
+
+```bash
+vllm serve ... 
+    --enable-auto-tool-choice \
+    --tool-call-parser deepseek_v3 \
+    --chat-template {see_above}
+```
+
+### DeepSeek-V3.1 Models (`deepseek_v31`)
+Supported models:
+
+* `deepseek-ai/DeepSeek-V3.1` (use with [examples/tool_chat_template_deepseekv31.jinja](../../examples/tool_chat_template_deepseekv31.jinja))
+
+```bash
+vllm serve ... 
+    --enable-auto-tool-choice \
+    --tool-call-parser deepseek_v31 \
+    --chat-template ../../examples/tool_chat_template_deepseekv31.jinja
+```
+
+### Kimi-K2 Models (`kimi_k2`)
+Supported models:
+
+* `moonshotai/Kimi-K2-Instruct`
+
+```bash
+vllm serve ... 
+    --enable-auto-tool-choice \
+    --tool-call-parser kimi_k2
+```

--- a/scripts/quickstart/README.zh.md
+++ b/scripts/quickstart/README.zh.md
@@ -40,6 +40,7 @@
     - [安装 lm\_eval](#安装-lm_eval)
     - [如果需要，设置代理或 HF 镜像](#如果需要设置代理或-hf-镜像)
     - [运行 lm\_eval](#运行-lm_eval)
+  - [工具调用功能](#工具调用功能)
 
 ## 硬件要求
 
@@ -609,4 +610,45 @@ export no_proxy=127.0.0.1
 如果需要，更改以下命令中的模型路径、vLLM IP 地址或端口。
 ```bash
 lm_eval --model local-completions --tasks gsm8k --model_args model=/data/hf_models/DeepSeek-R1-G2,max_gen_toks=4096,max_length=16384,base_url=http://127.0.0.1:8688/v1/completions --batch_size 16 --log_samples --output_path ./lm_eval_output
+```
+
+## 工具调用功能
+vLLM 支持调用用户定义的函数（Tool Calling）。
+
+工具调用功能与推理输出（Reasoning Outputs）不兼容。启用工具调用功能时，请务必从启动命令中**移除**推理相关参数（--enable-reasoning --reasoning-parser deepseek_r1），并**添加**下方各模型所需的特定参数。
+
+### DeepSeek-V3 系列模型 (`deepseek_v3`)
+支持的模型：
+
+* `deepseek-ai/DeepSeek-V3-0324` (使用 [examples/tool_chat_template_deepseekv3.jinja](../../examples/tool_chat_template_deepseekv3.jinja))
+* `deepseek-ai/DeepSeek-R1-0528` (使用 [examples/tool_chat_template_deepseekr1.jinja](../../examples/tool_chat_template_deepseekr1.jinja))
+
+```bash
+vllm serve ... 
+    --enable-auto-tool-choice \
+    --tool-call-parser deepseek_v3 \
+    --chat-template <上述对应的模板路径>
+```
+
+### DeepSeek-V3.1 系列模型 (`deepseek_v31`)
+支持的模型：
+
+* `deepseek-ai/DeepSeek-V3.1` (使用 [examples/tool_chat_template_deepseekv31.jinja](../../examples/tool_chat_template_deepseekv31.jinja))
+
+```bash
+vllm serve ... 
+    --enable-auto-tool-choice \
+    --tool-call-parser deepseek_v31 \
+    --chat-template ../../examples/tool_chat_template_deepseekv31.jinja
+```
+
+### Kimi-K2 系列模型 (`kimi_k2`)
+支持的模型：
+
+* `moonshotai/Kimi-K2-Instruct`
+
+```bash
+vllm serve ... 
+    --enable-auto-tool-choice \
+    --tool-call-parser kimi_k2
 ```

--- a/scripts/quickstart/README.zh.md
+++ b/scripts/quickstart/README.zh.md
@@ -402,14 +402,11 @@ export GLOO_SOCKET_IFNAME=enx6c1ff7012f87
 #### 如果需要，调整环境变量。确保头节点和工作节点具有相同的配置，除了 VLLM_HOST_IP、GLOO_SOCKER_IFNAME 和 HCCL_SOCKET_IFNAME。
 ```bash
 #预热缓存文件夹
-export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k_1k_20k_16k,false,32768
+export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k,false,32768
 
 # vllm 参数
-max_num_batched_tokens=32768
-max_num_seqs=512
-input_min=768
-input_max=20480
-output_max=16896
+export max_num_batched_tokens=32768
+export max_num_seqs=512
 ```
 
 

--- a/scripts/quickstart/set_head_node.sh
+++ b/scripts/quickstart/set_head_node.sh
@@ -8,14 +8,14 @@ export VLLM_HOST_IP=
 export GLOO_SOCKET_IFNAME=
 
 # warmup cache folder
-export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k_1k_20k_16k,false,32768
+export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k,false,32768
 
 # vllm parameters
 export max_num_batched_tokens=32768
 export max_num_seqs=512
-input_min=768
-input_max=20480
-output_max=16896
+input_min=1
+input_max=$max_num_batched_tokens
+output_max=$max_num_batched_tokens
 
 # Change to fp8_inc if want to use fp8 kv cache
 export KV_CACHE_DTYPE=auto

--- a/scripts/quickstart/set_worker_node.sh
+++ b/scripts/quickstart/set_worker_node.sh
@@ -7,14 +7,14 @@ export VLLM_HOST_IP=
 export GLOO_SOCKET_IFNAME=
 
 #warmup cache folder
-export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k_1k_20k_16k,false,32768
+export PT_HPU_RECIPE_CACHE_CONFIG=/data/cache/cache_32k,false,32768
 
 # vLLM parameters
 export max_num_batched_tokens=32768
 export max_num_seqs=512
-input_min=768
-input_max=20480
-output_max=16896
+input_min=1
+input_max=$max_num_batched_tokens
+output_max=$max_num_batched_tokens
 
 BASH_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "$BASH_DIR"/utils.sh

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -916,8 +916,7 @@ class OpenAIServingChat(OpenAIServing):
                                 ChatCompletionNamedToolChoiceParam
                                 ) and request.tool_choice != "required"):
                 message = ChatMessage(role=role,
-                                      reasoning_content=reasoning_content,
-                                      content=content)
+                                      content=output.text)
 
             # if the request uses tools and specified a tool choice
             elif request.tool_choice and type(


### PR DESCRIPTION
1. Fixes a bug in tool calling within the OpenAI serving entrypoint.

2. Adds documentation (README) for tool calling support.

3. Configures a default 32K context for two-node HPU setups.