### PR TITLE
use float16 for the fp8 range conversion to reduce peak memory usage

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -462,7 +462,7 @@ def _maybe_convert_fp8_range(name: str, tensor: torch.Tensor) -> torch.Tensor:
         return tensor
 
     if tensor.dtype == torch.float8_e4m3fn:
-        return (tensor.float() / 2).to(torch.float8_e4m3fn)
+        return (tensor.to(torch.float16) / 2).to(torch.float8_e4m3fn)
 
     if (tensor.dtype in [torch.float32, torch.bfloat16]
             and "scale" in name.split(".")[-1]):


### PR DESCRIPTION
Currently the `fp8_e4m3fn` weights will be converted to `float32` and divided by `2` then converts back to `fp8_e4m3fn`. The peak memory usage could be estimated as `size_of(fp8) * num_elm + size_of(float32) * num_elm + size_of(fp8) * num_elm = 6 * num_elm`. For the model Qwen3-VL-235B-A22B-Instruct-FP8, the experts' weights are packed into large tensors which will results in large peak memory usage and cause OOM for the 16GiB host memory per HPU restriction.

name | dtype | shape | min | max | size (GiB)
-- | -- | -- | -- | -- | --
model.language_model.layers.0.mlp.experts.gate_up_proj | torch.float8_e4m3fn | [128 4096 3072] | -448 | 448 | 1.5
model.language_model.layers.0.mlp.experts.down_proj | torch.float8_e4m3fn | [128 1536 4096] | -448 | 448 | 0.75

This PR use `float16` instead of `float32` to reduce the estimated peak memory to `size_of(fp8) * num_elm + size_of(float16) * num_elm + size_of(fp8) * num_elm = 4 * num_elm`.
As the final dtype is `fp8_e4m3fn` for which all the values could be represented by `float16`, the impact on accuracy could be ignored.