### PR TITLE
[Bugfix] fix missing 'finish_reason': null in streaming chat (#19662)

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -973,7 +973,7 @@ class OpenAIServingChat(OpenAIServing):
                             total_tokens=num_prompt_tokens + completion_tokens,
                         )
 
-                    data = chunk.model_dump_json(exclude_none=True)
+                    data = chunk.model_dump_json(exclude_unset=True)
                     yield f"data: {data}\n\n"
 
             # once the final token is handled, if stream_options.include_usage


### PR DESCRIPTION
(cherry picked from commit 836d4ce140a65a0c5067cca58709cfb86c811b81)

It was changed in commit 05a4324f8e3932c25554791ff248e3e0200eef92 then it was fixed in commit 836d4ce140a65a0c5067cca58709cfb86c811b81 on https://github.com/vllm-project/vllm. aice/v1.22.0 has 05a4324f8e3932c25554791ff248e3e0200eef92, hence we should apply 836d4ce140a65a0c5067cca58709cfb86c811b81 to aice/v1.22.0 too, otherwise the reasoning content is displayed incorrectly in streaming chat. 