### PR TITLE
Fix warmup issue when chunked prefill and random prefix cache hits oc…

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -287,7 +287,21 @@ set_bucketing(){
     prompt_seq_step=$block_size
     prompt_seq_max=$max_num_batched_tokens
     if [ "$chunk_size" != "" ]; then
-        prompt_seq_step=$max_num_batched_tokens
+        has_prefix_caching=false
+        for p in "${extra_params[@]}"; do
+            if [ "$p" == "--enable-prefix-caching" ]; then
+                has_prefix_caching=true
+                break
+            fi
+        done
+
+        # if prefix caching is disabled, increasing prompt_seq_step to reduce the number of context-length buckets.
+        if [ "$has_prefix_caching" == "false" ]; then
+            prompt_seq_step=$max_num_batched_tokens
+        else
+            # if prefix caching is enabled, align FSDPA slice chunk size with chunk_size.
+            export VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE=$chunk_size
+        fi
         prompt_seq_max=$max_model_len
     fi
     export VLLM_PROMPT_SEQ_BUCKET_MIN=${VLLM_PROMPT_SEQ_BUCKET_MIN:-$prompt_seq_min}

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -2220,6 +2220,7 @@ class Scheduler:
         num_uncached_new_tokens = 0
 
         seqs = seq_group.get_seqs(status=status)
+        adjust_new_tokens = False
         # Compute the number of new uncached and cached tokens for
         # each sequence.
         for seq in seqs:
@@ -2268,6 +2269,11 @@ class Scheduler:
 
             num_uncached_new_tokens += num_uncached_new_tokens_seq
             num_cached_new_tokens += num_cached_new_tokens_seq
+            if (self.scheduler_config.chunked_prefill_enabled
+                    and num_computed_tokens_seq == 0
+                    and num_cached_tokens_seq != 0
+                    and num_uncached_new_tokens > budget.token_budget):
+                adjust_new_tokens = True
 
         if num_uncached_new_tokens == 0 and num_cached_new_tokens > 0:
             # For a fully cached hit sequence, we actually need to recompute the
@@ -2290,6 +2296,12 @@ class Scheduler:
                 partial_prefill_metadata,
             )
 
+        if adjust_new_tokens:
+            # For the first chunk, if APC detects a prefix cache hit,
+            # adjust the number of new tokens so that the resulting
+            # context length is aligned to the chunk size after execution.
+            adjust_count = num_cached_tokens_seq % budget.token_budget
+            num_uncached_new_tokens -= adjust_count
         return num_uncached_new_tokens, num_cached_new_tokens
 
     @staticmethod

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1779,6 +1779,15 @@ class LLMEngine:
 
             for idx, scheduled_seq_group in enumerate(
                     scheduler_outputs.scheduled_seq_groups):
+                # When using chunked prefill, the initial value of
+                # actual_num_batched_tokens only includes prefill tokens.
+                # Decode tokens should also be added; otherwise,
+                # the statistics log will be incorrect.
+
+                if (self.scheduler_config.chunked_prefill_enabled
+                        and idx >= scheduler_outputs.num_prefill_groups):
+                    actual_num_batched_tokens += 1
+
                 # Skip double logging when using async output proc
                 if finished_before and idx in finished_before:
                     actual_num_batched_tokens -= 1


### PR DESCRIPTION
Fix warmup issue when chunked prefill and random prefix cache hits occur together.
when both chunked prefill and APC enabled, for the first chunk, if APC detects a prefix cache hit, scheduler will adjust the number of new tokens so that the resulting context length is aligned to the chunk size after execution.