### PR TITLE
GAUDISW-247349 [1.24.1][vLLM][G2] RuntimeError: device_allocator INTERNAL ASSERT FAILED at "/npu-stack/pytorch-fork/c10/core/CachingDeviceAllocator.h":116, please report a bug to PyTorch. Allocator for hpu is not a DeviceAllocator.

### DIFF
--- a/tests/distributed/test_cleanup.py
+++ b/tests/distributed/test_cleanup.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for cleanup_dist_env_and_memory robustness."""
+from unittest.mock import MagicMock, patch
+
+
+def test_cleanup_handles_runtime_error_in_empty_cache():
+    """Verify cleanup doesn't crash if empty_cache raises RuntimeError.
+
+    This is a regression test for HPU/Gaudi2 where the allocator
+    doesn't implement the DeviceAllocator interface.
+    """
+    failing_empty_cache = MagicMock(
+        side_effect=RuntimeError(
+            "Allocator for hpu is not a DeviceAllocator"
+        )
+    )
+    mock_platform = MagicMock()
+    mock_platform.empty_cache = failing_empty_cache
+    mock_platform.is_cpu.return_value = False
+
+    with patch(
+        "vllm.distributed.parallel_state.destroy_model_parallel"
+    ), patch(
+        "vllm.distributed.parallel_state"
+        ".destroy_distributed_environment"
+    ), patch(
+        "torch.distributed.destroy_process_group"
+    ), patch(
+        "vllm.distributed.parallel_state.gc.collect"
+    ), patch(
+        "vllm.distributed.parallel_state.current_platform",
+        mock_platform,
+    ), patch(
+        "torch._C._host_emptyCache",
+        side_effect=RuntimeError(
+            "Allocator for hpu is not a DeviceAllocator"
+        ),
+    ):
+        from vllm.distributed.parallel_state import (
+            cleanup_dist_env_and_memory,
+        )
+        # Should not raise
+        cleanup_dist_env_and_memory()
+
+
+def test_cleanup_handles_attribute_error_in_host_empty_cache():
+    """Verify cleanup handles missing _host_emptyCache (PyTorch < 2.5).
+    """
+    mock_platform = MagicMock()
+    mock_platform.empty_cache = None
+    mock_platform.is_cpu.return_value = False
+
+    with patch(
+        "vllm.distributed.parallel_state.destroy_model_parallel"
+    ), patch(
+        "vllm.distributed.parallel_state"
+        ".destroy_distributed_environment"
+    ), patch(
+        "torch.distributed.destroy_process_group"
+    ), patch(
+        "vllm.distributed.parallel_state.gc.collect"
+    ), patch(
+        "vllm.distributed.parallel_state.current_platform",
+        mock_platform,
+    ), patch(
+        "torch._C._host_emptyCache",
+        side_effect=AttributeError("not available"),
+    ):
+        from vllm.distributed.parallel_state import (
+            cleanup_dist_env_and_memory,
+        )
+        # Should not raise
+        cleanup_dist_env_and_memory()
+
+
+def test_cleanup_succeeds_on_cpu_platform():
+    """Verify cleanup skips host cache clearing on CPU."""
+    mock_platform = MagicMock()
+    mock_platform.empty_cache = None
+    mock_platform.is_cpu.return_value = True
+
+    with patch(
+        "vllm.distributed.parallel_state.destroy_model_parallel"
+    ), patch(
+        "vllm.distributed.parallel_state"
+        ".destroy_distributed_environment"
+    ), patch(
+        "torch.distributed.destroy_process_group"
+    ), patch(
+        "vllm.distributed.parallel_state.gc.collect"
+    ), patch(
+        "vllm.distributed.parallel_state.current_platform",
+        mock_platform,
+    ):
+        from vllm.distributed.parallel_state import (
+            cleanup_dist_env_and_memory,
+        )
+        # Should not raise
+        cleanup_dist_env_and_memory()

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1202,13 +1202,21 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
     from vllm.platforms import current_platform
     empty_cache = current_platform.empty_cache
     if empty_cache is not None:
-        empty_cache()
+        try:
+            empty_cache()
+        except RuntimeError as e:
+            logger.warning(
+                "Failed to empty device cache: %s", e)
     try:
         if not current_platform.is_cpu():
             torch._C._host_emptyCache()
     except AttributeError:
         logger.warning(
-            "torch._C._host_emptyCache() only available in Pytorch >=2.5")
+            "torch._C._host_emptyCache() only available in"
+            " Pytorch >=2.5")
+    except RuntimeError as e:
+        logger.warning(
+            "Failed to empty host cache: %s", e)
 
 
 def in_the_same_node_as(pg: Union[ProcessGroup, StatelessProcessGroup],

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -128,6 +128,21 @@ class HpuPlatform(Platform):
         return False
 
     @classmethod
+    def empty_cache(cls) -> None:
+        """Empty HPU device cache using native API."""
+        try:
+            import habana_frameworks.torch  # noqa: F401
+            torch.hpu.empty_cache()
+        except RuntimeError:
+            logger.warning(
+                "Failed to empty HPU cache. The HPU allocator"
+                " may not support cache clearing.")
+        except ImportError:
+            logger.warning(
+                "habana_frameworks not available,"
+                " skipping HPU cache clearing.")
+
+    @classmethod
     def get_punica_wrapper(cls) -> str:
         return "vllm.lora.punica_wrapper.punica_hpu.PunicaWrapperHPU"
 


### PR DESCRIPTION
Automated implementation for **GAUDISW-247349**.

**Summary:** [1.24.1][vLLM][G2] RuntimeError: device_allocator INTERNAL ASSERT FAILED at "/npu-stack/pytorch-fork/c10/core/CachingDeviceAllocator.h":116, please report a bug to PyTorch. Allocator for hpu is not a DeviceAllocator.

Branch: `dev/sys_qaplatformbot/GAUDISW-247349--20260407103618`