### PR TITLE
Fix AttributeError in fixed_sub_image_list for embedding models

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -215,9 +215,10 @@ def is_mm_optimized(model):
 def fixed_sub_image_list(model):
     # So far, in deepseek OCR model, the sub image mode only
     # supports 0~6 excluding 1. 1 means the sub image is equal
-    # to global image, which is not allowed.
-    return [i for i in range(6+1) if i!=1] \
-        if model.config.model_type == 'deepseek_ocr' else None
+    # to global image, which is not allowed.    
+    if hasattr(model, 'config') and model.config.model_type == 'deepseek_ocr':
+        return [i for i in range(6+1) if i!=1]
+    return None
 
 
 def pad_flat_tensor(tensor, desired_size):


### PR DESCRIPTION
### What does this PR do?

This PR fixes an AttributeError in `fixed_sub_image_list` when running
non-vision models such as `BertEmbeddingModel`.

Previously, the function assumed `model.config` always exists, which
causes: 
AttributeError: 'BertEmbeddingModel' object has no attribute 'config'

### What is changed?

- Add a defensive check using `hasattr(model, "config")`
- Only apply the DeepSeek OCR specific logic when `model.config.model_type == "deepseek_ocr"`

### Impact

- No behavior change for `deepseek_ocr` models
- Improves robustness for embedding / non-vision models
- Safe for existing HPU inference paths
