### PR TITLE
Reduce host memory consumptions and refine threading for weights loading

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -4519,10 +4519,6 @@ class VllmConfig:
                     logger.info_once(
                         'Enable conversion from fp8_e4m3fn to fp8_e4m3fnuz')
                     os.environ["VLLM_HPU_CONVERT_TO_FP8UZ"] = "true"
-                if envs.VLLM_HPU_CONVERT_TO_FP8UZ and \
-                    self.load_config.device != 'cpu':
-                    logger.info_once('Reset weights_load_device to CPU.')
-                    self.load_config.device = 'cpu'
 
         if self.model_config is not None and \
             self.scheduler_config.chunked_prefill_enabled and \

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -456,6 +456,21 @@ def np_cache_weights_iterator(
         yield name, torch.from_numpy(param)
 
 
+def _maybe_convert_fp8_range(name: str, tensor: torch.Tensor) -> torch.Tensor:
+    """Convert FP8 tensor range for HPU FP8UZ compatibility when enabled."""
+    if not (current_platform.is_hpu() and envs.VLLM_HPU_CONVERT_TO_FP8UZ):
+        return tensor
+
+    if tensor.dtype == torch.float8_e4m3fn:
+        return (tensor.float() / 2).to(torch.float8_e4m3fn)
+
+    if (tensor.dtype in [torch.float32, torch.bfloat16]
+            and "scale" in name.split(".")[-1]):
+        tensor = tensor * 2
+
+    return tensor
+
+
 def safetensors_weights_iterator(
     hf_weights_files: list[str],
     use_tqdm_on_load: bool,
@@ -469,19 +484,7 @@ def safetensors_weights_iterator(
     ):
         with safe_open(st_file, framework="pt") as f:
             for name in f.keys():  # noqa: SIM118
-                param = f.get_tensor(name)
-                if current_platform.is_hpu(
-                ) and envs.VLLM_HPU_CONVERT_TO_FP8UZ:
-                    fp8_e4m3fnuz_max = torch.finfo(torch.float8_e4m3fnuz).max
-                    fp8_e4m3fn_max = torch.finfo(torch.float8_e4m3fn).max
-                    if param.dtype == torch.float8_e4m3fn:
-                        param = (param.float() * fp8_e4m3fnuz_max /
-                                 fp8_e4m3fn_max).to(torch.float8_e4m3fn)
-                    elif param.dtype in [torch.float32, torch.bfloat16
-                                         ] and "scale" in name.split(".")[-1]:
-                        param *= fp8_e4m3fn_max / fp8_e4m3fnuz_max
-                if current_platform.is_hpu():
-                    param = param.to("hpu")
+                param = _maybe_convert_fp8_range(name, f.get_tensor(name))
                 yield name, param
 
 
@@ -498,7 +501,8 @@ def runai_safetensors_weights_iterator(
                 bar_format=_BAR_FORMAT,
         ):
             streamer.stream_file(st_file)
-            yield from streamer.get_tensors()
+            for name, param in streamer.get_tensors():
+                yield name, _maybe_convert_fp8_range(name, param)
 
 
 def fastsafetensors_weights_iterator(
@@ -532,20 +536,7 @@ def fastsafetensors_weights_iterator(
             try:
                 keys = list(fb.key_to_rank_lidx.keys())
                 for k in keys:
-                    t = fb.get_tensor(k)
-                    if current_platform.is_hpu(
-                    ) and envs.VLLM_HPU_CONVERT_TO_FP8UZ:
-                        fp8_e4m3fnuz_max = torch.finfo(
-                            torch.float8_e4m3fnuz).max
-                        fp8_e4m3fn_max = torch.finfo(torch.float8_e4m3fn).max
-                        if t.dtype == torch.float8_e4m3fn:
-                            t = (t.float() * fp8_e4m3fnuz_max /
-                                 fp8_e4m3fn_max).to(torch.float8_e4m3fn)
-                        elif t.dtype in [torch.float32, torch.bfloat16
-                                         ] and "scale" in k.split(".")[-1]:
-                            t *= fp8_e4m3fn_max / fp8_e4m3fnuz_max
-                    if current_platform.is_hpu():
-                        t = t.to("hpu")
+                    t = _maybe_convert_fp8_range(k, fb.get_tensor(k))
                     yield k, t
             finally:
                 fb.close()
@@ -568,7 +559,8 @@ def pt_weights_iterator(
         state = torch.load(bin_file,
                            map_location=pt_load_map_location,
                            weights_only=True)
-        yield from state.items()
+        for name, tensor in state.items():
+            yield name, _maybe_convert_fp8_range(name, tensor)
         del state
 
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -476,10 +476,12 @@ def safetensors_weights_iterator(
                     fp8_e4m3fn_max = torch.finfo(torch.float8_e4m3fn).max
                     if param.dtype == torch.float8_e4m3fn:
                         param = (param.float() * fp8_e4m3fnuz_max /
-                                 fp8_e4m3fn_max).to(torch.float8_e4m3fnuz)
+                                 fp8_e4m3fn_max).to(torch.float8_e4m3fn)
                     elif param.dtype in [torch.float32, torch.bfloat16
                                          ] and "scale" in name.split(".")[-1]:
                         param *= fp8_e4m3fn_max / fp8_e4m3fnuz_max
+                if current_platform.is_hpu():
+                    param = param.to("hpu")
                 yield name, param
 
 
@@ -538,10 +540,12 @@ def fastsafetensors_weights_iterator(
                         fp8_e4m3fn_max = torch.finfo(torch.float8_e4m3fn).max
                         if t.dtype == torch.float8_e4m3fn:
                             t = (t.float() * fp8_e4m3fnuz_max /
-                                 fp8_e4m3fn_max).to(torch.float8_e4m3fnuz)
+                                 fp8_e4m3fn_max).to(torch.float8_e4m3fn)
                         elif t.dtype in [torch.float32, torch.bfloat16
                                          ] and "scale" in k.split(".")[-1]:
                             t *= fp8_e4m3fn_max / fp8_e4m3fnuz_max
+                    if current_platform.is_hpu():
+                        t = t.to("hpu")
                     yield k, t
             finally:
                 fb.close()

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -1188,13 +1188,48 @@ def with_thread_limits():
     """
     Decorator to temporarily set OMP_NUM_THREADS and PyTorch threads,
     and restore them after the function call.
-    
-    Args:
-        div_omp: divide CPU cores by this for OMP_NUM_THREADS
-        div_torch: divide CPU cores by this for torch.set_num_threads
+
+    For single-HPU FP8 conversion on multi-NUMA hosts, this also pins the
+    process to one visible NUMA node to avoid cross-socket scheduling.
     """
 
     def decorator(func):
+
+        def _parse_cpulist(cpulist: str) -> set[int]:
+            cpus: set[int] = set()
+            for chunk in cpulist.split(","):
+                chunk = chunk.strip()
+                if not chunk:
+                    continue
+                if "-" in chunk:
+                    start_str, end_str = chunk.split("-", 1)
+                    cpus.update(range(int(start_str), int(end_str) + 1))
+                else:
+                    cpus.add(int(chunk))
+            return cpus
+
+        def _numa_cpu_sets(affinity: list[int]) -> list[list[int]]:
+            if not affinity:
+                return []
+            affinity_set = set(affinity)
+            node_dir = "/sys/devices/system/node"
+            if not os.path.isdir(node_dir):
+                return []
+
+            cpu_sets: list[list[int]] = []
+            for entry in sorted(os.listdir(node_dir)):
+                if not entry.startswith("node"):
+                    continue
+                cpulist_path = os.path.join(node_dir, entry, "cpulist")
+                try:
+                    with open(cpulist_path) as f:
+                        node_cpus = _parse_cpulist(f.read().strip())
+                except (OSError, ValueError):
+                    continue
+                visible_node_cpus = sorted(node_cpus & affinity_set)
+                if visible_node_cpus:
+                    cpu_sets.append(visible_node_cpus)
+            return cpu_sets
 
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -1206,28 +1241,46 @@ def with_thread_limits():
                 world_size = torch.distributed.get_world_size()
             world_size = min(world_size, 8)
 
-            div_omp = world_size
-            div_torch = world_size
-
             # Save original settings
             old_omp = os.environ.get("OMP_NUM_THREADS", None)
             old_torch = torch.get_num_threads()
             import psutil
-            num_cores = len(psutil.Process().cpu_affinity() or [0])
+            process = psutil.Process()
+            old_affinity = process.cpu_affinity() or [0]
+            affinity = old_affinity
+            num_cores = len(affinity)
+
+            numa_cpu_sets = _numa_cpu_sets(affinity)
+            numa_nodes = len(numa_cpu_sets)
+            effective_cores = num_cores
+            pinned_cores = num_cores
+            # On single-HPU runs with multiple NUMA nodes visible, avoid
+            # spanning all sockets during conversion.
+            if world_size == 1 and numa_nodes > 1:
+                selected_node_cpus = max(numa_cpu_sets, key=len)
+                process.cpu_affinity(selected_node_cpus)
+                affinity = selected_node_cpus
+                pinned_cores = len(selected_node_cpus)
+                effective_cores = pinned_cores
+
+            target_threads = max(1, effective_cores // world_size)
 
             # Set new limits
-            os.environ["OMP_NUM_THREADS"] = str(max(1, num_cores // div_omp))
-            torch.set_num_threads(max(1, num_cores // div_torch))
+            os.environ["OMP_NUM_THREADS"] = str(target_threads)
+            torch.set_num_threads(target_threads)
             logger.warning_once(
                 "Setting OMP_NUM_THREADS to %s and torch.set_num_threads to %s "
-                "for %s available CPU cores and world size %s",
+                "for %s available CPU cores, %s pinned cores, %s effective "
+                "cores, %s NUMA nodes and world size %s",
                 os.environ["OMP_NUM_THREADS"], torch.get_num_threads(),
-                num_cores, world_size)
+                num_cores, pinned_cores, effective_cores, numa_nodes,
+                world_size)
             try:
                 # Call the actual function
                 return func(*args, **kwargs)
             finally:
                 # Restore original settings
+                process.cpu_affinity(old_affinity)
                 if old_omp is None:
                     os.environ.pop("OMP_NUM_THREADS", None)
                 else:


### PR DESCRIPTION
- Disable forcing `weights_load_device=cpu`. The weights will be loaded to CPU first and convert fp8 range if necessary on CPU. Then move to HPU tensor-by-tensor to reduce the peak host memory consumption.
- Refine the number of threads for fp8 range conversion to avoid cross NUMA access for 1 HPU case.