### PR TITLE
Reduce TP overhead for MiniMax-M2 Attention w/ Unit MOE quantization

### DIFF
--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -582,6 +582,9 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         decode_batch_size = 0
         decode_seq_len = 0
         decode_hidden_size = 0
+        query = query.squeeze(0)
+        key = key.squeeze(0)
+        value = value.squeeze(0)
         if attn_metadata.num_prefills > 0:
             attn_data = self.preprocess_forward(
                 query[:attn_metadata.num_prefill_tokens],

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -98,6 +98,8 @@ class RMSNorm(CustomOp):
     Refer to https://arxiv.org/abs/1910.07467
     """
 
+    name = "RMSNorm"
+
     def __init__(
         self,
         hidden_size: int,
@@ -108,6 +110,8 @@ class RMSNorm(CustomOp):
     ) -> None:
         super().__init__()
 
+        self.tp_world = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
         self.hidden_size = hidden_size
         self.variance_epsilon = eps
         self.variance_size_override = (None if var_hidden_size == hidden_size
@@ -226,6 +230,38 @@ class RMSNorm(CustomOp):
             self.weight.data,
             self.variance_epsilon,
         )
+
+    @staticmethod
+    def forward_qk(
+        q_norm: "RMSNorm",
+        k_norm: "RMSNorm",
+        q: torch.Tensor,
+        k: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        qnorm_slice = q_norm.hidden_size // q_norm.tp_world
+        knorm_slice = k_norm.hidden_size // q_norm.tp_world
+        s, e = q_norm.tp_rank, q_norm.tp_rank + 1
+        qnorm_weight = q_norm.weight[s * qnorm_slice : e * qnorm_slice]
+        knorm_weight = k_norm.weight[s * knorm_slice : e * knorm_slice]
+        orig_dtype = q.dtype
+        q = q.to(torch.float32)
+        k = k.to(torch.float32)
+        q_var = q.pow(2).mean(dim=-1).unsqueeze(1)
+        k_var = k.pow(2).mean(dim=-1).unsqueeze(1)
+        if q_norm.tp_world > 1:
+            qk_var = torch.cat([q_var, k_var], dim=1)
+            qk_var = tensor_model_parallel_all_reduce(qk_var) / q_norm.tp_world
+            q_var, k_var = qk_var.chunk(2, dim=1)
+        q = q * torch.rsqrt(
+            q_var.transpose(-1, -2) +
+            q_norm.variance_epsilon) * qnorm_weight
+        k = k * torch.rsqrt(
+            k_var.transpose(-1, -2) +
+            k_norm.variance_epsilon) * knorm_weight
+        q = q.to(orig_dtype)
+        k = k.to(orig_dtype)
+        return q, k
+
 
     def extra_repr(self) -> str:
         s = f"hidden_size={self.weight.data.size(0)}"

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -241,8 +241,8 @@ class RMSNorm(CustomOp):
         qnorm_slice = q_norm.hidden_size // q_norm.tp_world
         knorm_slice = k_norm.hidden_size // q_norm.tp_world
         s, e = q_norm.tp_rank, q_norm.tp_rank + 1
-        qnorm_weight = q_norm.weight[s * qnorm_slice : e * qnorm_slice]
-        knorm_weight = k_norm.weight[s * knorm_slice : e * knorm_slice]
+        qnorm_weight = q_norm.weight[s * qnorm_slice:e * qnorm_slice]
+        knorm_weight = k_norm.weight[s * knorm_slice:e * knorm_slice]
         orig_dtype = q.dtype
         q = q.to(torch.float32)
         k = k.to(torch.float32)
@@ -252,12 +252,10 @@ class RMSNorm(CustomOp):
             qk_var = torch.cat([q_var, k_var], dim=1)
             qk_var = tensor_model_parallel_all_reduce(qk_var) / q_norm.tp_world
             q_var, k_var = qk_var.chunk(2, dim=1)
-        q = q * torch.rsqrt(
-            q_var.transpose(-1, -2) +
-            q_norm.variance_epsilon) * qnorm_weight
-        k = k * torch.rsqrt(
-            k_var.transpose(-1, -2) +
-            k_norm.variance_epsilon) * knorm_weight
+        q = q * torch.rsqrt(q_var.transpose(-1, -2) +
+                            q_norm.variance_epsilon) * qnorm_weight
+        k = k * torch.rsqrt(k_var.transpose(-1, -2) +
+                            k_norm.variance_epsilon) * knorm_weight
         q = q.to(orig_dtype)
         k = k.to(orig_dtype)
         return q, k

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -231,6 +231,10 @@ class RMSNorm(CustomOp):
             self.variance_epsilon,
         )
 
+    # This path is used to reduce number of all_reduce calls.
+    # When RMSNorm is initialized but we want to apply TP to qk,
+    # it is better to combine qk tensors and perform one all_reduce
+    # if bs * seq is small.
     @staticmethod
     def forward_qk(
         q_norm: "RMSNorm",
@@ -259,7 +263,6 @@ class RMSNorm(CustomOp):
         q = q.to(orig_dtype)
         k = k.to(orig_dtype)
         return q, k
-
 
     def extra_repr(self) -> str:
         s = f"hidden_size={self.weight.data.size(0)}"

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -27,6 +27,7 @@
 from collections.abc import Iterable
 from typing import Any, Optional
 
+import os
 import torch
 from torch import nn
 from transformers import PretrainedConfig
@@ -35,12 +36,14 @@ from vllm.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.distributed import (get_pp_group,
+                              get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size,
                               tensor_model_parallel_all_reduce)
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import (MiniMaxText01RMSNormTP,
                                                   RMSNorm)
-from vllm.model_executor.layers.linear import (QKVParallelLinear,
+from vllm.model_executor.layers.linear import (ColumnParallelLinear,
+                                               QKVParallelLinear,
                                                ReplicatedLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -123,7 +126,6 @@ class MiniMaxM2MoE(nn.Module):
         router_logits, _ = self.gate(hidden_states.to(torch.float32))
         final_hidden_states = self.experts(hidden_states=hidden_states,
                                            router_logits=router_logits)
-        final_hidden_states = final_hidden_states
         if self.tp_size > 1:
             final_hidden_states = tensor_model_parallel_all_reduce(
                 final_hidden_states)
@@ -152,20 +154,21 @@ class MiniMaxM2Attention(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
-        tp_size = get_tensor_model_parallel_world_size()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
         self.total_num_heads = num_heads
-        assert self.total_num_heads % tp_size == 0
-        self.num_heads = self.total_num_heads // tp_size
+        assert self.total_num_heads % self.tp_size == 0
+        self.num_heads = self.total_num_heads // self.tp_size
         self.total_num_kv_heads = num_kv_heads
-        if self.total_num_kv_heads >= tp_size:
+        if self.total_num_kv_heads >= self.tp_size:
             # Number of KV heads is greater than TP size, so we partition
             # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
+            assert self.total_num_kv_heads % self.tp_size == 0
         else:
             # Number of KV heads is less than TP size, so we replicate
             # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+            assert self.tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // self.tp_size)
         self.head_dim = head_dim or (hidden_size // self.total_num_heads)
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
@@ -173,15 +176,53 @@ class MiniMaxM2Attention(nn.Module):
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
 
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size,
-            self.head_dim,
-            self.total_num_heads,
-            self.total_num_kv_heads,
-            bias=qkv_bias,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkv_proj",
-        )
+        self.enable_unit_moe = os.environ.get('VLLM_ENABLE_UNIT_MOE',
+            'false').lower() == 'true'
+
+        if self.enable_unit_moe:
+            self.q_proj = ReplicatedLinear(
+                hidden_size,
+                self.head_dim * self.total_num_heads,
+                bias=qkv_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.q_proj",
+            )
+            self.k_proj = ReplicatedLinear(
+                hidden_size,
+                self.head_dim * self.total_num_kv_heads,
+                bias=qkv_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.k_proj",
+            )
+            self.v_proj = ColumnParallelLinear(
+                hidden_size,
+                self.head_dim * self.total_num_kv_heads,
+                bias=qkv_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.v_proj",
+            )
+            self.q_norm = RMSNorm(self.head_dim *
+                                  self.total_num_heads,
+                                  eps=rms_norm_eps)
+            self.k_norm = RMSNorm(self.head_dim *
+                                  self.total_num_kv_heads,
+                                  eps=rms_norm_eps)
+        else:
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size,
+                self.head_dim,
+                self.total_num_heads,
+                self.total_num_kv_heads,
+                bias=qkv_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
+            self.q_norm = MiniMaxText01RMSNormTP(self.head_dim *
+                                                 self.total_num_heads,
+                                                 eps=rms_norm_eps)
+            self.k_norm = MiniMaxText01RMSNormTP(self.head_dim *
+                                                 self.total_num_kv_heads,
+                                                 eps=rms_norm_eps)
 
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
@@ -209,27 +250,97 @@ class MiniMaxM2Attention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
-        self.q_norm = MiniMaxText01RMSNormTP(self.head_dim *
-                                             self.total_num_heads,
-                                             eps=rms_norm_eps)
-        self.k_norm = MiniMaxText01RMSNormTP(self.head_dim *
-                                             self.total_num_kv_heads,
-                                             eps=rms_norm_eps)
+    def hpu_qgemm(
+        self,
+        qinput: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.ops.hpu.fp8_gemm_v2(A=qinput,
+                                         trans_A=False,
+                                         B=weight.contiguous(),
+                                         trans_B=True,
+                                         D=None,
+                                         out_dtype=torch.bfloat16,
+                                         A_scale_inv=input_scale,
+                                         B_scale_inv=weight_scale,
+                                         bias=None,
+                                         accumulate=False)
 
     def forward(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = MiniMaxText01RMSNormTP.forward_qk(self.q_norm, self.k_norm,
-                                                 q.contiguous(),
-                                                 k.contiguous())
+        orig_shape = hidden_states.shape
+        if self.enable_unit_moe:
+            bs = orig_shape[0] if len(orig_shape) == 3 else 1
+            seq = orig_shape[-2]
+            x = hidden_states.reshape(-1, self.hidden_size)
+            x_fp8 = torch.ops.hpu.cast_to_fp8_v2(x,
+                                                 1.0 / self.q_proj.input_scale,
+                                                 False,
+                                                 False,
+                                                 torch.float8_e4m3fn)[0]
+            qweight_slice = self.q_proj.weight.size(1) // self.tp_size
+            kweight_slice = self.k_proj.weight.size(1) // self.tp_size
+
+            if bs * seq > 256:
+                s = self.tp_rank
+                e = self.tp_rank + 1
+                W_Q = self.q_proj.weight.transpose(0, 1)[ \
+                    s * qweight_slice : e * qweight_slice, :]
+                W_K = self.k_proj.weight.transpose(0, 1)[ \
+                    s * kweight_slice : e * kweight_slice, :]
+                S_Q = self.q_proj.weight_scale[ \
+                    s * qweight_slice : e * qweight_slice]
+                S_K = self.k_proj.weight_scale[ \
+                    s * kweight_slice : e * kweight_slice]
+            else:
+                W_Q = self.q_proj.weight.transpose(0, 1)
+                W_K = self.k_proj.weight.transpose(0, 1)
+                S_Q = self.q_proj.weight_scale
+                S_K = self.k_proj.weight_scale
+            W_V = self.v_proj.weight.transpose(0, 1)
+            S_V = self.v_proj.weight_scale
+
+            q = self.hpu_qgemm(qinput=x_fp8,
+                               weight=W_Q,
+                               input_scale=self.q_proj.input_scale,
+                               weight_scale=S_Q).reshape(bs, seq, -1)
+            k = self.hpu_qgemm(qinput=x_fp8,
+                               weight=W_K,
+                               input_scale=self.q_proj.input_scale,
+                               weight_scale=S_K).reshape(bs, seq, -1)
+            v = self.hpu_qgemm(qinput=x_fp8,
+                               weight=W_V,
+                               input_scale=self.q_proj.input_scale,
+                               weight_scale=S_V).reshape(bs, seq, -1)
+
+            if bs * seq > 256:
+                q, k = RMSNorm.forward_qk(self.q_norm,
+                                          self.k_norm,
+                                          q.contiguous(),
+                                          k.contiguous())
+            else:
+                q = self.q_norm(q)
+                k = self.k_norm(k)
+                q = q.reshape(bs, seq, self.tp_size, -1).permute(2, 0, 1, 3)[self.tp_rank]
+                k = k.reshape(bs, seq, self.tp_size, -1).permute(2, 0, 1, 3)[self.tp_rank]
+        else:
+            qkv, _ = self.qkv_proj(hidden_states)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
+                                dim=-1)
+            q, k = MiniMaxText01RMSNormTP.forward_qk(self.q_norm,
+                                                     self.k_norm,
+                                                     q.contiguous(),
+                                                     k.contiguous())
+
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
-        return output
+        return output.reshape(orig_shape)
 
 
 class MiniMaxM2DecoderLayer(nn.Module):
@@ -397,12 +508,14 @@ class MiniMaxM2Model(nn.Module):
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
+        disable_unit_moe = not os.environ.get('VLLM_ENABLE_UNIT_MOE',
+            'false').lower() == 'true'
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
             ("qkv_proj", "v_proj", "v"),
-        ]
+        ] if disable_unit_moe else []
 
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -24,10 +24,10 @@
 # limitations under the License.
 """Inference-only MiniMaxM2 model."""
 
+import os
 from collections.abc import Iterable
 from typing import Any, Optional
 
-import os
 import torch
 from torch import nn
 from transformers import PretrainedConfig
@@ -35,8 +35,7 @@ from transformers import PretrainedConfig
 from vllm.attention import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
-from vllm.distributed import (get_pp_group,
-                              get_tensor_model_parallel_rank,
+from vllm.distributed import (get_pp_group, get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size,
                               tensor_model_parallel_all_reduce)
 from vllm.model_executor.layers.fused_moe import FusedMoE
@@ -177,7 +176,7 @@ class MiniMaxM2Attention(nn.Module):
         self.max_position_embeddings = max_position_embeddings
 
         self.enable_unit_moe = os.environ.get('VLLM_ENABLE_UNIT_MOE',
-            'false').lower() == 'true'
+                                              'false').lower() == 'true'
 
         if self.enable_unit_moe:
             self.q_proj = ReplicatedLinear(
@@ -201,11 +200,9 @@ class MiniMaxM2Attention(nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.v_proj",
             )
-            self.q_norm = RMSNorm(self.head_dim *
-                                  self.total_num_heads,
+            self.q_norm = RMSNorm(self.head_dim * self.total_num_heads,
                                   eps=rms_norm_eps)
-            self.k_norm = RMSNorm(self.head_dim *
-                                  self.total_num_kv_heads,
+            self.k_norm = RMSNorm(self.head_dim * self.total_num_kv_heads,
                                   eps=rms_norm_eps)
         else:
             self.qkv_proj = QKVParallelLinear(
@@ -250,13 +247,9 @@ class MiniMaxM2Attention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
-    def hpu_qgemm(
-        self,
-        qinput: torch.Tensor,
-        weight: torch.Tensor,
-        input_scale: torch.Tensor,
-        weight_scale: torch.Tensor
-    ) -> torch.Tensor:
+    def hpu_qgemm(self, qinput: torch.Tensor, weight: torch.Tensor,
+                  input_scale: torch.Tensor,
+                  weight_scale: torch.Tensor) -> torch.Tensor:
         return torch.ops.hpu.fp8_gemm_v2(A=qinput,
                                          trans_A=False,
                                          B=weight.contiguous(),
@@ -280,8 +273,7 @@ class MiniMaxM2Attention(nn.Module):
             x = hidden_states.reshape(-1, self.hidden_size)
             x_fp8 = torch.ops.hpu.cast_to_fp8_v2(x,
                                                  1.0 / self.q_proj.input_scale,
-                                                 False,
-                                                 False,
+                                                 False, False,
                                                  torch.float8_e4m3fn)[0]
             qweight_slice = self.q_proj.weight.size(1) // self.tp_size
             kweight_slice = self.k_proj.weight.size(1) // self.tp_size
@@ -319,21 +311,20 @@ class MiniMaxM2Attention(nn.Module):
                                weight_scale=S_V).reshape(bs, seq, -1)
 
             if bs * seq > 256:
-                q, k = RMSNorm.forward_qk(self.q_norm,
-                                          self.k_norm,
-                                          q.contiguous(),
-                                          k.contiguous())
+                q, k = RMSNorm.forward_qk(self.q_norm, self.k_norm,
+                                          q.contiguous(), k.contiguous())
             else:
                 q = self.q_norm(q)
                 k = self.k_norm(k)
-                q = q.reshape(bs, seq, self.tp_size, -1).permute(2, 0, 1, 3)[self.tp_rank]
-                k = k.reshape(bs, seq, self.tp_size, -1).permute(2, 0, 1, 3)[self.tp_rank]
+                q = q.reshape(bs, seq, self.tp_size,
+                              -1).permute(2, 0, 1, 3)[self.tp_rank]
+                k = k.reshape(bs, seq, self.tp_size,
+                              -1).permute(2, 0, 1, 3)[self.tp_rank]
         else:
             qkv, _ = self.qkv_proj(hidden_states)
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size],
                                 dim=-1)
-            q, k = MiniMaxText01RMSNormTP.forward_qk(self.q_norm,
-                                                     self.k_norm,
+            q, k = MiniMaxText01RMSNormTP.forward_qk(self.q_norm, self.k_norm,
                                                      q.contiguous(),
                                                      k.contiguous())
 
@@ -508,14 +499,14 @@ class MiniMaxM2Model(nn.Module):
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
-        disable_unit_moe = not os.environ.get('VLLM_ENABLE_UNIT_MOE',
-            'false').lower() == 'true'
+        enable_unit_moe = os.environ.get('VLLM_ENABLE_UNIT_MOE',
+                                         'false').lower() == 'true'
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
             ("qkv_proj", "v_proj", "v"),
-        ] if disable_unit_moe else []
+        ] if not enable_unit_moe else []
 
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -177,6 +177,7 @@ class MiniMaxM2Attention(nn.Module):
 
         self.enable_unit_moe = os.environ.get('VLLM_ENABLE_UNIT_MOE',
                                               'false').lower() == 'true'
+        self.qknorm_tp_limit = int(os.environ.get("VLLM_QKNORM_TP_LIMIT", 256))
 
         if self.enable_unit_moe:
             self.q_proj = ReplicatedLinear(
@@ -278,7 +279,7 @@ class MiniMaxM2Attention(nn.Module):
             qweight_slice = self.q_proj.weight.size(1) // self.tp_size
             kweight_slice = self.k_proj.weight.size(1) // self.tp_size
 
-            if bs * seq > 256:
+            if bs * seq > self.qknorm_tp_limit:
                 s = self.tp_rank
                 e = self.tp_rank + 1
                 W_Q = self.q_proj.weight.transpose(0, 1)[ \
@@ -310,7 +311,7 @@ class MiniMaxM2Attention(nn.Module):
                                input_scale=self.q_proj.input_scale,
                                weight_scale=S_V).reshape(bs, seq, -1)
 
-            if bs * seq > 256:
+            if bs * seq > self.qknorm_tp_limit:
                 q, k = RMSNorm.forward_qk(self.q_norm, self.k_norm,
                                           q.contiguous(), k.contiguous())
             else:


### PR DESCRIPTION
## Purpose
This PR add a code path to reduce TP overhead for MiniMax-M2 attention when the Unit MoE quantization flag is enabled (VLLM_ENABLE_UNIT_MOE=true).
It also keeps the original INC FP8 path for MiniMax-M2 in the modeling.

Perf:
<img width="1084" height="213" alt="image" src="https://github.com/user-attachments/assets/7103d7cc-b911-4a2d-b1af-86405c13105e" />

Accuracy:
vllm ({'pretrained': '/data3/MiniMax-M2.1-G2-Per-Tensor/', 'tensor_parallel_size': 4, 'enable_expert_parallel': True, 'distributed_executor_backend': 'mp', 'max_length': 16384, 'max_gen_toks': 2048}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: 256
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9447|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|
