### PR TITLE
fix hidden_states dim mis-match for MiniMax-M2

### DIFF
--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -115,7 +115,8 @@ class MiniMaxM2MoE(nn.Module):
         param.data.copy_(loaded_weight.to(torch.float32))
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        bs, seq_len, hidden_dim = hidden_states.shape
+        orig_shape = hidden_states.shape
+        hidden_dim = hidden_states.shape[-1]
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         # router_logits: (bs * seq_len, n_experts)
@@ -127,7 +128,7 @@ class MiniMaxM2MoE(nn.Module):
             final_hidden_states = tensor_model_parallel_all_reduce(
                 final_hidden_states)
 
-        return final_hidden_states.view(bs, seq_len, hidden_dim)
+        return final_hidden_states.view(orig_shape)
 
 
 class MiniMaxM2Attention(nn.Module):


### PR DESCRIPTION
Fix the following error raised during the warmup.
``` log
INFO 01-26 14:30:03 [hpu_model_runner.py:3943] [Warmup][Graph/prompt][351/352] batch_size:1 query_len:128 num_blocks:1 free_mem:7.476 GiB
INFO 01-26 14:30:07 [hpu_model_runner.py:3943] [Warmup][Graph/prompt][352/352] batch_size:1 query_len:128 num_blocks:0 free_mem:7.476 GiB
INFO 01-26 14:30:11 [hpu_model_runner.py:3943] [Warmup][Graph/mix/prompt][1/352] batch_size:1 query_len:8192 num_blocks:960 free_mem:7.476 GiB
INFO 01-26 14:30:11 [hpu_model_runner.py:3943] [Warmup][Graph/mix/decode][1/112] batch_size:16 query_len:1 num_blocks:8599 free_mem:7.476 GiB
ERROR 01-26 14:30:12 [engine.py:474] not enough values to unpack (expected 3, got 2)
ERROR 01-26 14:30:12 [engine.py:474] Traceback (most recent call last):
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/engine/multiprocessing/engine.py", line 462, in run_mp_engine
ERROR 01-26 14:30:12 [engine.py:474]     engine = MQLLMEngine.from_vllm_config(
ERROR 01-26 14:30:12 [engine.py:474]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/engine/multiprocessing/engine.py", line 135, in from_vllm_config
ERROR 01-26 14:30:12 [engine.py:474]     return cls(
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/engine/multiprocessing/engine.py", line 89, in __init__
ERROR 01-26 14:30:12 [engine.py:474]     self.engine = LLMEngine(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/engine/llm_engine.py", line 280, in __init__
ERROR 01-26 14:30:12 [engine.py:474]     self._initialize_kv_caches()
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/engine/llm_engine.py", line 432, in _initialize_kv_caches
ERROR 01-26 14:30:12 [engine.py:474]     self.model_executor.initialize_cache(num_gpu_blocks, num_cpu_blocks)
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/executor/executor_base.py", line 124, in initialize_cache
ERROR 01-26 14:30:12 [engine.py:474]     self.collective_rpc("initialize_cache",
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/executor/executor_base.py", line 331, in collective_rpc
ERROR 01-26 14:30:12 [engine.py:474]     return self._run_workers(method, *args, **(kwargs or {}))
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/executor/mp_distributed_executor.py", line 190, in _run_workers
ERROR 01-26 14:30:12 [engine.py:474]     driver_worker_output = run_method(self.driver_worker, sent_method,
ERROR 01-26 14:30:12 [engine.py:474]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/utils.py", line 2784, in run_method
ERROR 01-26 14:30:12 [engine.py:474]     return func(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/worker/hpu_worker.py", line 401, in initialize_cache
ERROR 01-26 14:30:12 [engine.py:474]     self._warm_up_model()
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/worker/hpu_worker.py", line 422, in _warm_up_model
ERROR 01-26 14:30:12 [engine.py:474]     self.model_runner.warmup_model(self.hpu_cache[0])
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
ERROR 01-26 14:30:12 [engine.py:474]     return func(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/worker/hpu_model_runner.py", line 4186, in warmup_model
ERROR 01-26 14:30:12 [engine.py:474]     self.warmup_graphs(
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/worker/hpu_model_runner.py", line 4012, in warmup_graphs
ERROR 01-26 14:30:12 [engine.py:474]     self.warmup_scenario_mix(
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/worker/hpu_model_runner.py", line 3867, in warmup_scenario_mix
ERROR 01-26 14:30:12 [engine.py:474]     self.execute_model(
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
ERROR 01-26 14:30:12 [engine.py:474]     return func(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/worker/hpu_model_runner.py", line 4904, in execute_model
ERROR 01-26 14:30:12 [engine.py:474]     hidden_states = self.model.forward(
ERROR 01-26 14:30:12 [engine.py:474]                     ^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 891, in forward
ERROR 01-26 14:30:12 [engine.py:474]     return wrapped_hpugraph_forward(
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 681, in wrapped_hpugraph_forward
ERROR 01-26 14:30:12 [engine.py:474]     return orig_fwd(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/worker/hpu_model_runner.py", line 938, in forward
ERROR 01-26 14:30:12 [engine.py:474]     hidden_states = self.model(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
ERROR 01-26 14:30:12 [engine.py:474]     return self._call_impl(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1884, in _call_impl
ERROR 01-26 14:30:12 [engine.py:474]     return inner()
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1832, in inner
ERROR 01-26 14:30:12 [engine.py:474]     result = forward_call(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/model_executor/models/minimax_m2.py", line 517, in forward
ERROR 01-26 14:30:12 [engine.py:474]     hidden_states = self.model(input_ids, positions, intermediate_tensors,
ERROR 01-26 14:30:12 [engine.py:474]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/compilation/decorators.py", line 173, in __call__
ERROR 01-26 14:30:12 [engine.py:474]     return self.forward(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/model_executor/models/minimax_m2.py", line 378, in forward
ERROR 01-26 14:30:12 [engine.py:474]     hidden_states, residual = layer(positions, hidden_states, residual)
ERROR 01-26 14:30:12 [engine.py:474]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
ERROR 01-26 14:30:12 [engine.py:474]     return self._call_impl(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1884, in _call_impl
ERROR 01-26 14:30:12 [engine.py:474]     return inner()
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1832, in inner
ERROR 01-26 14:30:12 [engine.py:474]     result = forward_call(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/model_executor/models/minimax_m2.py", line 306, in forward
ERROR 01-26 14:30:12 [engine.py:474]     hidden_states = self.block_sparse_moe(hidden_states)
ERROR 01-26 14:30:12 [engine.py:474]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
ERROR 01-26 14:30:12 [engine.py:474]     return self._call_impl(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1884, in _call_impl
ERROR 01-26 14:30:12 [engine.py:474]     return inner()
ERROR 01-26 14:30:12 [engine.py:474]            ^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1832, in inner
ERROR 01-26 14:30:12 [engine.py:474]     result = forward_call(*args, **kwargs)
ERROR 01-26 14:30:12 [engine.py:474]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474]   File "/data/ftao1/vllm_1.22/vllm-fork/vllm/model_executor/models/minimax_m2.py", line 118, in forward
ERROR 01-26 14:30:12 [engine.py:474]     bs, seq_len, hidden_dim = hidden_states.shape
ERROR 01-26 14:30:12 [engine.py:474]     ^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-26 14:30:12 [engine.py:474] ValueError: not enough values to unpack (expected 3, got 2)
```