### PR TITLE
fix indexing error and patching of EOS token in delayed-sampling

### DIFF
--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -4749,8 +4749,21 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             seq_data = list(sg.seq_data.values())[0]
             # This is a hack. Assigning output_token_ids triggers
             # a cache recomputation and we only need to update the last token
-            seq_data.output_token_ids_array[-1] = real_out
-            seq_data._cached_all_token_ids[-1] = real_out
+            if seq_data.output_token_ids_array \
+                and seq_data._cached_all_token_ids:
+                last_token = seq_data.output_token_ids_array[-1]
+                assert last_token == seq_data._cached_all_token_ids[-1]
+                if last_token == DUMMY_TOKEN_ID:
+                    seq_data.output_token_ids_array[-1] = real_out
+                    seq_data._cached_all_token_ids[-1] = real_out
+                else:
+                    logger.debug('Last token %s is not patched by %s',
+                                 last_token, real_out)
+                assert seq_data.output_token_ids_array[-1] != DUMMY_TOKEN_ID
+                assert seq_data._cached_all_token_ids[-1] != DUMMY_TOKEN_ID
+            else:
+                logger.debug('Skip patching with %s as last token is empty',
+                             real_out)
         delayed_logprobs = None
         delayed_prompt_logprobs = None
         assert model_output.sampling_metadata is not None, \

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -4740,7 +4740,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         assert len(
             ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
         output_data = ctx.output_queue[0]
-        assert len(output_data.outputs) == 1
+        if output_data.outputs != 1:
+            return
         for fake_out, real_out in zip(output_data.outputs[0], delayed_tokens):
             fake_out.samples[0].output_token = real_out
         for sg, real_out in zip(output_data.seq_group_metadata_list,


### PR DESCRIPTION
1. Apply https://github.com/HabanaAI/vllm-fork/pull/1886.
2. WA for Omni crash.