### PR TITLE
Enable chunked prefill for qwen3vl

### DIFF
--- a/examples/online_serving/openai_chat_completion_client_for_multimodal.py
+++ b/examples/online_serving/openai_chat_completion_client_for_multimodal.py
@@ -127,6 +127,28 @@ def run_single_image(model: str, local_image: Optional[str] = None) -> None:
     result = chat_completion_from_url.choices[0].message.content
     print("Chat completion output from image url:", result)
 
+    ## Use base64 encoded image in the payload
+    image_base64 = encode_base64_content_from_url(image_url)
+    chat_completion_from_base64 = client.chat.completions.create(
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/jpeg;base64,{image_base64}"},
+                    },
+                ],
+            }
+        ],
+        model=model,
+        max_completion_tokens=64,
+    )
+
+    result = chat_completion_from_base64.choices[0].message.content
+    print("Chat completion output from base64 encoded image:", result)
+
 
 # Multi-image input inference
 def run_multi_image(model: str) -> None:

--- a/examples/online_serving/openai_chat_completion_client_for_multimodal.py
+++ b/examples/online_serving/openai_chat_completion_client_for_multimodal.py
@@ -21,6 +21,8 @@ python openai_chat_completion_client_for_multimodal.py --chat-type audio
 """
 
 import base64
+import os
+from typing import Optional
 
 import requests
 from openai import OpenAI
@@ -37,6 +39,15 @@ client = OpenAI(
     api_key=openai_api_key,
     base_url=openai_api_base,
 )
+
+
+def encode_base64_content_from_file(path: str) -> str:
+    """Encode a local file to base64 format."""
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Local file not found: {path}")
+
+    with open(path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
 
 
 def encode_base64_content_from_url(content_url: str) -> str:
@@ -62,9 +73,40 @@ def run_text_only(model: str) -> None:
 
 
 # Single-image input inference
-def run_single_image(model: str) -> None:
-    ## Use image url in the payload
-    image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+def run_single_image(model: str, local_image: Optional[str] = None) -> None:
+    if local_image:
+        print(f"Using local image: {local_image}")
+        image_base64 = encode_base64_content_from_file(local_image)
+
+        chat_completion = client.chat.completions.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What's in this image?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/jpeg;base64,{image_base64}"
+                            },
+                        },
+                    ],
+                }
+            ],
+            model=model,
+            max_completion_tokens=64,
+        )
+
+        result = chat_completion.choices[0].message.content
+        print("Chat completion output from local image:", result)
+        return
+
+    image_url = (
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/"
+        "Gfp-wisconsin-madison-the-nature-boardwalk.jpg/"
+        "2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+    )
+
     chat_completion_from_url = client.chat.completions.create(
         messages=[
             {
@@ -84,28 +126,6 @@ def run_single_image(model: str) -> None:
 
     result = chat_completion_from_url.choices[0].message.content
     print("Chat completion output from image url:", result)
-
-    ## Use base64 encoded image in the payload
-    image_base64 = encode_base64_content_from_url(image_url)
-    chat_completion_from_base64 = client.chat.completions.create(
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "What's in this image?"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/jpeg;base64,{image_base64}"},
-                    },
-                ],
-            }
-        ],
-        model=model,
-        max_completion_tokens=64,
-    )
-
-    result = chat_completion_from_base64.choices[0].message.content
-    print("Chat completion output from base64 encoded image:", result)
 
 
 # Multi-image input inference
@@ -288,13 +308,22 @@ def parse_args():
         choices=list(example_function_map.keys()),
         help="Conversation type with multimodal data.",
     )
+    parser.add_argument(
+        "--local-image",
+        type=str,
+        default=None,
+        help="Path to a local image file for single-image test.",
+    )
     return parser.parse_args()
 
 
 def main(args) -> None:
     chat_type = args.chat_type
     model = get_first_model(client)
-    example_function_map[chat_type](model)
+    if chat_type == "single-image":
+        run_single_image(model, args.local_image)
+    else:
+        example_function_map[chat_type](model)
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -1289,6 +1289,9 @@ class MRotaryEmbedding(RotaryEmbedding):
             offsets = offsets.view(positions.shape[0], -1)
         num_tokens = query.shape[0] * query.shape[1]
         positions = positions.view(-1, num_tokens)
+
+        # Check `positions.shape[0] == 3` to ensure this branch is
+        # only taken for the true 3D VL positional encoding case.
         if positions.ndim == 2 and positions.shape[0] == 3:
             cos_sin = (self.cos_sin_cache_mrope0[positions[0]] +
                        self.cos_sin_cache_mrope1[positions[1]] +

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -1287,8 +1287,9 @@ class MRotaryEmbedding(RotaryEmbedding):
 
         if offsets is not None:
             offsets = offsets.view(positions.shape[0], -1)
-        num_tokens = positions.shape[-1]
-        if positions.ndim == 2:
+        num_tokens = query.shape[0] * query.shape[1]
+        positions = positions.view(-1, num_tokens)
+        if positions.ndim == 2 and positions.shape[0] == 3:
             cos_sin = (self.cos_sin_cache_mrope0[positions[0]] +
                        self.cos_sin_cache_mrope1[positions[1]] +
                        self.cos_sin_cache_mrope2[positions[2]])

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1178,6 +1178,12 @@ class Qwen3VLForConditionalGeneration(nn.Module, SupportsMultiModal,
             for _ in range(self.deepstack_num_level)
         ] if self.use_deepstack else None
 
+        # multimodal chunked prefill offsets
+        self.mm_offset_image = 0
+        self.mm_offset_image_multiscale = 0
+        self.mm_offset_video = 0
+        self.mm_offset_video_multiscale = 0
+
     def _get_deepstack_input_embeds(self) -> IntermediateTensors:
         # get deepstack_input_embeds from buffer, and clear the buffer
         return IntermediateTensors({

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1473,6 +1473,8 @@ class Qwen3VLForConditionalGeneration(nn.Module, SupportsMultiModal,
         image_input: Optional[Qwen2_5_VLImageInputs] = None,
         video_input: Optional[Qwen2_5_VLVideoInputs] = None,
     ) -> torch.Tensor:
+        if input_ids.ndim == 1:
+            input_ids = input_ids.unsqueeze(0)
         inputs_embeds = self.get_input_embeddings(
             input_ids)[:, :, :self.text_dim]
 
@@ -1493,19 +1495,28 @@ class Qwen3VLForConditionalGeneration(nn.Module, SupportsMultiModal,
                     [visual_dim, visual_dim * self.deepstack_num_level],
                     dim=-1)
 
-                deepstack_input_embeds = merge_multimodal_embeddings(
+                (
+                    deepstack_input_embeds,
+                    new_offset_multiscale,
+                ) = merge_multimodal_embeddings(
                     input_ids,
                     deepstack_input_embeds,
                     image_embeds_multiscale,
                     placeholder_token_id=self.config.image_token_id,
+                    mm_offset=self.mm_offset_image_multiscale,
+                    return_offset=True,
                 )
+                self.mm_offset_image_multiscale = new_offset_multiscale
 
-            inputs_embeds = merge_multimodal_embeddings(
+            inputs_embeds, new_offset = merge_multimodal_embeddings(
                 input_ids,
                 inputs_embeds,
                 image_embeds,
                 placeholder_token_id=self.config.image_token_id,
+                mm_offset=self.mm_offset_image,
+                return_offset=True,
             )
+            self.mm_offset_image = new_offset
 
         if video_input is not None:
             video_embeds = self._process_video_input(video_input)
@@ -1516,19 +1527,28 @@ class Qwen3VLForConditionalGeneration(nn.Module, SupportsMultiModal,
                     [visual_dim, visual_dim * self.deepstack_num_level],
                     dim=-1)
 
-                deepstack_input_embeds = merge_multimodal_embeddings(
+                (
+                    deepstack_input_embeds,
+                    new_offset_multiscale,
+                ) = merge_multimodal_embeddings(
                     input_ids,
                     deepstack_input_embeds,
                     video_embeds_multiscale,
                     placeholder_token_id=self.config.video_token_id,
+                    mm_offset=self.mm_offset_video_multiscale,
+                    return_offset=True,
                 )
+                self.mm_offset_video_multiscale = new_offset_multiscale
 
-            inputs_embeds = merge_multimodal_embeddings(
+            inputs_embeds, new_offset = merge_multimodal_embeddings(
                 input_ids,
                 inputs_embeds,
                 video_embeds,
                 placeholder_token_id=self.config.video_token_id,
+                mm_offset=self.mm_offset_video,
+                return_offset=True,
             )
+            self.mm_offset_video = new_offset
 
         if self.use_deepstack and deepstack_input_embeds is not None:
             inputs_embeds = torch.cat((inputs_embeds, deepstack_input_embeds),

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -364,3 +364,9 @@ class Qwen3VLMoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
                         config.text_config.hidden_size)
             for _ in range(self.deepstack_num_level)
         ] if self.use_deepstack else None
+
+        # multimodal chunked prefill offsets
+        self.mm_offset_image = 0
+        self.mm_offset_image_multiscale = 0
+        self.mm_offset_video = 0
+        self.mm_offset_video_multiscale = 0

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -436,7 +436,9 @@ def _merge_multimodal_embeddings(
     inputs_embeds: torch.Tensor,
     is_multimodal: torch.Tensor,
     multimodal_embeddings: NestedTensors,
-) -> torch.Tensor:
+    mm_offset: int = 0,
+    return_offset: bool = False,
+) -> Union[torch.Tensor, tuple[torch.Tensor, int]]:
     """
     Merge ``multimodal_embeddings`` into ``inputs_embeds`` by overwriting the
     positions in ``inputs_embeds`` corresponding to placeholder tokens in
@@ -453,13 +455,22 @@ def _merge_multimodal_embeddings(
         inputs_embeds = inputs_embeds.reshape(-1, hidden_size)
         if isinstance(multimodal_embeddings, torch.Tensor):
             flattened = multimodal_embeddings.reshape(-1, hidden_size)
-            inputs_embeds[is_multimodal] = flattened
+            num_mm = is_multimodal.sum()
+            start = mm_offset
+            end = start + num_mm
+            inputs_embeds[is_multimodal] = flattened[start:end]
+            mm_offset = end
+            if mm_offset >= flattened.shape[0]:
+                mm_offset = 0
         else:
             flattened = _flatten_embeddings(multimodal_embeddings)
             inputs_embeds[is_multimodal] = flattened
+
         inputs_embeds = inputs_embeds.reshape(batch_size, seq_length,
                                               hidden_size)
 
+        if return_offset:
+            return inputs_embeds, mm_offset
         return inputs_embeds
     num_expected_tokens = is_multimodal.sum().item()
     assert isinstance(num_expected_tokens, int)
@@ -516,7 +527,9 @@ def merge_multimodal_embeddings(
     inputs_embeds: torch.Tensor,
     multimodal_embeddings: NestedTensors,
     placeholder_token_id: Union[int, list[int]],
-) -> torch.Tensor:
+    mm_offset: int = 0,
+    return_offset: bool = False,
+) -> Union[torch.Tensor, tuple[torch.Tensor, int]]:
     """
     Merge ``multimodal_embeddings`` into ``inputs_embeds`` by overwriting the
     positions in ``inputs_embeds`` corresponding to placeholder tokens in
@@ -549,12 +562,16 @@ def merge_multimodal_embeddings(
             inputs_embeds,
             torch.isin(input_ids, placeholder_token_id),
             multimodal_embeddings,
+            mm_offset,
+            return_offset,
         )
 
     return _merge_multimodal_embeddings(
         inputs_embeds,
         (input_ids == placeholder_token_id),
         multimodal_embeddings,
+        mm_offset,
+        return_offset,
     )
 
 

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -509,6 +509,9 @@ class SamplingTensors:
                         prompt_tokens.append(seq_data.prompt_token_ids_array)
                         output_tokens.append(seq_data.output_token_ids_array)
 
+        if do_top_p_top_k and len(top_ks) == 0:
+            do_top_p_top_k = False
+
         top_k_scalar = top_ks[0] if do_top_p_top_k and all(
             k == top_ks[0] for k in top_ks) else None
         top_p_scalar = top_ps[0] if do_top_p_top_k and all(

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1030,10 +1030,13 @@ def make_mrope_positions_tensor_with_pad( \
                 positions = input_mrope_position[idx]
             else:
                 positions = input_positions[b_idx]
-            padding_size = max_prompt_len - len(positions)
-            assert padding_size >= 0
-            padded_positions = positions \
-                + (max_prompt_len - len(positions)) * [pad]
+
+            # robust for chunked prefill
+            if len(positions) >= max_prompt_len:
+                padded_positions = positions[:max_prompt_len]
+            else:
+                padding_size = max_prompt_len - len(positions)
+                padded_positions = positions + padding_size * [pad]
             mrope_input_positions[idx].extend(padded_positions)
     return torch.tensor(mrope_input_positions, dtype=torch.long, device='cpu')
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1031,7 +1031,9 @@ def make_mrope_positions_tensor_with_pad( \
             else:
                 positions = input_positions[b_idx]
 
-            # robust for chunked prefill
+            # With chunked prefill, positions may cover the full prompt
+            # while the current chunk only processes `max_prompt_len`
+            # tokens. Truncate if positions is longer than the chunk size.
             if len(positions) >= max_prompt_len:
                 padded_positions = positions[:max_prompt_len]
             else:

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -4002,6 +4002,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                 if query_len in seen_query_len:
                     continue
                 seen_query_len.add(query_len)
+                ctx = 0
                 # Graph memory usage is proportional to seq dimension in a batch
                 phase = f"Graph/{'mix'}/{'prompt'}"
                 seq_len = query_len + ctx * self.block_size
@@ -4017,6 +4018,7 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
                         kv_caches,
                         temperature=1.0
                         if batch_size not in warmed_random_sampler_bs else 0,
+                        img_args=UNSET_IMG_ARGS if self.is_mm_run() else None,
                     )
                 warmed_random_sampler_bs.add(batch_size)
                 used_mem = align_workers(mem_prof.consumed_device_memory,


### PR DESCRIPTION
This PR try to enable chunked prefill for qwen3vl MOE model. Chunked prefill usage is the same as other models, -k to set the chunk size, -n to set max number of the mixed sequences.

test command:
#server:
bash start_gaudi_vllm_server.sh -w /home/HF_models/Qwen3-VL-30B-A3B-Instruct -s -m 0 -t 1 -b 8 -k 2048 -x 8192 -a 127.0.0.1:8000
#client:
python openai_chat_completion_client_for_multimodal.py --local-image /home/test.jpg

 