### PR TITLE
Limit the usage of hpu graph when APC is on

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1644,8 +1644,11 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
             return False
         if not self.skip_warmup:
             # when APC is on, seq_len only contains the new query length.
-            seq_len = seq_len + ctx_blocks * self.block_size
-            return batch_size * seq_len <= self.max_seq_len_to_capture
+            if seq_len > 1:
+                seq_len = seq_len + ctx_blocks * self.block_size
+                return batch_size * seq_len <= self.max_seq_len_to_capture
+            else:
+                return True
         bucket = (batch_size, seq_len, ctx_blocks)
         if seq_len > 1:
             ctx_len = ctx_blocks * self.block_size

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1642,13 +1642,6 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
     def _use_graphs(self, batch_size, seq_len, ctx_blocks=0):
         if self.enforce_eager:
             return False
-        if not self.skip_warmup:
-            if seq_len > 1:
-                # when APC is on, seq_len only contains the new query length.
-                seq_len = seq_len + ctx_blocks * self.block_size
-                return batch_size * seq_len <= self.max_seq_len_to_capture
-            else:
-                return True
         bucket = (batch_size, seq_len, ctx_blocks)
         if seq_len > 1:
             ctx_len = ctx_blocks * self.block_size

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1643,8 +1643,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if self.enforce_eager:
             return False
         if not self.skip_warmup:
-            # when APC is on, seq_len only contains the new query length.
             if seq_len > 1:
+                # when APC is on, seq_len only contains the new query length.
                 seq_len = seq_len + ctx_blocks * self.block_size
                 return batch_size * seq_len <= self.max_seq_len_to_capture
             else:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1643,6 +1643,8 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if self.enforce_eager:
             return False
         if not self.skip_warmup:
+            # when APC is on, seq_len only contains the new query length.
+            seq_len = seq_len + ctx_blocks * self.block_size
             return batch_size * seq_len <= self.max_seq_len_to_capture
         bucket = (batch_size, seq_len, ctx_blocks)
         if seq_len > 1:


### PR DESCRIPTION
Sometimes the hpu graph with APC consumes too much memory and leads to OOM.